### PR TITLE
feat: bronze layer — all 21 free tier endpoints

### DIFF
--- a/.github/workflows/ingest.yml
+++ b/.github/workflows/ingest.yml
@@ -6,13 +6,18 @@ on:
   workflow_dispatch:
     inputs:
       full_load:
-        description: "Pass --full-load to fetch entire season"
+        description: "Set to 'true' to run a full historical load"
         required: false
         default: "false"
+      season:
+        description: "Season year for full load (e.g. 2023). Leave empty to load all seasons 2020-2025."
+        required: false
+        default: ""
 
 jobs:
   ingest:
     runs-on: ubuntu-latest
+    timeout-minutes: 360  # 6h max — covers one full season load (~2.3h)
 
     steps:
       - name: Checkout
@@ -26,7 +31,7 @@ jobs:
       - name: Install dependencies
         run: pip install -r requirements.txt
 
-      - name: Run ingestion (incremental)
+      - name: Run ingestion (daily incremental)
         if: ${{ github.event.inputs.full_load != 'true' }}
         env:
           MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
@@ -34,8 +39,16 @@ jobs:
           TARGET_DB: superligaen_dev
         run: python ingestion/ingest_superligaen.py --lookback 2
 
-      - name: Run ingestion (full load)
-        if: ${{ github.event.inputs.full_load == 'true' }}
+      - name: Run ingestion (full load — single season)
+        if: ${{ github.event.inputs.full_load == 'true' && github.event.inputs.season != '' }}
+        env:
+          MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
+          API_FOOTBALL_KEY: ${{ secrets.API_FOOTBALL_KEY }}
+          TARGET_DB: superligaen_dev
+        run: python ingestion/ingest_superligaen.py --full-load --season ${{ github.event.inputs.season }}
+
+      - name: Run ingestion (full load — all seasons)
+        if: ${{ github.event.inputs.full_load == 'true' && github.event.inputs.season == '' }}
         env:
           MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
           API_FOOTBALL_KEY: ${{ secrets.API_FOOTBALL_KEY }}

--- a/ingestion/ingest_superligaen.py
+++ b/ingestion/ingest_superligaen.py
@@ -499,8 +499,9 @@ def run(lookback_days: int = 2, full_load: bool = False, season: int | None = No
         seasons = [season] if season else list(range(FIRST_SEASON, CURRENT_SEASON + 1))
         log.info("Full load — seasons: %s", seasons)
 
-        # Truncate all bronze tables once before loading
-        truncate_all(conn)
+        # Truncate only when loading all seasons — single-season runs append to existing data
+        if not season:
+            truncate_all(conn)
 
         for s in seasons:
             log.info("=== Season %d ===", s)

--- a/ingestion/ingest_superligaen.py
+++ b/ingestion/ingest_superligaen.py
@@ -299,31 +299,78 @@ def ensure_schema_and_tables(conn: duckdb.DuckDBPyConnection) -> None:
 # Load helpers
 # ---------------------------------------------------------------------------
 
-def _upsert(conn, table: str, key_cols: list, key_vals: list, payload) -> None:
+ALL_BRONZE_TABLES = [
+    "api_football__fixtures",
+    "api_football__fixture_events",
+    "api_football__fixture_statistics",
+    "api_football__fixture_lineups",
+    "api_football__fixture_players",
+    "api_football__fixture_predictions",
+    "api_football__fixture_odds",
+    "api_football__standings",
+    "api_football__topscorers",
+    "api_football__topassists",
+    "api_football__topyellowcards",
+    "api_football__topredcards",
+    "api_football__injuries",
+    "api_football__rounds",
+    "api_football__leagues",
+    "api_football__venues",
+    "api_football__coaches",
+    "api_football__squads",
+    "api_football__transfers",
+    "api_football__sidelined",
+    "api_football__trophies",
+    "api_football__teams",
+    "api_football__team_statistics",
+    "api_football__players",
+]
+
+
+def truncate_all(conn) -> None:
+    for table in ALL_BRONZE_TABLES:
+        conn.execute(f"DELETE FROM bronze.{table}")
+    log.info("Truncated all bronze tables")
+
+
+def _insert(conn, table: str, key_cols: list, key_vals: list, payload) -> None:
     cols         = ", ".join(key_cols) + ", raw_json"
     placeholders = ", ".join(["?"] * len(key_vals)) + ", ?"
     conn.execute(
-        f"INSERT OR REPLACE INTO bronze.{table} ({cols}) VALUES ({placeholders})",
+        f"INSERT INTO bronze.{table} ({cols}) VALUES ({placeholders})",
         key_vals + [json.dumps(payload)],
     )
 
 
-def load_fixtures_bulk(conn, fixtures: list) -> None:
+def _delete_insert(conn, table: str, key_cols: list, key_vals: list, payload) -> None:
+    where = " AND ".join(f"{col} = ?" for col in key_cols)
+    conn.execute(f"DELETE FROM bronze.{table} WHERE {where}", key_vals)
+    _insert(conn, table, key_cols, key_vals, payload)
+
+
+def load_fixtures_bulk(conn, fixtures: list, truncate: bool = False) -> None:
+    if truncate:
+        conn.execute("DELETE FROM bronze.api_football__fixtures")
     rows = [(f["fixture"]["id"], json.dumps(f)) for f in fixtures]
     conn.executemany(
-        "INSERT OR REPLACE INTO bronze.api_football__fixtures (fixture_id, raw_json) VALUES (?, ?)",
+        "INSERT INTO bronze.api_football__fixtures (fixture_id, raw_json) VALUES (?, ?)",
         rows,
     )
-    log.info("Upserted %d rows into bronze.api_football__fixtures", len(rows))
+    log.info("Loaded %d rows into bronze.api_football__fixtures", len(rows))
 
 
 # ---------------------------------------------------------------------------
 # Shared helpers
 # ---------------------------------------------------------------------------
 
-def load_season_aggregates(conn, season: int, sleep: float = 0.0) -> None:
-    """Full refresh of season-level aggregates. Runs on every daily run and full load."""
+def load_season_aggregates(conn, season: int, sleep: float = 0.0, full_load: bool = False) -> None:
+    """
+    Season-level aggregates.
+    - Full load: plain INSERT (tables already truncated).
+    - Incremental: DELETE by season then INSERT.
+    """
     log.info("Season %d: loading aggregates", season)
+    write = _insert if full_load else _delete_insert
     for table, fetcher in (
         ("api_football__standings",      lambda: fetch_standings(season, sleep)),
         ("api_football__topscorers",     lambda: fetch_topscorers(season, sleep)),
@@ -333,34 +380,39 @@ def load_season_aggregates(conn, season: int, sleep: float = 0.0) -> None:
         ("api_football__injuries",       lambda: fetch_injuries(season, sleep)),
     ):
         try:
-            _upsert(conn, table, ["season"], [season], fetcher())
+            write(conn, table, ["season"], [season], fetcher())
         except Exception as exc:
             log.warning("Failed %s season %d: %s", table, season, exc)
 
 
-def load_fixture_details(conn, fixtures: list, sleep: float = 0.0) -> None:
-    """Fetch and store all fixture-level endpoints for finished matches."""
+def load_fixture_details(conn, fixtures: list, sleep: float = 0.0, full_load: bool = False) -> None:
+    """
+    Fixture-level endpoints for finished matches.
+    - Full load: plain INSERT (tables already truncated).
+    - Incremental: DELETE by fixture_id then INSERT.
+    """
     finished = [f for f in fixtures if f["fixture"]["status"]["short"] in ("FT", "AET", "PEN")]
     log.info("%d finished fixtures — fetching fixture-level endpoints", len(finished))
+    write = _insert if full_load else _delete_insert
 
     for f in finished:
         fixture_id = f["fixture"]["id"]
         home = f["teams"]["home"]["name"]
         away = f["teams"]["away"]["name"]
         try:
-            _upsert(conn, "api_football__fixture_events",      ["fixture_id"], [fixture_id], fetch_events(fixture_id, sleep))
-            _upsert(conn, "api_football__fixture_statistics",  ["fixture_id"], [fixture_id], fetch_statistics(fixture_id, sleep))
-            _upsert(conn, "api_football__fixture_lineups",     ["fixture_id"], [fixture_id], fetch_lineups(fixture_id, sleep))
-            _upsert(conn, "api_football__fixture_players",     ["fixture_id"], [fixture_id], fetch_fixture_players(fixture_id, sleep))
-            _upsert(conn, "api_football__fixture_predictions", ["fixture_id"], [fixture_id], fetch_predictions(fixture_id, sleep))
-            _upsert(conn, "api_football__fixture_odds",        ["fixture_id"], [fixture_id], fetch_odds(fixture_id, sleep))
+            write(conn, "api_football__fixture_events",      ["fixture_id"], [fixture_id], fetch_events(fixture_id, sleep))
+            write(conn, "api_football__fixture_statistics",  ["fixture_id"], [fixture_id], fetch_statistics(fixture_id, sleep))
+            write(conn, "api_football__fixture_lineups",     ["fixture_id"], [fixture_id], fetch_lineups(fixture_id, sleep))
+            write(conn, "api_football__fixture_players",     ["fixture_id"], [fixture_id], fetch_fixture_players(fixture_id, sleep))
+            write(conn, "api_football__fixture_predictions", ["fixture_id"], [fixture_id], fetch_predictions(fixture_id, sleep))
+            write(conn, "api_football__fixture_odds",        ["fixture_id"], [fixture_id], fetch_odds(fixture_id, sleep))
             log.info("Loaded fixture %d: %s vs %s", fixture_id, home, away)
         except Exception as exc:
             log.warning("Failed fixture %d (%s vs %s): %s", fixture_id, home, away, exc)
 
 
 def load_reference_and_team_data(conn, season: int, sleep: float = 0.0) -> None:
-    """Reference and per-team data for a given season. Full load only."""
+    """Reference and per-team data. Full load only — plain INSERT (tables already truncated)."""
     log.info("Season %d: loading reference data", season)
 
     for table, fetcher, key_col, key_val in (
@@ -370,13 +422,13 @@ def load_reference_and_team_data(conn, season: int, sleep: float = 0.0) -> None:
         ("api_football__rounds",  lambda: fetch_rounds(season, sleep), "season",    season),
     ):
         try:
-            _upsert(conn, table, [key_col], [key_val], fetcher())
+            _insert(conn, table, [key_col], [key_val], fetcher())
         except Exception as exc:
             log.warning("Failed %s season %d: %s", table, season, exc)
 
     try:
         for page, response in fetch_league_players(season, sleep):
-            _upsert(conn, "api_football__players", ["season", "page"], [season, page], response)
+            _insert(conn, "api_football__players", ["season", "page"], [season, page], response)
     except Exception as exc:
         log.warning("Failed api_football__players season %d: %s", season, exc)
 
@@ -398,12 +450,12 @@ def load_reference_and_team_data(conn, season: int, sleep: float = 0.0) -> None:
             ("api_football__trophies",  lambda tid=team_id: fetch_trophies(tid, sleep)),
         ):
             try:
-                _upsert(conn, table, ["team_id"], [team_id], fetcher())
+                _insert(conn, table, ["team_id"], [team_id], fetcher())
             except Exception as exc:
                 log.warning("Failed %s team %d season %d: %s", table, team_id, season, exc)
 
         try:
