### PR TITLE
config: update MotherDuck database names

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ An end-to-end data engineering project for Danish football data, built with:
 
 | Environment | MotherDuck schema | Triggered by |
 |-------------|-------------------|--------------|
-| `dev`       | `dev_danish_football` | Local work / PRs |
-| `prod`      | `danish_football`     | Merge to `main` |
+| `dev`       | MotherDuck `superligaen_dev` | Local work / PRs |
+| `prod`      | MotherDuck `superligaen`     | Merge to `main` |
 
 **Rule**: never commit directly to `main`. Always work on a `dev/<feature>` branch, open a PR, let CI pass, then merge. The `deploy.yml` workflow promotes to prod automatically on merge.
 

--- a/dbt/danish_football/profiles.yml
+++ b/dbt/danish_football/profiles.yml
@@ -2,14 +2,14 @@ danish_football:
   outputs:
     dev:
       type: duckdb
-      path: "md:danish_football?motherduck_token={{ env_var('MOTHERDUCK_TOKEN') }}"
-      schema: dev_danish_football
+      path: "md:superligaen_dev?motherduck_token={{ env_var('MOTHERDUCK_TOKEN') }}"
+      schema: main
       threads: 4
 
     prod:
       type: duckdb
-      path: "md:danish_football?motherduck_token={{ env_var('MOTHERDUCK_TOKEN') }}"
-      schema: danish_football
+      path: "md:superligaen?motherduck_token={{ env_var('MOTHERDUCK_TOKEN') }}"
+      schema: main
       threads: 4
 
   target: dev


### PR DESCRIPTION
## Summary

- `dev` target → `md:superligaen_dev` (MotherDuck database created by user)
- `prod` target → `md:superligaen` (MotherDuck database created by user)
- Both use the `main` schema within their respective databases
- Updates README env table to reflect the actual database names

## Note
The single `MOTHERDUCK_TOKEN` secret has access to both databases. Prod writes only happen via `deploy.yml` on merge to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)