-            _upsert(
+            _insert(
                 conn, "api_football__team_statistics",
                 ["season", "team_id"], [season, team_id],
                 fetch_team_statistics(team_id, season, sleep),
@@ -421,30 +473,40 @@ def run(lookback_days: int = 2, full_load: bool = False, season: int | None = No
     ensure_schema_and_tables(conn)
 
     if full_load:
-        sleep = 6.5
+        sleep   = 6.5
         seasons = [season] if season else list(range(FIRST_SEASON, CURRENT_SEASON + 1))
         log.info("Full load — seasons: %s", seasons)
 
+        # Truncate all bronze tables once before loading
+        truncate_all(conn)
+
         for s in seasons:
             log.info("=== Season %d ===", s)
-            load_season_aggregates(conn, s, sleep)
+            load_season_aggregates(conn, s, sleep, full_load=True)
             fixtures = fetch_fixtures(s, sleep=sleep)
-            load_fixtures_bulk(conn, fixtures)
-            load_fixture_details(conn, fixtures, sleep)
+            load_fixtures_bulk(conn, fixtures, truncate=False)  # already truncated above
+            load_fixture_details(conn, fixtures, sleep, full_load=True)
             load_reference_and_team_data(conn, s, sleep)
 
     else:
         # Daily incremental
-        # 1. Full refresh of current season aggregates
-        load_season_aggregates(conn, CURRENT_SEASON, sleep=0.0)
+        # 1. Delete + insert current season aggregates
+        load_season_aggregates(conn, CURRENT_SEASON, sleep=0.0, full_load=False)
 
-        # 2. Incremental fixture load for the lookback window
+        # 2. Delete + insert fixtures in the lookback window
         from_date = (date.today() - timedelta(days=lookback_days)).isoformat()
         to_date   = date.today().isoformat()
         log.info("Incremental fixture load — %s to %s", from_date, to_date)
         fixtures = fetch_fixtures(CURRENT_SEASON, from_date=from_date, to_date=to_date)
-        load_fixtures_bulk(conn, fixtures)
-        load_fixture_details(conn, fixtures, sleep=0.0)
+        for f in fixtures:
+            fixture_id = f["fixture"]["id"]
+            conn.execute("DELETE FROM bronze.api_football__fixtures WHERE fixture_id = ?", [fixture_id])
+            conn.execute(
+                "INSERT INTO bronze.api_football__fixtures (fixture_id, raw_json) VALUES (?, ?)",
+                [fixture_id, json.dumps(f)],
+            )
+        log.info("Loaded %d rows into bronze.api_football__fixtures", len(fixtures))
+        load_fixture_details(conn, fixtures, sleep=0.0, full_load=False)
 
     conn.close()
     log.info("Bronze ingestion complete")

--- a/ingestion/ingest_superligaen.py
+++ b/ingestion/ingest_superligaen.py
@@ -385,27 +385,49 @@ def load_season_aggregates(conn, season: int, sleep: float = 0.0, full_load: boo
             log.warning("Failed %s season %d: %s", table, season, exc)
 
 
+FIXTURE_DETAIL_TABLES = [
+    "api_football__fixture_events",
+    "api_football__fixture_statistics",
+    "api_football__fixture_lineups",
+    "api_football__fixture_players",
+    "api_football__fixture_predictions",
+    "api_football__fixture_odds",
+]
+
+
+def delete_fixture_details_by_ids(conn, fixture_ids: list[int]) -> None:
+    """Delete all fixture-detail rows for a given list of fixture IDs in one pass."""
+    if not fixture_ids:
+        return
+    placeholders = ", ".join("?" * len(fixture_ids))
+    for table in FIXTURE_DETAIL_TABLES:
+        conn.execute(
+            f"DELETE FROM bronze.{table} WHERE fixture_id IN ({placeholders})",
+            fixture_ids,
+        )
+    log.info("Deleted fixture detail rows for %d fixtures", len(fixture_ids))
+
+
 def load_fixture_details(conn, fixtures: list, sleep: float = 0.0, full_load: bool = False) -> None:
     """
     Fixture-level endpoints for finished matches.
     - Full load: plain INSERT (tables already truncated).
-    - Incremental: DELETE by fixture_id then INSERT.
+    - Incremental: caller must have already deleted the relevant rows by date window.
     """
     finished = [f for f in fixtures if f["fixture"]["status"]["short"] in ("FT", "AET", "PEN")]
     log.info("%d finished fixtures — fetching fixture-level endpoints", len(finished))
-    write = _insert if full_load else _delete_insert
 
     for f in finished:
         fixture_id = f["fixture"]["id"]
         home = f["teams"]["home"]["name"]
         away = f["teams"]["away"]["name"]
         try:
-            write(conn, "api_football__fixture_events",      ["fixture_id"], [fixture_id], fetch_events(fixture_id, sleep))
-            write(conn, "api_football__fixture_statistics",  ["fixture_id"], [fixture_id], fetch_statistics(fixture_id, sleep))
-            write(conn, "api_football__fixture_lineups",     ["fixture_id"], [fixture_id], fetch_lineups(fixture_id, sleep))
-            write(conn, "api_football__fixture_players",     ["fixture_id"], [fixture_id], fetch_fixture_players(fixture_id, sleep))
-            write(conn, "api_football__fixture_predictions", ["fixture_id"], [fixture_id], fetch_predictions(fixture_id, sleep))
-            write(conn, "api_football__fixture_odds",        ["fixture_id"], [fixture_id], fetch_odds(fixture_id, sleep))
+            _insert(conn, "api_football__fixture_events",      ["fixture_id"], [fixture_id], fetch_events(fixture_id, sleep))
+            _insert(conn, "api_football__fixture_statistics",  ["fixture_id"], [fixture_id], fetch_statistics(fixture_id, sleep))
+            _insert(conn, "api_football__fixture_lineups",     ["fixture_id"], [fixture_id], fetch_lineups(fixture_id, sleep))
+            _insert(conn, "api_football__fixture_players",     ["fixture_id"], [fixture_id], fetch_fixture_players(fixture_id, sleep))
+            _insert(conn, "api_football__fixture_predictions", ["fixture_id"], [fixture_id], fetch_predictions(fixture_id, sleep))
+            _insert(conn, "api_football__fixture_odds",        ["fixture_id"], [fixture_id], fetch_odds(fixture_id, sleep))
             log.info("Loaded fixture %d: %s vs %s", fixture_id, home, away)
         except Exception as exc:
             log.warning("Failed fixture %d (%s vs %s): %s", fixture_id, home, away, exc)
@@ -490,23 +512,35 @@ def run(lookback_days: int = 2, full_load: bool = False, season: int | None = No
 
     else:
         # Daily incremental
-        # 1. Delete + insert current season aggregates
-        load_season_aggregates(conn, CURRENT_SEASON, sleep=0.0, full_load=False)
-
-        # 2. Delete + insert fixtures in the lookback window
         from_date = (date.today() - timedelta(days=lookback_days)).isoformat()
         to_date   = date.today().isoformat()
-        log.info("Incremental fixture load — %s to %s", from_date, to_date)
-        fixtures = fetch_fixtures(CURRENT_SEASON, from_date=from_date, to_date=to_date)
-        for f in fixtures:
-            fixture_id = f["fixture"]["id"]
-            conn.execute("DELETE FROM bronze.api_football__fixtures WHERE fixture_id = ?", [fixture_id])
+        log.info("Incremental load — window: %s to %s", from_date, to_date)
+
+        # 1. Full refresh of current season aggregates (delete by season, then insert)
+        load_season_aggregates(conn, CURRENT_SEASON, sleep=0.0, full_load=False)
+
+        # 2. Delete the date window from fixtures and all fixture-detail tables upfront
+        fixture_ids_in_window = [
+            row[0] for row in conn.execute(
+                "SELECT fixture_id FROM bronze.api_football__fixtures "
+                "WHERE json_extract_string(raw_json, '$.fixture.date')::date "
+                "BETWEEN ?::date AND ?::date",
+                [from_date, to_date],
+            ).fetchall()
+        ]
+        if fixture_ids_in_window:
+            placeholders = ", ".join("?" * len(fixture_ids_in_window))
             conn.execute(
-                "INSERT INTO bronze.api_football__fixtures (fixture_id, raw_json) VALUES (?, ?)",
-                [fixture_id, json.dumps(f)],
+                f"DELETE FROM bronze.api_football__fixtures WHERE fixture_id IN ({placeholders})",
+                fixture_ids_in_window,
             )
-        log.info("Loaded %d rows into bronze.api_football__fixtures", len(fixtures))
-        load_fixture_details(conn, fixtures, sleep=0.0, full_load=False)
+            delete_fixture_details_by_ids(conn, fixture_ids_in_window)
+            log.info("Cleared %d fixtures from the date window", len(fixture_ids_in_window))
+
+        # 3. Fetch and bulk insert
+        fixtures = fetch_fixtures(CURRENT_SEASON, from_date=from_date, to_date=to_date)
+        load_fixtures_bulk(conn, fixtures)
+        load_fixture_details(conn, fixtures, sleep=0.0, full_load=True)  # tables already cleared
 
     conn.close()
     log.info("Bronze ingestion complete")

--- a/ingestion/ingest_superligaen.py
+++ b/ingestion/ingest_superligaen.py
@@ -416,22 +416,22 @@ def load_reference_and_team_data(conn, season: int, sleep: float = 0.0) -> None:
 # Main
 # ---------------------------------------------------------------------------
 
-def run(lookback_days: int = 2, full_load: bool = False) -> None:
+def run(lookback_days: int = 2, full_load: bool = False, season: int | None = None) -> None:
     conn = connect()
     ensure_schema_and_tables(conn)
 
     if full_load:
-        sleep   = 6.5
-        seasons = list(range(FIRST_SEASON, CURRENT_SEASON + 1))
-        log.info("Full load — seasons %d to %d", FIRST_SEASON, CURRENT_SEASON)
+        sleep = 6.5
+        seasons = [season] if season else list(range(FIRST_SEASON, CURRENT_SEASON + 1))
+        log.info("Full load — seasons: %s", seasons)
 
-        for season in seasons:
-            log.info("=== Season %d ===", season)
-            load_season_aggregates(conn, season, sleep)
-            fixtures = fetch_fixtures(season, sleep=sleep)
+        for s in seasons:
+            log.info("=== Season %d ===", s)
+            load_season_aggregates(conn, s, sleep)
+            fixtures = fetch_fixtures(s, sleep=sleep)
             load_fixtures_bulk(conn, fixtures)
             load_fixture_details(conn, fixtures, sleep)
-            load_reference_and_team_data(conn, season, sleep)
+            load_reference_and_team_data(conn, s, sleep)
 
     else:
         # Daily incremental
@@ -455,6 +455,9 @@ if __name__ == "__main__":
     parser.add_argument("--lookback", type=int, default=2,
                         help="Days to look back for finished fixtures (default: 2)")
     parser.add_argument("--full-load", action="store_true",
-                        help="Historical load from %d to %d — requires upgraded API plan" % (FIRST_SEASON, CURRENT_SEASON))
+                        help="Historical load — requires upgraded API plan (~2.3h per season)")
+    parser.add_argument("--season", type=int, default=None,
+                        help="Season year to load (e.g. 2023). Used with --full-load to load "
+                             "one season at a time. Omit to load all seasons %d-%d." % (FIRST_SEASON, CURRENT_SEASON))
     args = parser.parse_args()
-    run(lookback_days=args.lookback, full_load=args.full_load)
+    run(lookback_days=args.lookback, full_load=args.full_load, season=args.season)

--- a/ingestion/ingest_superligaen.py
+++ b/ingestion/ingest_superligaen.py
@@ -4,6 +4,9 @@ Bronze layer ingestion for Superligaen (Danish football).
 Fetches raw JSON from api-football.com and lands it as-is into the bronze
 schema in MotherDuck. No transformation — that is dbt's job.
 
+Rate limiting is handled automatically via retry with exponential backoff.
+No manual sleep needed — works on free and paid plans alike.
+
 Run modes:
   --lookback N   Incremental daily run. Fetches fixtures from the last N days
                  (default: 2) plus a full refresh of current-season aggregates
@@ -11,6 +14,9 @@ Run modes:
   --full-load    Historical load. Fetches all data for every season from
                  FIRST_SEASON to CURRENT_SEASON. Requires an upgraded
                  api-football plan (far exceeds 100 req/day).
+  --full-load --season YYYY
+                 Load a single season. Use this to stay within GitHub Actions'
+                 6-hour limit (~2.5h per season).
 
 Daily incremental — what gets loaded:
   FULL REFRESH (current season only, always up to date):
@@ -45,80 +51,100 @@ logging.basicConfig(
 )
 log = logging.getLogger(__name__)
 
-API_BASE     = "https://v3.football.api-sports.io"
-LEAGUE_ID    = 119
+API_BASE       = "https://v3.football.api-sports.io"
+LEAGUE_ID      = 119
 CURRENT_SEASON = 2025
 FIRST_SEASON   = 2020  # earliest season to load on --full-load
+MAX_RETRIES    = 10
 
 
 # ---------------------------------------------------------------------------
-# API helper
+# API helper — retries with exponential backoff on rate limit errors
 # ---------------------------------------------------------------------------
 
 def _headers() -> dict:
     return {"x-apisports-key": os.environ["API_FOOTBALL_KEY"]}
 
 
-def api_get(endpoint: str, params: dict, sleep: float = 0.0) -> dict:
-    if sleep:
-        time.sleep(sleep)
+def api_get(endpoint: str, params: dict) -> dict:
     url = f"{API_BASE}/{endpoint}"
-    resp = requests.get(url, headers=_headers(), params=params, timeout=30)
-    resp.raise_for_status()
-    data = resp.json()
-    if data.get("errors"):
-        raise RuntimeError(f"API error on {endpoint}: {data['errors']}")
-    remaining = resp.headers.get("x-ratelimit-requests-remaining")
-    if remaining is not None:
-        log.info("API requests remaining today: %s", remaining)
-    return data
+    for attempt in range(MAX_RETRIES):
+        resp = requests.get(url, headers=_headers(), params=params, timeout=30)
+
+        # HTTP 429 — rate limited
+        if resp.status_code == 429:
+            wait = 60 * (attempt + 1)
+            log.warning("Rate limit (HTTP 429) — waiting %ds before retry %d/%d", wait, attempt + 1, MAX_RETRIES)
+            time.sleep(wait)
+            continue
+
+        resp.raise_for_status()
+        data = resp.json()
+
+        # API-level rate limit error
+        if data.get("errors") and "rateLimit" in str(data["errors"]):
+            wait = 60 * (attempt + 1)
+            log.warning("Rate limit (API error) — waiting %ds before retry %d/%d", wait, attempt + 1, MAX_RETRIES)
+            time.sleep(wait)
+            continue
+
+        if data.get("errors"):
+            raise RuntimeError(f"API error on {endpoint}: {data['errors']}")
+
+        remaining = resp.headers.get("x-ratelimit-requests-remaining")
+        if remaining is not None:
+            log.info("API requests remaining today: %s", remaining)
+
+        return data
+
+    raise RuntimeError(f"Max retries ({MAX_RETRIES}) exceeded for {endpoint} {params}")
 
 
 # ---------------------------------------------------------------------------
 # Season-level fetchers
 # ---------------------------------------------------------------------------
 
-def fetch_standings(season: int, sleep: float = 0.0) -> list:
-    return api_get("standings", {"league": LEAGUE_ID, "season": season}, sleep)["response"]
+def fetch_standings(season: int) -> list:
+    return api_get("standings", {"league": LEAGUE_ID, "season": season})["response"]
 
-def fetch_topscorers(season: int, sleep: float = 0.0) -> list:
-    return api_get("players/topscorers", {"league": LEAGUE_ID, "season": season}, sleep)["response"]
+def fetch_topscorers(season: int) -> list:
+    return api_get("players/topscorers", {"league": LEAGUE_ID, "season": season})["response"]
 
-def fetch_topassists(season: int, sleep: float = 0.0) -> list:
-    return api_get("players/topassists", {"league": LEAGUE_ID, "season": season}, sleep)["response"]
+def fetch_topassists(season: int) -> list:
+    return api_get("players/topassists", {"league": LEAGUE_ID, "season": season})["response"]
 
-def fetch_topyellowcards(season: int, sleep: float = 0.0) -> list:
-    return api_get("players/topyellowcards", {"league": LEAGUE_ID, "season": season}, sleep)["response"]
+def fetch_topyellowcards(season: int) -> list:
+    return api_get("players/topyellowcards", {"league": LEAGUE_ID, "season": season})["response"]
 
-def fetch_topredcards(season: int, sleep: float = 0.0) -> list:
-    return api_get("players/topredcards", {"league": LEAGUE_ID, "season": season}, sleep)["response"]
+def fetch_topredcards(season: int) -> list:
+    return api_get("players/topredcards", {"league": LEAGUE_ID, "season": season})["response"]
 
-def fetch_injuries(season: int, sleep: float = 0.0) -> list:
-    return api_get("injuries", {"league": LEAGUE_ID, "season": season}, sleep)["response"]
+def fetch_injuries(season: int) -> list:
+    return api_get("injuries", {"league": LEAGUE_ID, "season": season})["response"]
 
 
 # ---------------------------------------------------------------------------
 # Reference fetchers
 # ---------------------------------------------------------------------------
 
-def fetch_leagues(sleep: float = 0.0) -> list:
-    return api_get("leagues", {"id": LEAGUE_ID}, sleep)["response"]
+def fetch_leagues() -> list:
+    return api_get("leagues", {"id": LEAGUE_ID})["response"]
 
-def fetch_teams(season: int, sleep: float = 0.0) -> list:
-    return api_get("teams", {"league": LEAGUE_ID, "season": season}, sleep)["response"]
+def fetch_teams(season: int) -> list:
+    return api_get("teams", {"league": LEAGUE_ID, "season": season})["response"]
 
-def fetch_venues(sleep: float = 0.0) -> list:
-    return api_get("venues", {"league": LEAGUE_ID}, sleep)["response"]
+def fetch_venues() -> list:
+    return api_get("venues", {"league": LEAGUE_ID})["response"]
 
-def fetch_rounds(season: int, sleep: float = 0.0) -> list:
-    return api_get("fixtures/rounds", {"league": LEAGUE_ID, "season": season}, sleep)["response"]
+def fetch_rounds(season: int) -> list:
+    return api_get("fixtures/rounds", {"league": LEAGUE_ID, "season": season})["response"]
 
-def fetch_league_players(season: int, sleep: float = 0.0) -> list[tuple[int, list]]:
+def fetch_league_players(season: int) -> list[tuple[int, list]]:
     """Returns (page, response) tuples across all pages."""
     results = []
     page = 1
     while True:
-        data = api_get("players", {"league": LEAGUE_ID, "season": season, "page": page}, sleep)
+        data = api_get("players", {"league": LEAGUE_ID, "season": season, "page": page})
         results.append((page, data["response"]))
         if page >= data["paging"]["total"]:
             break
@@ -130,60 +156,56 @@ def fetch_league_players(season: int, sleep: float = 0.0) -> list[tuple[int, lis
 # Per-team fetchers
 # ---------------------------------------------------------------------------
 
-def fetch_team_statistics(team_id: int, season: int, sleep: float = 0.0) -> dict:
-    return api_get(
-        "teams/statistics",
-        {"league": LEAGUE_ID, "season": season, "team": team_id},
-        sleep,
-    )["response"]
+def fetch_team_statistics(team_id: int, season: int) -> dict:
+    return api_get("teams/statistics", {"league": LEAGUE_ID, "season": season, "team": team_id})["response"]
 
-def fetch_coaches(team_id: int, sleep: float = 0.0) -> list:
-    return api_get("coachs", {"team": team_id}, sleep)["response"]
+def fetch_coaches(team_id: int) -> list:
+    return api_get("coachs", {"team": team_id})["response"]
 
-def fetch_squads(team_id: int, sleep: float = 0.0) -> list:
-    return api_get("players/squads", {"team": team_id}, sleep)["response"]
+def fetch_squads(team_id: int) -> list:
+    return api_get("players/squads", {"team": team_id})["response"]
 
-def fetch_transfers(team_id: int, sleep: float = 0.0) -> list:
-    return api_get("transfers", {"team": team_id}, sleep)["response"]
+def fetch_transfers(team_id: int) -> list:
+    return api_get("transfers", {"team": team_id})["response"]
 
-def fetch_sidelined(team_id: int, sleep: float = 0.0) -> list:
-    return api_get("sidelined", {"team": team_id}, sleep)["response"]
+def fetch_sidelined(team_id: int) -> list:
+    return api_get("sidelined", {"team": team_id})["response"]
 
-def fetch_trophies(team_id: int, sleep: float = 0.0) -> list:
-    return api_get("trophies", {"team": team_id}, sleep)["response"]
+def fetch_trophies(team_id: int) -> list:
+    return api_get("trophies", {"team": team_id})["response"]
 
 
 # ---------------------------------------------------------------------------
 # Per-fixture fetchers
 # ---------------------------------------------------------------------------
 
-def fetch_fixtures(season: int, from_date: str | None = None, to_date: str | None = None, sleep: float = 0.0) -> list:
+def fetch_fixtures(season: int, from_date: str | None = None, to_date: str | None = None) -> list:
     params = {"league": LEAGUE_ID, "season": season}
     if from_date:
         params["from"] = from_date
     if to_date:
         params["to"] = to_date
-    data = api_get("fixtures", params, sleep)
+    data = api_get("fixtures", params)
     log.info("Season %d: fetched %d fixtures", season, len(data["response"]))
     return data["response"]
 
-def fetch_events(fixture_id: int, sleep: float = 0.0) -> list:
-    return api_get("fixtures/events", {"fixture": fixture_id}, sleep)["response"]
+def fetch_events(fixture_id: int) -> list:
+    return api_get("fixtures/events", {"fixture": fixture_id})["response"]
 
-def fetch_statistics(fixture_id: int, sleep: float = 0.0) -> list:
-    return api_get("fixtures/statistics", {"fixture": fixture_id}, sleep)["response"]
+def fetch_statistics(fixture_id: int) -> list:
+    return api_get("fixtures/statistics", {"fixture": fixture_id})["response"]
 
-def fetch_lineups(fixture_id: int, sleep: float = 0.0) -> list:
-    return api_get("fixtures/lineups", {"fixture": fixture_id}, sleep)["response"]
+def fetch_lineups(fixture_id: int) -> list:
+    return api_get("fixtures/lineups", {"fixture": fixture_id})["response"]
 
-def fetch_fixture_players(fixture_id: int, sleep: float = 0.0) -> list:
-    return api_get("fixtures/players", {"fixture": fixture_id}, sleep)["response"]
+def fetch_fixture_players(fixture_id: int) -> list:
+    return api_get("fixtures/players", {"fixture": fixture_id})["response"]
 
-def fetch_predictions(fixture_id: int, sleep: float = 0.0) -> list:
-    return api_get("predictions", {"fixture": fixture_id}, sleep)["response"]
+def fetch_predictions(fixture_id: int) -> list:
+    return api_get("predictions", {"fixture": fixture_id})["response"]
 
-def fetch_odds(fixture_id: int, sleep: float = 0.0) -> list:
-    return api_get("odds", {"fixture": fixture_id}, sleep)["response"]
+def fetch_odds(fixture_id: int) -> list:
+    return api_get("odds", {"fixture": fixture_id})["response"]
 
 
 # ---------------------------------------------------------------------------
@@ -201,7 +223,6 @@ def connect() -> duckdb.DuckDBPyConnection:
 def ensure_schema_and_tables(conn: duckdb.DuckDBPyConnection) -> None:
     conn.execute("CREATE SCHEMA IF NOT EXISTS bronze")
 
-    # fixture_id PK
     for table in (
         "api_football__fixtures",
         "api_football__fixture_events",
@@ -219,7 +240,6 @@ def ensure_schema_and_tables(conn: duckdb.DuckDBPyConnection) -> None:
             )
         """)
 
-    # season PK
     for table in (
         "api_football__standings",
         "api_football__topscorers",
@@ -237,7 +257,6 @@ def ensure_schema_and_tables(conn: duckdb.DuckDBPyConnection) -> None:
             )
         """)
 
-    # league_id PK
     for table in ("api_football__leagues", "api_football__venues"):
         conn.execute(f"""
             CREATE TABLE IF NOT EXISTS bronze.{table} (
@@ -247,7 +266,6 @@ def ensure_schema_and_tables(conn: duckdb.DuckDBPyConnection) -> None:
             )
         """)
 
-    # team_id PK
     for table in (
         "api_football__coaches",
         "api_football__squads",
@@ -263,7 +281,6 @@ def ensure_schema_and_tables(conn: duckdb.DuckDBPyConnection) -> None:
             )
         """)
 
-    # season PK — teams vary by season
     conn.execute("""
         CREATE TABLE IF NOT EXISTS bronze.api_football__teams (
             season      INTEGER PRIMARY KEY,
@@ -271,8 +288,6 @@ def ensure_schema_and_tables(conn: duckdb.DuckDBPyConnection) -> None:
             ingested_at TIMESTAMP DEFAULT current_timestamp
         )
     """)
-
-    # composite PKs
     conn.execute("""
         CREATE TABLE IF NOT EXISTS bronze.api_football__team_statistics (
             season      INTEGER,
@@ -326,6 +341,15 @@ ALL_BRONZE_TABLES = [
     "api_football__players",
 ]
 
+FIXTURE_DETAIL_TABLES = [
+    "api_football__fixture_events",
+    "api_football__fixture_statistics",
+    "api_football__fixture_lineups",
+    "api_football__fixture_players",
+    "api_football__fixture_predictions",
+    "api_football__fixture_odds",
+]
+
 
 def truncate_all(conn) -> None:
     for table in ALL_BRONZE_TABLES:
@@ -348,9 +372,7 @@ def _delete_insert(conn, table: str, key_cols: list, key_vals: list, payload) ->
     _insert(conn, table, key_cols, key_vals, payload)
 
 
-def load_fixtures_bulk(conn, fixtures: list, truncate: bool = False) -> None:
-    if truncate:
-        conn.execute("DELETE FROM bronze.api_football__fixtures")
+def load_fixtures_bulk(conn, fixtures: list) -> None:
     rows = [(f["fixture"]["id"], json.dumps(f)) for f in fixtures]
     conn.executemany(
         "INSERT INTO bronze.api_football__fixtures (fixture_id, raw_json) VALUES (?, ?)",
@@ -363,21 +385,21 @@ def load_fixtures_bulk(conn, fixtures: list, truncate: bool = False) -> None:
 # Shared helpers
 # ---------------------------------------------------------------------------
 
-def load_season_aggregates(conn, season: int, sleep: float = 0.0, full_load: bool = False) -> None:
+def load_season_aggregates(conn, season: int, incremental: bool = False) -> None:
     """
     Season-level aggregates.
     - Full load: plain INSERT (tables already truncated).
     - Incremental: DELETE by season then INSERT.
     """
     log.info("Season %d: loading aggregates", season)
-    write = _insert if full_load else _delete_insert
+    write = _delete_insert if incremental else _insert
     for table, fetcher in (
-        ("api_football__standings",      lambda: fetch_standings(season, sleep)),
-        ("api_football__topscorers",     lambda: fetch_topscorers(season, sleep)),
-        ("api_football__topassists",     lambda: fetch_topassists(season, sleep)),
-        ("api_football__topyellowcards", lambda: fetch_topyellowcards(season, sleep)),
-        ("api_football__topredcards",    lambda: fetch_topredcards(season, sleep)),
-        ("api_football__injuries",       lambda: fetch_injuries(season, sleep)),
+        ("api_football__standings",      lambda: fetch_standings(season)),
+        ("api_football__topscorers",     lambda: fetch_topscorers(season)),
+        ("api_football__topassists",     lambda: fetch_topassists(season)),
+        ("api_football__topyellowcards", lambda: fetch_topyellowcards(season)),
+        ("api_football__topredcards",    lambda: fetch_topredcards(season)),
+        ("api_football__injuries",       lambda: fetch_injuries(season)),
     ):
         try:
             write(conn, table, ["season"], [season], fetcher())
@@ -385,35 +407,8 @@ def load_season_aggregates(conn, season: int, sleep: float = 0.0, full_load: boo
             log.warning("Failed %s season %d: %s", table, season, exc)
 
 
-FIXTURE_DETAIL_TABLES = [
-    "api_football__fixture_events",
-    "api_football__fixture_statistics",
-    "api_football__fixture_lineups",
-    "api_football__fixture_players",
-    "api_football__fixture_predictions",
-    "api_football__fixture_odds",
-]
-
-
-def delete_fixture_details_by_ids(conn, fixture_ids: list[int]) -> None:
-    """Delete all fixture-detail rows for a given list of fixture IDs in one pass."""
-    if not fixture_ids:
-        return
-    placeholders = ", ".join("?" * len(fixture_ids))
-    for table in FIXTURE_DETAIL_TABLES:
-        conn.execute(
-            f"DELETE FROM bronze.{table} WHERE fixture_id IN ({placeholders})",
-            fixture_ids,
-        )
-    log.info("Deleted fixture detail rows for %d fixtures", len(fixture_ids))
-
-
-def load_fixture_details(conn, fixtures: list, sleep: float = 0.0, full_load: bool = False) -> None:
-    """
-    Fixture-level endpoints for finished matches.
-    - Full load: plain INSERT (tables already truncated).
-    - Incremental: caller must have already deleted the relevant rows by date window.
-    """
+def load_fixture_details(conn, fixtures: list) -> None:
+    """Fetch and insert all fixture-level endpoints for finished matches."""
     finished = [f for f in fixtures if f["fixture"]["status"]["short"] in ("FT", "AET", "PEN")]
     log.info("%d finished fixtures — fetching fixture-level endpoints", len(finished))
 
@@ -422,26 +417,26 @@ def load_fixture_details(conn, fixtures: list, sleep: float = 0.0, full_load: bo
         home = f["teams"]["home"]["name"]
         away = f["teams"]["away"]["name"]
         try:
-            _insert(conn, "api_football__fixture_events",      ["fixture_id"], [fixture_id], fetch_events(fixture_id, sleep))
-            _insert(conn, "api_football__fixture_statistics",  ["fixture_id"], [fixture_id], fetch_statistics(fixture_id, sleep))
-            _insert(conn, "api_football__fixture_lineups",     ["fixture_id"], [fixture_id], fetch_lineups(fixture_id, sleep))
-            _insert(conn, "api_football__fixture_players",     ["fixture_id"], [fixture_id], fetch_fixture_players(fixture_id, sleep))
-            _insert(conn, "api_football__fixture_predictions", ["fixture_id"], [fixture_id], fetch_predictions(fixture_id, sleep))
-            _insert(conn, "api_football__fixture_odds",        ["fixture_id"], [fixture_id], fetch_odds(fixture_id, sleep))
+            _insert(conn, "api_football__fixture_events",      ["fixture_id"], [fixture_id], fetch_events(fixture_id))
+            _insert(conn, "api_football__fixture_statistics",  ["fixture_id"], [fixture_id], fetch_statistics(fixture_id))
+            _insert(conn, "api_football__fixture_lineups",     ["fixture_id"], [fixture_id], fetch_lineups(fixture_id))
+            _insert(conn, "api_football__fixture_players",     ["fixture_id"], [fixture_id], fetch_fixture_players(fixture_id))
+            _insert(conn, "api_football__fixture_predictions", ["fixture_id"], [fixture_id], fetch_predictions(fixture_id))
+            _insert(conn, "api_football__fixture_odds",        ["fixture_id"], [fixture_id], fetch_odds(fixture_id))
             log.info("Loaded fixture %d: %s vs %s", fixture_id, home, away)
         except Exception as exc:
             log.warning("Failed fixture %d (%s vs %s): %s", fixture_id, home, away, exc)
 
 
-def load_reference_and_team_data(conn, season: int, sleep: float = 0.0) -> None:
+def load_reference_and_team_data(conn, season: int) -> None:
     """Reference and per-team data. Full load only — plain INSERT (tables already truncated)."""
     log.info("Season %d: loading reference data", season)
 
     for table, fetcher, key_col, key_val in (
-        ("api_football__leagues", lambda: fetch_leagues(sleep),        "league_id", LEAGUE_ID),
-        ("api_football__teams",   lambda: fetch_teams(season, sleep),  "season",    season),
-        ("api_football__venues",  lambda: fetch_venues(sleep),         "league_id", LEAGUE_ID),
-        ("api_football__rounds",  lambda: fetch_rounds(season, sleep), "season",    season),
+        ("api_football__leagues", fetch_leagues,              "league_id", LEAGUE_ID),
+        ("api_football__teams",   lambda: fetch_teams(season),"season",    season),
+        ("api_football__venues",  fetch_venues,               "league_id", LEAGUE_ID),
+        ("api_football__rounds",  lambda: fetch_rounds(season),"season",   season),
     ):
         try:
             _insert(conn, table, [key_col], [key_val], fetcher())
@@ -449,12 +444,11 @@ def load_reference_and_team_data(conn, season: int, sleep: float = 0.0) -> None:
             log.warning("Failed %s season %d: %s", table, season, exc)
 
     try:
-        for page, response in fetch_league_players(season, sleep):
+        for page, response in fetch_league_players(season):
             _insert(conn, "api_football__players", ["season", "page"], [season, page], response)
     except Exception as exc:
         log.warning("Failed api_football__players season %d: %s", season, exc)
 
-    # Derive team IDs from what we just loaded
     rows = conn.execute(
         "SELECT DISTINCT json_extract_string(raw_json, '$.team.id')::integer "
         "FROM bronze.api_football__teams WHERE season = ?",
@@ -465,11 +459,11 @@ def load_reference_and_team_data(conn, season: int, sleep: float = 0.0) -> None:
 
     for team_id in team_ids:
         for table, fetcher in (
-            ("api_football__coaches",   lambda tid=team_id: fetch_coaches(tid, sleep)),
-            ("api_football__squads",    lambda tid=team_id: fetch_squads(tid, sleep)),
-            ("api_football__transfers", lambda tid=team_id: fetch_transfers(tid, sleep)),
-            ("api_football__sidelined", lambda tid=team_id: fetch_sidelined(tid, sleep)),
-            ("api_football__trophies",  lambda tid=team_id: fetch_trophies(tid, sleep)),
+            ("api_football__coaches",   lambda tid=team_id: fetch_coaches(tid)),
+            ("api_football__squads",    lambda tid=team_id: fetch_squads(tid)),
+            ("api_football__transfers", lambda tid=team_id: fetch_transfers(tid)),
+            ("api_football__sidelined", lambda tid=team_id: fetch_sidelined(tid)),
+            ("api_football__trophies",  lambda tid=team_id: fetch_trophies(tid)),
         ):
             try:
                 _insert(conn, table, ["team_id"], [team_id], fetcher())
@@ -480,7 +474,7 @@ def load_reference_and_team_data(conn, season: int, sleep: float = 0.0) -> None:
             _insert(
                 conn, "api_football__team_statistics",
                 ["season", "team_id"], [season, team_id],
-                fetch_team_statistics(team_id, season, sleep),
+                fetch_team_statistics(team_id, season),
             )
         except Exception as exc:
             log.warning("Failed team_statistics team %d season %d: %s", team_id, season, exc)
@@ -495,32 +489,30 @@ def run(lookback_days: int = 2, full_load: bool = False, season: int | None = No
     ensure_schema_and_tables(conn)
 
     if full_load:
-        sleep   = 6.5
         seasons = [season] if season else list(range(FIRST_SEASON, CURRENT_SEASON + 1))
         log.info("Full load — seasons: %s", seasons)
 
-        # Truncate only when loading all seasons — single-season runs append to existing data
+        # Truncate only when loading all seasons — single-season runs append
         if not season:
             truncate_all(conn)
 
         for s in seasons:
             log.info("=== Season %d ===", s)
-            load_season_aggregates(conn, s, sleep, full_load=True)
-            fixtures = fetch_fixtures(s, sleep=sleep)
-            load_fixtures_bulk(conn, fixtures, truncate=False)  # already truncated above
-            load_fixture_details(conn, fixtures, sleep, full_load=True)
-            load_reference_and_team_data(conn, s, sleep)
+            load_season_aggregates(conn, s)
+            fixtures = fetch_fixtures(s)
+            load_fixtures_bulk(conn, fixtures)
+            load_fixture_details(conn, fixtures)
+            load_reference_and_team_data(conn, s)
 
     else:
-        # Daily incremental
         from_date = (date.today() - timedelta(days=lookback_days)).isoformat()
         to_date   = date.today().isoformat()
         log.info("Incremental load — window: %s to %s", from_date, to_date)
 
-        # 1. Full refresh of current season aggregates (delete by season, then insert)
-        load_season_aggregates(conn, CURRENT_SEASON, sleep=0.0, full_load=False)
+        # 1. Full refresh of current season aggregates
+        load_season_aggregates(conn, CURRENT_SEASON, incremental=True)
 
-        # 2. Delete the date window from fixtures and all fixture-detail tables upfront
+        # 2. Delete the date window upfront from fixtures and all detail tables
         fixture_ids_in_window = [
             row[0] for row in conn.execute(
                 "SELECT fixture_id FROM bronze.api_football__fixtures "
@@ -535,13 +527,17 @@ def run(lookback_days: int = 2, full_load: bool = False, season: int | None = No
                 f"DELETE FROM bronze.api_football__fixtures WHERE fixture_id IN ({placeholders})",
                 fixture_ids_in_window,
             )
-            delete_fixture_details_by_ids(conn, fixture_ids_in_window)
+            for table in FIXTURE_DETAIL_TABLES:
+                conn.execute(
+                    f"DELETE FROM bronze.{table} WHERE fixture_id IN ({placeholders})",
+                    fixture_ids_in_window,
+                )
             log.info("Cleared %d fixtures from the date window", len(fixture_ids_in_window))
 
-        # 3. Fetch and bulk insert
+        # 3. Fetch and insert
         fixtures = fetch_fixtures(CURRENT_SEASON, from_date=from_date, to_date=to_date)
         load_fixtures_bulk(conn, fixtures)
-        load_fixture_details(conn, fixtures, sleep=0.0, full_load=True)  # tables already cleared
+        load_fixture_details(conn, fixtures)
 
     conn.close()
     log.info("Bronze ingestion complete")
@@ -552,9 +548,9 @@ if __name__ == "__main__":
     parser.add_argument("--lookback", type=int, default=2,
                         help="Days to look back for finished fixtures (default: 2)")
     parser.add_argument("--full-load", action="store_true",
-                        help="Historical load — requires upgraded API plan (~2.3h per season)")
+                        help="Historical load — requires upgraded API plan (~2.5h per season)")
     parser.add_argument("--season", type=int, default=None,
-                        help="Season year to load (e.g. 2023). Used with --full-load to load "
-                             "one season at a time. Omit to load all seasons %d-%d." % (FIRST_SEASON, CURRENT_SEASON))
+                        help="Season year for --full-load (e.g. 2023). "
+                             "Omit to load all seasons %d-%d." % (FIRST_SEASON, CURRENT_SEASON))
     args = parser.parse_args()
     run(lookback_days=args.lookback, full_load=args.full_load, season=args.season)

--- a/ingestion/ingest_superligaen.py
+++ b/ingestion/ingest_superligaen.py
@@ -5,40 +5,25 @@ Fetches raw JSON from api-football.com and lands it as-is into the bronze
 schema in MotherDuck. No transformation — that is dbt's job.
 
 Run modes:
-  --lookback N   Fetch fixtures from the last N days (default: 2). Always
-                 refreshes season aggregates (standings, top scorers, etc.)
-  --full-load    Fetch the entire season plus all reference and per-team data.
-                 Requires an upgraded api-football plan (>100 req/day).
+  --lookback N   Incremental daily run. Fetches fixtures from the last N days
+                 (default: 2) plus a full refresh of current-season aggregates
+                 (standings, top scorers, injuries, etc.).
+  --full-load    Historical load. Fetches all data for every season from
+                 FIRST_SEASON to CURRENT_SEASON. Requires an upgraded
+                 api-football plan (far exceeds 100 req/day).
 
-Tables populated on EVERY run (season aggregates — change each matchday):
-  api_football__standings
-  api_football__topscorers
-  api_football__topassists
-  api_football__topyellowcards
-  api_football__topredcards
-  api_football__injuries
+Daily incremental — what gets loaded:
+  FULL REFRESH (current season only, always up to date):
+    standings, topscorers, topassists, topyellowcards, topredcards, injuries
 
-Tables populated on FULL LOAD only (reference / relatively static):
-  api_football__leagues
-  api_football__teams
-  api_football__venues
-  api_football__rounds
-  api_football__players             (paginated — all player profiles)
-  api_football__team_statistics     (keyed by season + team_id)
-  api_football__coaches             (keyed by team_id)
-  api_football__squads              (keyed by team_id)
-  api_football__transfers           (keyed by team_id)
-  api_football__sidelined           (keyed by team_id)
-  api_football__trophies            (keyed by team_id)
+  INCREMENTAL (fixtures in the lookback window):
+    fixtures, fixture_events, fixture_statistics, fixture_lineups,
+    fixture_players, fixture_predictions, fixture_odds
 
-Tables populated for every finished fixture (both runs):
-  api_football__fixtures
-  api_football__fixture_events
-  api_football__fixture_statistics
-  api_football__fixture_lineups
-  api_football__fixture_players
-  api_football__fixture_predictions
-  api_football__fixture_odds        (free tier: 7-day history only)
+Full load — what gets loaded (for each season from FIRST_SEASON onwards):
+  All of the above, plus reference and per-team data:
+    leagues, teams, venues, rounds, players (paginated),
+    team_statistics, coaches, squads, transfers, sidelined, trophies
 """
 
 import argparse
@@ -60,9 +45,10 @@ logging.basicConfig(
 )
 log = logging.getLogger(__name__)
 
-API_BASE = "https://v3.football.api-sports.io"
-LEAGUE_ID = 119
+API_BASE     = "https://v3.football.api-sports.io"
+LEAGUE_ID    = 119
 CURRENT_SEASON = 2025
+FIRST_SEASON   = 2020  # earliest season to load on --full-load
 
 
 # ---------------------------------------------------------------------------
@@ -89,54 +75,50 @@ def api_get(endpoint: str, params: dict, sleep: float = 0.0) -> dict:
 
 
 # ---------------------------------------------------------------------------
-# Season-level fetchers (always run)
+# Season-level fetchers
 # ---------------------------------------------------------------------------
 
-def fetch_standings(sleep: float = 0.0) -> list:
-    return api_get("standings", {"league": LEAGUE_ID, "season": CURRENT_SEASON}, sleep)["response"]
+def fetch_standings(season: int, sleep: float = 0.0) -> list:
+    return api_get("standings", {"league": LEAGUE_ID, "season": season}, sleep)["response"]
 
-def fetch_topscorers(sleep: float = 0.0) -> list:
-    return api_get("players/topscorers", {"league": LEAGUE_ID, "season": CURRENT_SEASON}, sleep)["response"]
+def fetch_topscorers(season: int, sleep: float = 0.0) -> list:
+    return api_get("players/topscorers", {"league": LEAGUE_ID, "season": season}, sleep)["response"]
 
-def fetch_topassists(sleep: float = 0.0) -> list:
-    return api_get("players/topassists", {"league": LEAGUE_ID, "season": CURRENT_SEASON}, sleep)["response"]
+def fetch_topassists(season: int, sleep: float = 0.0) -> list:
+    return api_get("players/topassists", {"league": LEAGUE_ID, "season": season}, sleep)["response"]
 
-def fetch_topyellowcards(sleep: float = 0.0) -> list:
-    return api_get("players/topyellowcards", {"league": LEAGUE_ID, "season": CURRENT_SEASON}, sleep)["response"]
+def fetch_topyellowcards(season: int, sleep: float = 0.0) -> list:
+    return api_get("players/topyellowcards", {"league": LEAGUE_ID, "season": season}, sleep)["response"]
 
-def fetch_topredcards(sleep: float = 0.0) -> list:
-    return api_get("players/topredcards", {"league": LEAGUE_ID, "season": CURRENT_SEASON}, sleep)["response"]
+def fetch_topredcards(season: int, sleep: float = 0.0) -> list:
+    return api_get("players/topredcards", {"league": LEAGUE_ID, "season": season}, sleep)["response"]
 
-def fetch_injuries(sleep: float = 0.0) -> list:
-    return api_get("injuries", {"league": LEAGUE_ID, "season": CURRENT_SEASON}, sleep)["response"]
+def fetch_injuries(season: int, sleep: float = 0.0) -> list:
+    return api_get("injuries", {"league": LEAGUE_ID, "season": season}, sleep)["response"]
 
 
 # ---------------------------------------------------------------------------
-# Reference fetchers (full load only)
+# Reference fetchers
 # ---------------------------------------------------------------------------
 
 def fetch_leagues(sleep: float = 0.0) -> list:
     return api_get("leagues", {"id": LEAGUE_ID}, sleep)["response"]
 
-def fetch_teams(sleep: float = 0.0) -> list:
-    return api_get("teams", {"league": LEAGUE_ID, "season": CURRENT_SEASON}, sleep)["response"]
+def fetch_teams(season: int, sleep: float = 0.0) -> list:
+    return api_get("teams", {"league": LEAGUE_ID, "season": season}, sleep)["response"]
 
 def fetch_venues(sleep: float = 0.0) -> list:
     return api_get("venues", {"league": LEAGUE_ID}, sleep)["response"]
 
-def fetch_rounds(sleep: float = 0.0) -> list:
-    return api_get("fixtures/rounds", {"league": LEAGUE_ID, "season": CURRENT_SEASON}, sleep)["response"]
+def fetch_rounds(season: int, sleep: float = 0.0) -> list:
+    return api_get("fixtures/rounds", {"league": LEAGUE_ID, "season": season}, sleep)["response"]
 
-def fetch_league_players(sleep: float = 0.0) -> list[tuple[int, list]]:
+def fetch_league_players(season: int, sleep: float = 0.0) -> list[tuple[int, list]]:
     """Returns (page, response) tuples across all pages."""
     results = []
     page = 1
     while True:
-        data = api_get(
-            "players",
-            {"league": LEAGUE_ID, "season": CURRENT_SEASON, "page": page},
-            sleep,
-        )
+        data = api_get("players", {"league": LEAGUE_ID, "season": season, "page": page}, sleep)
         results.append((page, data["response"]))
         if page >= data["paging"]["total"]:
             break
@@ -145,13 +127,13 @@ def fetch_league_players(sleep: float = 0.0) -> list[tuple[int, list]]:
 
 
 # ---------------------------------------------------------------------------
-# Per-team fetchers (full load only)
+# Per-team fetchers
 # ---------------------------------------------------------------------------
 
-def fetch_team_statistics(team_id: int, sleep: float = 0.0) -> dict:
+def fetch_team_statistics(team_id: int, season: int, sleep: float = 0.0) -> dict:
     return api_get(
         "teams/statistics",
-        {"league": LEAGUE_ID, "season": CURRENT_SEASON, "team": team_id},
+        {"league": LEAGUE_ID, "season": season, "team": team_id},
         sleep,
     )["response"]
 
@@ -172,17 +154,17 @@ def fetch_trophies(team_id: int, sleep: float = 0.0) -> list:
 
 
 # ---------------------------------------------------------------------------
-# Per-fixture fetchers (both runs)
+# Per-fixture fetchers
 # ---------------------------------------------------------------------------
 
-def fetch_fixtures(from_date: str | None = None, to_date: str | None = None, sleep: float = 0.0) -> list:
-    params = {"league": LEAGUE_ID, "season": CURRENT_SEASON}
+def fetch_fixtures(season: int, from_date: str | None = None, to_date: str | None = None, sleep: float = 0.0) -> list:
+    params = {"league": LEAGUE_ID, "season": season}
     if from_date:
         params["from"] = from_date
     if to_date:
         params["to"] = to_date
     data = api_get("fixtures", params, sleep)
-    log.info("Fetched %d fixtures", len(data["response"]))
+    log.info("Season %d: fetched %d fixtures", season, len(data["response"]))
     return data["response"]
 
 def fetch_events(fixture_id: int, sleep: float = 0.0) -> list:
@@ -245,7 +227,6 @@ def ensure_schema_and_tables(conn: duckdb.DuckDBPyConnection) -> None:
         "api_football__topyellowcards",
         "api_football__topredcards",
         "api_football__injuries",
-        "api_football__teams",
         "api_football__rounds",
     ):
         conn.execute(f"""
@@ -282,6 +263,15 @@ def ensure_schema_and_tables(conn: duckdb.DuckDBPyConnection) -> None:
             )
         """)
 
+    # season PK — teams vary by season
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS bronze.api_football__teams (
+            season      INTEGER PRIMARY KEY,
+            raw_json    JSON NOT NULL,
+            ingested_at TIMESTAMP DEFAULT current_timestamp
+        )
+    """)
+
     # composite PKs
     conn.execute("""
         CREATE TABLE IF NOT EXISTS bronze.api_football__team_statistics (
@@ -310,7 +300,7 @@ def ensure_schema_and_tables(conn: duckdb.DuckDBPyConnection) -> None:
 # ---------------------------------------------------------------------------
 
 def _upsert(conn, table: str, key_cols: list, key_vals: list, payload) -> None:
-    cols = ", ".join(key_cols) + ", raw_json"
+    cols         = ", ".join(key_cols) + ", raw_json"
     placeholders = ", ".join(["?"] * len(key_vals)) + ", ?"
     conn.execute(
         f"INSERT OR REPLACE INTO bronze.{table} ({cols}) VALUES ({placeholders})",
@@ -318,116 +308,40 @@ def _upsert(conn, table: str, key_cols: list, key_vals: list, payload) -> None:
     )
 
 
-def load_fixtures(conn, fixtures: list) -> None:
+def load_fixtures_bulk(conn, fixtures: list) -> None:
     rows = [(f["fixture"]["id"], json.dumps(f)) for f in fixtures]
     conn.executemany(
         "INSERT OR REPLACE INTO bronze.api_football__fixtures (fixture_id, raw_json) VALUES (?, ?)",
         rows,
     )
-    log.info("Loaded %d rows into bronze.api_football__fixtures", len(rows))
+    log.info("Upserted %d rows into bronze.api_football__fixtures", len(rows))
 
 
 # ---------------------------------------------------------------------------
-# Main
+# Shared helpers
 # ---------------------------------------------------------------------------
 
-def run(lookback_days: int = 2, full_load: bool = False) -> None:
-    conn = connect()
-    ensure_schema_and_tables(conn)
-
-    sleep = 6.5 if full_load else 0.0
-
-    # --- Season aggregates (every run) ---
-    log.info("Fetching season aggregates")
+def load_season_aggregates(conn, season: int, sleep: float = 0.0) -> None:
+    """Full refresh of season-level aggregates. Runs on every daily run and full load."""
+    log.info("Season %d: loading aggregates", season)
     for table, fetcher in (
-        ("api_football__standings",      lambda: fetch_standings(sleep)),
-        ("api_football__topscorers",     lambda: fetch_topscorers(sleep)),
-        ("api_football__topassists",     lambda: fetch_topassists(sleep)),
-        ("api_football__topyellowcards", lambda: fetch_topyellowcards(sleep)),
-        ("api_football__topredcards",    lambda: fetch_topredcards(sleep)),
-        ("api_football__injuries",       lambda: fetch_injuries(sleep)),
+        ("api_football__standings",      lambda: fetch_standings(season, sleep)),
+        ("api_football__topscorers",     lambda: fetch_topscorers(season, sleep)),
+        ("api_football__topassists",     lambda: fetch_topassists(season, sleep)),
+        ("api_football__topyellowcards", lambda: fetch_topyellowcards(season, sleep)),
+        ("api_football__topredcards",    lambda: fetch_topredcards(season, sleep)),
+        ("api_football__injuries",       lambda: fetch_injuries(season, sleep)),
     ):
         try:
-            _upsert(conn, table, ["season"], [CURRENT_SEASON], fetcher())
-            log.info("Loaded %s", table)
+            _upsert(conn, table, ["season"], [season], fetcher())
         except Exception as exc:
-            log.warning("Failed %s: %s", table, exc)
+            log.warning("Failed %s season %d: %s", table, season, exc)
 
-    # --- Fixtures ---
-    if full_load:
-        log.info("Full load — fetching entire season %d", CURRENT_SEASON)
-        fixtures = fetch_fixtures(sleep=sleep)
-    else:
-        from_date = (date.today() - timedelta(days=lookback_days)).isoformat()
-        to_date = date.today().isoformat()
-        log.info("Incremental load — %s to %s", from_date, to_date)
-        fixtures = fetch_fixtures(from_date=from_date, to_date=to_date, sleep=sleep)
 
-    load_fixtures(conn, fixtures)
-
-    # --- Reference data (full load only) ---
-    if full_load:
-        log.info("Fetching reference data")
-
-        for table, fetcher, key_col, key_val in (
-            ("api_football__leagues", lambda: fetch_leagues(sleep), "league_id", LEAGUE_ID),
-            ("api_football__teams",   lambda: fetch_teams(sleep),   "season",    CURRENT_SEASON),
-            ("api_football__venues",  lambda: fetch_venues(sleep),  "league_id", LEAGUE_ID),
-            ("api_football__rounds",  lambda: fetch_rounds(sleep),  "season",    CURRENT_SEASON),
-        ):
-            try:
-                _upsert(conn, table, [key_col], [key_val], fetcher())
-                log.info("Loaded %s", table)
-            except Exception as exc:
-                log.warning("Failed %s: %s", table, exc)
-
-        # Players (paginated)
-        try:
-            for page, response in fetch_league_players(sleep):
-                _upsert(conn, "api_football__players", ["season", "page"], [CURRENT_SEASON, page], response)
-            log.info("Loaded api_football__players")
-        except Exception as exc:
-            log.warning("Failed api_football__players: %s", exc)
-
-        # Per-team data — derive team list from what we just loaded
-        teams = conn.execute(
-            "SELECT DISTINCT json_extract_string(raw_json, '$.team.id')::integer AS team_id "
-            "FROM bronze.api_football__teams WHERE season = ?",
-            [CURRENT_SEASON],
-        ).fetchall()
-        team_ids = [row[0] for row in teams if row[0]]
-        log.info("Fetching per-team data for %d teams", len(team_ids))
-
-        for team_id in team_ids:
-            for table, fetcher in (
-                ("api_football__coaches",   lambda tid=team_id: fetch_coaches(tid, sleep)),
-                ("api_football__squads",    lambda tid=team_id: fetch_squads(tid, sleep)),
-                ("api_football__transfers", lambda tid=team_id: fetch_transfers(tid, sleep)),
-                ("api_football__sidelined", lambda tid=team_id: fetch_sidelined(tid, sleep)),
-                ("api_football__trophies",  lambda tid=team_id: fetch_trophies(tid, sleep)),
-            ):
-                try:
-                    _upsert(conn, table, ["team_id"], [team_id], fetcher())
-                except Exception as exc:
-                    log.warning("Failed %s team %d: %s", table, team_id, exc)
-
-            try:
-                _upsert(
-                    conn, "api_football__team_statistics",
-                    ["season", "team_id"], [CURRENT_SEASON, team_id],
-                    fetch_team_statistics(team_id, sleep),
-                )
-            except Exception as exc:
-                log.warning("Failed api_football__team_statistics team %d: %s", team_id, exc)
-
-            log.info("Loaded all data for team %d", team_id)
-
-    # --- Per-fixture details (finished matches) ---
-    finished = [
-        f for f in fixtures
-        if f["fixture"]["status"]["short"] in ("FT", "AET", "PEN")
-    ]
-    log.info("%d finished fixtures — fetching all fixture-level endpoints", len(finished))
+def load_fixture_details(conn, fixtures: list, sleep: float = 0.0) -> None:
+    """Fetch and store all fixture-level endpoints for finished matches."""
+    finished = [f for f in fixtures if f["fixture"]["status"]["short"] in ("FT", "AET", "PEN")]
+    log.info("%d finished fixtures — fetching fixture-level endpoints", len(finished))
 
     for f in finished:
         fixture_id = f["fixture"]["id"]
@@ -444,6 +358,94 @@ def run(lookback_days: int = 2, full_load: bool = False) -> None:
         except Exception as exc:
             log.warning("Failed fixture %d (%s vs %s): %s", fixture_id, home, away, exc)
 
+
+def load_reference_and_team_data(conn, season: int, sleep: float = 0.0) -> None:
+    """Reference and per-team data for a given season. Full load only."""
+    log.info("Season %d: loading reference data", season)
+
+    for table, fetcher, key_col, key_val in (
+        ("api_football__leagues", lambda: fetch_leagues(sleep),        "league_id", LEAGUE_ID),
+        ("api_football__teams",   lambda: fetch_teams(season, sleep),  "season",    season),
+        ("api_football__venues",  lambda: fetch_venues(sleep),         "league_id", LEAGUE_ID),
+        ("api_football__rounds",  lambda: fetch_rounds(season, sleep), "season",    season),
+    ):
+        try:
+            _upsert(conn, table, [key_col], [key_val], fetcher())
+        except Exception as exc:
+            log.warning("Failed %s season %d: %s", table, season, exc)
+
+    try:
+        for page, response in fetch_league_players(season, sleep):
+            _upsert(conn, "api_football__players", ["season", "page"], [season, page], response)
+    except Exception as exc:
+        log.warning("Failed api_football__players season %d: %s", season, exc)
+
+    # Derive team IDs from what we just loaded
+    rows = conn.execute(
+        "SELECT DISTINCT json_extract_string(raw_json, '$.team.id')::integer "
+        "FROM bronze.api_football__teams WHERE season = ?",
+        [season],
+    ).fetchall()
+    team_ids = [r[0] for r in rows if r[0]]
+    log.info("Season %d: loading per-team data for %d teams", season, len(team_ids))
+
+    for team_id in team_ids:
+        for table, fetcher in (
+            ("api_football__coaches",   lambda tid=team_id: fetch_coaches(tid, sleep)),
+            ("api_football__squads",    lambda tid=team_id: fetch_squads(tid, sleep)),
+            ("api_football__transfers", lambda tid=team_id: fetch_transfers(tid, sleep)),
+            ("api_football__sidelined", lambda tid=team_id: fetch_sidelined(tid, sleep)),
+            ("api_football__trophies",  lambda tid=team_id: fetch_trophies(tid, sleep)),
+        ):
+            try:
+                _upsert(conn, table, ["team_id"], [team_id], fetcher())
+            except Exception as exc:
+                log.warning("Failed %s team %d season %d: %s", table, team_id, season, exc)
+
+        try:
+            _upsert(
+                conn, "api_football__team_statistics",
+                ["season", "team_id"], [season, team_id],
+                fetch_team_statistics(team_id, season, sleep),
+            )
+        except Exception as exc:
+            log.warning("Failed team_statistics team %d season %d: %s", team_id, season, exc)
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def run(lookback_days: int = 2, full_load: bool = False) -> None:
+    conn = connect()
+    ensure_schema_and_tables(conn)
+
+    if full_load:
+        sleep   = 6.5
+        seasons = list(range(FIRST_SEASON, CURRENT_SEASON + 1))
+        log.info("Full load — seasons %d to %d", FIRST_SEASON, CURRENT_SEASON)
+
+        for season in seasons:
+            log.info("=== Season %d ===", season)
+            load_season_aggregates(conn, season, sleep)
+            fixtures = fetch_fixtures(season, sleep=sleep)
+            load_fixtures_bulk(conn, fixtures)
+            load_fixture_details(conn, fixtures, sleep)
+            load_reference_and_team_data(conn, season, sleep)
+
+    else:
+        # Daily incremental
+        # 1. Full refresh of current season aggregates
+        load_season_aggregates(conn, CURRENT_SEASON, sleep=0.0)
+
+        # 2. Incremental fixture load for the lookback window
+        from_date = (date.today() - timedelta(days=lookback_days)).isoformat()
+        to_date   = date.today().isoformat()
+        log.info("Incremental fixture load — %s to %s", from_date, to_date)
+        fixtures = fetch_fixtures(CURRENT_SEASON, from_date=from_date, to_date=to_date)
+        load_fixtures_bulk(conn, fixtures)
+        load_fixture_details(conn, fixtures, sleep=0.0)
+
     conn.close()
     log.info("Bronze ingestion complete")
 
@@ -453,6 +455,6 @@ if __name__ == "__main__":
     parser.add_argument("--lookback", type=int, default=2,
                         help="Days to look back for finished fixtures (default: 2)")
     parser.add_argument("--full-load", action="store_true",
-                        help="Fetch entire season + all reference and per-team data")
+                        help="Historical load from %d to %d — requires upgraded API plan" % (FIRST_SEASON, CURRENT_SEASON))
     args = parser.parse_args()
     run(lookback_days=args.lookback, full_load=args.full_load)

--- a/ingestion/ingest_superligaen.py
+++ b/ingestion/ingest_superligaen.py
@@ -4,17 +4,41 @@ Bronze layer ingestion for Superligaen (Danish football).
 Fetches raw JSON from api-football.com and lands it as-is into the bronze
 schema in MotherDuck. No transformation — that is dbt's job.
 
-Tables written (bronze schema):
-  api_football__fixtures            one row per fixture, full API response JSON
-  api_football__fixture_events      one row per fixture, full events array JSON
-  api_football__fixture_statistics  one row per fixture, full statistics array JSON
-  api_football__fixture_lineups     one row per fixture, full lineups array JSON
-  api_football__fixture_players     one row per fixture, full player stats array JSON
+Run modes:
+  --lookback N   Fetch fixtures from the last N days (default: 2). Always
+                 refreshes season aggregates (standings, top scorers, etc.)
+  --full-load    Fetch the entire season plus all reference and per-team data.
+                 Requires an upgraded api-football plan (>100 req/day).
 
-Usage:
-  python ingestion/ingest_superligaen.py              # last 2 days (daily run)
-  python ingestion/ingest_superligaen.py --lookback 7 # last 7 days
-  python ingestion/ingest_superligaen.py --full-load  # entire current season
+Tables populated on EVERY run (season aggregates — change each matchday):
+  api_football__standings
+  api_football__topscorers
+  api_football__topassists
+  api_football__topyellowcards
+  api_football__topredcards
+  api_football__injuries
+
+Tables populated on FULL LOAD only (reference / relatively static):
+  api_football__leagues
+  api_football__teams
+  api_football__venues
+  api_football__rounds
+  api_football__players             (paginated — all player profiles)
+  api_football__team_statistics     (keyed by season + team_id)
+  api_football__coaches             (keyed by team_id)
+  api_football__squads              (keyed by team_id)
+  api_football__transfers           (keyed by team_id)
+  api_football__sidelined           (keyed by team_id)
+  api_football__trophies            (keyed by team_id)
+
+Tables populated for every finished fixture (both runs):
+  api_football__fixtures
+  api_football__fixture_events
+  api_football__fixture_statistics
+  api_football__fixture_lineups
+  api_football__fixture_players
+  api_football__fixture_predictions
+  api_football__fixture_odds        (free tier: 7-day history only)
 """
 
 import argparse
@@ -37,12 +61,12 @@ logging.basicConfig(
 log = logging.getLogger(__name__)
 
 API_BASE = "https://v3.football.api-sports.io"
-LEAGUE_ID = 119       # Superligaen
+LEAGUE_ID = 119
 CURRENT_SEASON = 2024
 
 
 # ---------------------------------------------------------------------------
-# API helpers
+# API helper
 # ---------------------------------------------------------------------------
 
 def _headers() -> dict:
@@ -64,35 +88,124 @@ def api_get(endpoint: str, params: dict, sleep: float = 0.0) -> dict:
     return data
 
 
-def fetch_fixtures(from_date: str | None = None, to_date: str | None = None, sleep: float = 0.0) -> list[dict]:
+# ---------------------------------------------------------------------------
+# Season-level fetchers (always run)
+# ---------------------------------------------------------------------------
+
+def fetch_standings(sleep: float = 0.0) -> list:
+    return api_get("standings", {"league": LEAGUE_ID, "season": CURRENT_SEASON}, sleep)["response"]
+
+def fetch_topscorers(sleep: float = 0.0) -> list:
+    return api_get("players/topscorers", {"league": LEAGUE_ID, "season": CURRENT_SEASON}, sleep)["response"]
+
+def fetch_topassists(sleep: float = 0.0) -> list:
+    return api_get("players/topassists", {"league": LEAGUE_ID, "season": CURRENT_SEASON}, sleep)["response"]
+
+def fetch_topyellowcards(sleep: float = 0.0) -> list:
+    return api_get("players/topyellowcards", {"league": LEAGUE_ID, "season": CURRENT_SEASON}, sleep)["response"]
+
+def fetch_topredcards(sleep: float = 0.0) -> list:
+    return api_get("players/topredcards", {"league": LEAGUE_ID, "season": CURRENT_SEASON}, sleep)["response"]
+
+def fetch_injuries(sleep: float = 0.0) -> list:
+    return api_get("injuries", {"league": LEAGUE_ID, "season": CURRENT_SEASON}, sleep)["response"]
+
+
+# ---------------------------------------------------------------------------
+# Reference fetchers (full load only)
+# ---------------------------------------------------------------------------
+
+def fetch_leagues(sleep: float = 0.0) -> list:
+    return api_get("leagues", {"id": LEAGUE_ID}, sleep)["response"]
+
+def fetch_teams(sleep: float = 0.0) -> list:
+    return api_get("teams", {"league": LEAGUE_ID, "season": CURRENT_SEASON}, sleep)["response"]
+
+def fetch_venues(sleep: float = 0.0) -> list:
+    return api_get("venues", {"league": LEAGUE_ID}, sleep)["response"]
+
+def fetch_rounds(sleep: float = 0.0) -> list:
+    return api_get("fixtures/rounds", {"league": LEAGUE_ID, "season": CURRENT_SEASON}, sleep)["response"]
+
+def fetch_league_players(sleep: float = 0.0) -> list[tuple[int, list]]:
+    """Returns (page, response) tuples across all pages."""
+    results = []
+    page = 1
+    while True:
+        data = api_get(
+            "players",
+            {"league": LEAGUE_ID, "season": CURRENT_SEASON, "page": page},
+            sleep,
+        )
+        results.append((page, data["response"]))
+        if page >= data["paging"]["total"]:
+            break
+        page += 1
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Per-team fetchers (full load only)
+# ---------------------------------------------------------------------------
+
+def fetch_team_statistics(team_id: int, sleep: float = 0.0) -> dict:
+    return api_get(
+        "teams/statistics",
+        {"league": LEAGUE_ID, "season": CURRENT_SEASON, "team": team_id},
+        sleep,
+    )["response"]
+
+def fetch_coaches(team_id: int, sleep: float = 0.0) -> list:
+    return api_get("coachs", {"team": team_id}, sleep)["response"]
+
+def fetch_squads(team_id: int, sleep: float = 0.0) -> list:
+    return api_get("players/squads", {"team": team_id}, sleep)["response"]
+
+def fetch_transfers(team_id: int, sleep: float = 0.0) -> list:
+    return api_get("transfers", {"team": team_id}, sleep)["response"]
+
+def fetch_sidelined(team_id: int, sleep: float = 0.0) -> list:
+    return api_get("sidelined", {"team": team_id}, sleep)["response"]
+
+def fetch_trophies(team_id: int, sleep: float = 0.0) -> list:
+    return api_get("trophies", {"team": team_id}, sleep)["response"]
+
+
+# ---------------------------------------------------------------------------
+# Per-fixture fetchers (both runs)
+# ---------------------------------------------------------------------------
+
+def fetch_fixtures(from_date: str | None = None, to_date: str | None = None, sleep: float = 0.0) -> list:
     params = {"league": LEAGUE_ID, "season": CURRENT_SEASON}
     if from_date:
         params["from"] = from_date
     if to_date:
         params["to"] = to_date
-    data = api_get("fixtures", params, sleep=sleep)
+    data = api_get("fixtures", params, sleep)
     log.info("Fetched %d fixtures", len(data["response"]))
     return data["response"]
 
+def fetch_events(fixture_id: int, sleep: float = 0.0) -> list:
+    return api_get("fixtures/events", {"fixture": fixture_id}, sleep)["response"]
 
-def fetch_events(fixture_id: int, sleep: float = 0.0) -> list[dict]:
-    return api_get("fixtures/events", {"fixture": fixture_id}, sleep=sleep)["response"]
+def fetch_statistics(fixture_id: int, sleep: float = 0.0) -> list:
+    return api_get("fixtures/statistics", {"fixture": fixture_id}, sleep)["response"]
 
+def fetch_lineups(fixture_id: int, sleep: float = 0.0) -> list:
+    return api_get("fixtures/lineups", {"fixture": fixture_id}, sleep)["response"]
 
-def fetch_statistics(fixture_id: int, sleep: float = 0.0) -> list[dict]:
-    return api_get("fixtures/statistics", {"fixture": fixture_id}, sleep=sleep)["response"]
+def fetch_fixture_players(fixture_id: int, sleep: float = 0.0) -> list:
+    return api_get("fixtures/players", {"fixture": fixture_id}, sleep)["response"]
 
+def fetch_predictions(fixture_id: int, sleep: float = 0.0) -> list:
+    return api_get("predictions", {"fixture": fixture_id}, sleep)["response"]
 
-def fetch_lineups(fixture_id: int, sleep: float = 0.0) -> list[dict]:
-    return api_get("fixtures/lineups", {"fixture": fixture_id}, sleep=sleep)["response"]
-
-
-def fetch_players(fixture_id: int, sleep: float = 0.0) -> list[dict]:
-    return api_get("fixtures/players", {"fixture": fixture_id}, sleep=sleep)["response"]
+def fetch_odds(fixture_id: int, sleep: float = 0.0) -> list:
+    return api_get("odds", {"fixture": fixture_id}, sleep)["response"]
 
 
 # ---------------------------------------------------------------------------
-# MotherDuck helpers
+# MotherDuck
 # ---------------------------------------------------------------------------
 
 def connect() -> duckdb.DuckDBPyConnection:
@@ -106,36 +219,106 @@ def connect() -> duckdb.DuckDBPyConnection:
 def ensure_schema_and_tables(conn: duckdb.DuckDBPyConnection) -> None:
     conn.execute("CREATE SCHEMA IF NOT EXISTS bronze")
 
+    # fixture_id PK
     for table in (
         "api_football__fixtures",
         "api_football__fixture_events",
         "api_football__fixture_statistics",
         "api_football__fixture_lineups",
         "api_football__fixture_players",
+        "api_football__fixture_predictions",
+        "api_football__fixture_odds",
     ):
         conn.execute(f"""
             CREATE TABLE IF NOT EXISTS bronze.{table} (
-                fixture_id   INTEGER PRIMARY KEY,
-                raw_json     JSON    NOT NULL,
-                ingested_at  TIMESTAMP DEFAULT current_timestamp
+                fixture_id  INTEGER PRIMARY KEY,
+                raw_json    JSON NOT NULL,
+                ingested_at TIMESTAMP DEFAULT current_timestamp
             )
         """)
 
-    log.info("Bronze schema and tables verified")
+    # season PK
+    for table in (
+        "api_football__standings",
+        "api_football__topscorers",
+        "api_football__topassists",
+        "api_football__topyellowcards",
+        "api_football__topredcards",
+        "api_football__injuries",
+        "api_football__teams",
+        "api_football__rounds",
+    ):
+        conn.execute(f"""
+            CREATE TABLE IF NOT EXISTS bronze.{table} (
+                season      INTEGER PRIMARY KEY,
+                raw_json    JSON NOT NULL,
+                ingested_at TIMESTAMP DEFAULT current_timestamp
+            )
+        """)
+
+    # league_id PK
+    for table in ("api_football__leagues", "api_football__venues"):
+        conn.execute(f"""
+            CREATE TABLE IF NOT EXISTS bronze.{table} (
+                league_id   INTEGER PRIMARY KEY,
+                raw_json    JSON NOT NULL,
+                ingested_at TIMESTAMP DEFAULT current_timestamp
+            )
+        """)
+
+    # team_id PK
+    for table in (
+        "api_football__coaches",
+        "api_football__squads",
+        "api_football__transfers",
+        "api_football__sidelined",
+        "api_football__trophies",
+    ):
+        conn.execute(f"""
+            CREATE TABLE IF NOT EXISTS bronze.{table} (
+                team_id     INTEGER PRIMARY KEY,
+                raw_json    JSON NOT NULL,
+                ingested_at TIMESTAMP DEFAULT current_timestamp
+            )
+        """)
+
+    # composite PKs
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS bronze.api_football__team_statistics (
+            season      INTEGER,
+            team_id     INTEGER,
+            raw_json    JSON NOT NULL,
+            ingested_at TIMESTAMP DEFAULT current_timestamp,
+            PRIMARY KEY (season, team_id)
+        )
+    """)
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS bronze.api_football__players (
+            season      INTEGER,
+            page        INTEGER,
+            raw_json    JSON NOT NULL,
+            ingested_at TIMESTAMP DEFAULT current_timestamp,
+            PRIMARY KEY (season, page)
+        )
+    """)
+
+    log.info("Bronze schema and all 21 tables verified")
 
 
 # ---------------------------------------------------------------------------
-# Load helpers — raw JSON, no transformation
+# Load helpers
 # ---------------------------------------------------------------------------
 
-def _upsert(conn: duckdb.DuckDBPyConnection, table: str, fixture_id: int, payload) -> None:
+def _upsert(conn, table: str, key_cols: list, key_vals: list, payload) -> None:
+    cols = ", ".join(key_cols) + ", raw_json"
+    placeholders = ", ".join(["?"] * len(key_vals)) + ", ?"
     conn.execute(
-        f"INSERT OR REPLACE INTO bronze.{table} (fixture_id, raw_json) VALUES (?, ?)",
-        [fixture_id, json.dumps(payload)],
+        f"INSERT OR REPLACE INTO bronze.{table} ({cols}) VALUES ({placeholders})",
+        key_vals + [json.dumps(payload)],
     )
 
 
-def load_fixtures(conn: duckdb.DuckDBPyConnection, fixtures: list[dict]) -> None:
+def load_fixtures(conn, fixtures: list) -> None:
     rows = [(f["fixture"]["id"], json.dumps(f)) for f in fixtures]
     conn.executemany(
         "INSERT OR REPLACE INTO bronze.api_football__fixtures (fixture_id, raw_json) VALUES (?, ?)",
@@ -152,35 +335,111 @@ def run(lookback_days: int = 2, full_load: bool = False) -> None:
     conn = connect()
     ensure_schema_and_tables(conn)
 
-    # Full loads respect the 10 req/min free tier limit — daily runs are fast
     sleep = 6.5 if full_load else 0.0
 
+    # --- Season aggregates (every run) ---
+    log.info("Fetching season aggregates")
+    for table, fetcher in (
+        ("api_football__standings",      lambda: fetch_standings(sleep)),
+        ("api_football__topscorers",     lambda: fetch_topscorers(sleep)),
+        ("api_football__topassists",     lambda: fetch_topassists(sleep)),
+        ("api_football__topyellowcards", lambda: fetch_topyellowcards(sleep)),
+        ("api_football__topredcards",    lambda: fetch_topredcards(sleep)),
+        ("api_football__injuries",       lambda: fetch_injuries(sleep)),
+    ):
+        try:
+            _upsert(conn, table, ["season"], [CURRENT_SEASON], fetcher())
+            log.info("Loaded %s", table)
+        except Exception as exc:
+            log.warning("Failed %s: %s", table, exc)
+
+    # --- Fixtures ---
     if full_load:
-        log.info("Full load — fetching entire season %d (rate-limited)", CURRENT_SEASON)
+        log.info("Full load — fetching entire season %d", CURRENT_SEASON)
         fixtures = fetch_fixtures(sleep=sleep)
     else:
         from_date = (date.today() - timedelta(days=lookback_days)).isoformat()
         to_date = date.today().isoformat()
         log.info("Incremental load — %s to %s", from_date, to_date)
-        fixtures = fetch_fixtures(from_date=from_date, to_date=to_date)
+        fixtures = fetch_fixtures(from_date=from_date, to_date=to_date, sleep=sleep)
 
     load_fixtures(conn, fixtures)
 
+    # --- Reference data (full load only) ---
+    if full_load:
+        log.info("Fetching reference data")
+
+        for table, fetcher, key_col, key_val in (
+            ("api_football__leagues", lambda: fetch_leagues(sleep), "league_id", LEAGUE_ID),
+            ("api_football__teams",   lambda: fetch_teams(sleep),   "season",    CURRENT_SEASON),
+            ("api_football__venues",  lambda: fetch_venues(sleep),  "league_id", LEAGUE_ID),
+            ("api_football__rounds",  lambda: fetch_rounds(sleep),  "season",    CURRENT_SEASON),
+        ):
+            try:
+                _upsert(conn, table, [key_col], [key_val], fetcher())
+                log.info("Loaded %s", table)
+            except Exception as exc:
+                log.warning("Failed %s: %s", table, exc)
+
+        # Players (paginated)
+        try:
+            for page, response in fetch_league_players(sleep):
+                _upsert(conn, "api_football__players", ["season", "page"], [CURRENT_SEASON, page], response)
+            log.info("Loaded api_football__players")
+        except Exception as exc:
+            log.warning("Failed api_football__players: %s", exc)
+
+        # Per-team data — derive team list from what we just loaded
+        teams = conn.execute(
+            "SELECT DISTINCT json_extract_string(raw_json, '$.team.id')::integer AS team_id "
+            "FROM bronze.api_football__teams WHERE season = ?",
+            [CURRENT_SEASON],
+        ).fetchall()
+        team_ids = [row[0] for row in teams if row[0]]
+        log.info("Fetching per-team data for %d teams", len(team_ids))
+
+        for team_id in team_ids:
+            for table, fetcher in (
+                ("api_football__coaches",   lambda tid=team_id: fetch_coaches(tid, sleep)),
+                ("api_football__squads",    lambda tid=team_id: fetch_squads(tid, sleep)),
+                ("api_football__transfers", lambda tid=team_id: fetch_transfers(tid, sleep)),
+                ("api_football__sidelined", lambda tid=team_id: fetch_sidelined(tid, sleep)),
+                ("api_football__trophies",  lambda tid=team_id: fetch_trophies(tid, sleep)),
+            ):
+                try:
+                    _upsert(conn, table, ["team_id"], [team_id], fetcher())
+                except Exception as exc:
+                    log.warning("Failed %s team %d: %s", table, team_id, exc)
+
+            try:
+                _upsert(
+                    conn, "api_football__team_statistics",
+                    ["season", "team_id"], [CURRENT_SEASON, team_id],
+                    fetch_team_statistics(team_id, sleep),
+                )
+            except Exception as exc:
+                log.warning("Failed api_football__team_statistics team %d: %s", team_id, exc)
+
+            log.info("Loaded all data for team %d", team_id)
+
+    # --- Per-fixture details (finished matches) ---
     finished = [
         f for f in fixtures
         if f["fixture"]["status"]["short"] in ("FT", "AET", "PEN")
     ]
-    log.info("%d finished fixtures — fetching all detail endpoints", len(finished))
+    log.info("%d finished fixtures — fetching all fixture-level endpoints", len(finished))
 
     for f in finished:
         fixture_id = f["fixture"]["id"]
         home = f["teams"]["home"]["name"]
         away = f["teams"]["away"]["name"]
         try:
-            _upsert(conn, "api_football__fixture_events",     fixture_id, fetch_events(fixture_id, sleep=sleep))
-            _upsert(conn, "api_football__fixture_statistics", fixture_id, fetch_statistics(fixture_id, sleep=sleep))
-            _upsert(conn, "api_football__fixture_lineups",    fixture_id, fetch_lineups(fixture_id, sleep=sleep))
-            _upsert(conn, "api_football__fixture_players",    fixture_id, fetch_players(fixture_id, sleep=sleep))
+            _upsert(conn, "api_football__fixture_events",      ["fixture_id"], [fixture_id], fetch_events(fixture_id, sleep))
+            _upsert(conn, "api_football__fixture_statistics",  ["fixture_id"], [fixture_id], fetch_statistics(fixture_id, sleep))
+            _upsert(conn, "api_football__fixture_lineups",     ["fixture_id"], [fixture_id], fetch_lineups(fixture_id, sleep))
+            _upsert(conn, "api_football__fixture_players",     ["fixture_id"], [fixture_id], fetch_fixture_players(fixture_id, sleep))
+            _upsert(conn, "api_football__fixture_predictions", ["fixture_id"], [fixture_id], fetch_predictions(fixture_id, sleep))
+            _upsert(conn, "api_football__fixture_odds",        ["fixture_id"], [fixture_id], fetch_odds(fixture_id, sleep))
             log.info("Loaded fixture %d: %s vs %s", fixture_id, home, away)
         except Exception as exc:
             log.warning("Failed fixture %d (%s vs %s): %s", fixture_id, home, away, exc)
@@ -194,6 +453,6 @@ if __name__ == "__main__":
     parser.add_argument("--lookback", type=int, default=2,
                         help="Days to look back for finished fixtures (default: 2)")
     parser.add_argument("--full-load", action="store_true",
-                        help="Load entire current season (ignores --lookback)")
+                        help="Fetch entire season + all reference and per-team data")
     args = parser.parse_args()
     run(lookback_days=args.lookback, full_load=args.full_load)

--- a/ingestion/ingest_superligaen.py
+++ b/ingestion/ingest_superligaen.py
@@ -62,7 +62,7 @@ log = logging.getLogger(__name__)
 
 API_BASE = "https://v3.football.api-sports.io"
 LEAGUE_ID = 119
-CURRENT_SEASON = 2024
+CURRENT_SEASON = 2025
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Expands the bronze layer to cover every endpoint available on the api-football.com free tier.

## 21 Bronze tables

### Season aggregates — fetched on every run (change each matchday)
| Table | Endpoint |
|-------|----------|
| `api_football__standings` | `GET /standings` |
| `api_football__topscorers` | `GET /players/topscorers` |
| `api_football__topassists` | `GET /players/topassists` |
| `api_football__topyellowcards` | `GET /players/topyellowcards` |
| `api_football__topredcards` | `GET /players/topredcards` |
| `api_football__injuries` | `GET /injuries` |

### Reference data — full load only (relatively static)
| Table | Endpoint |
|-------|----------|
| `api_football__leagues` | `GET /leagues` |
| `api_football__teams` | `GET /teams` |
| `api_football__venues` | `GET /venues` |
| `api_football__rounds` | `GET /fixtures/rounds` |
| `api_football__players` | `GET /players` (paginated, season+page PK) |
| `api_football__team_statistics` | `GET /teams/statistics` (season+team_id PK) |
| `api_football__coaches` | `GET /coachs` (team_id PK) |
| `api_football__squads` | `GET /players/squads` (team_id PK) |
| `api_football__transfers` | `GET /transfers` (team_id PK) |
| `api_football__sidelined` | `GET /sidelined` (team_id PK) |
| `api_football__trophies` | `GET /trophies` (team_id PK) |

### Per finished fixture — fetched on every run
| Table | Endpoint |
|-------|----------|
| `api_football__fixtures` | `GET /fixtures` |
| `api_football__fixture_events` | `GET /fixtures/events` |
| `api_football__fixture_statistics` | `GET /fixtures/statistics` |
| `api_football__fixture_lineups` | `GET /fixtures/lineups` |
| `api_football__fixture_players` | `GET /fixtures/players` |
| `api_football__fixture_predictions` | `GET /predictions` |
| `api_football__fixture_odds` | `GET /odds` (free tier: 7-day history) |

## Rate limiting
- `--full-load`: 6.5s sleep per call — respects 10 req/min, requires upgraded plan
- `--lookback N`: no sleep — stays well within 100 req/day free tier

## Test plan
- [ ] Merge and trigger `ingest.yml` with `full_load: true` while on upgraded plan
- [ ] Verify all 21 tables exist in `superligaen_dev.bronze` in MotherDuck

🤖 Generated with [Claude Code](https://claude.com/claude-code)