### PR TITLE
fix: idempotency fixes and team ID extraction

### DIFF
--- a/ingestion/ingest_superligaen.py
+++ b/ingestion/ingest_superligaen.py
@@ -503,8 +503,9 @@ def load_reference_and_team_data(conn, season: int) -> None:
         log.warning("Failed api_football__players season %d: %s", season, exc)
 
     rows = conn.execute(
-        "SELECT DISTINCT json_extract_string(raw_json, '$.team.id')::integer "
-        "FROM bronze.api_football__teams WHERE season = ?",
+        "SELECT DISTINCT json_extract_string(team_row, '$.team.id')::integer "
+        "FROM (SELECT unnest(json_extract(raw_json, '$[*]')) AS team_row "
+        "      FROM bronze.api_football__teams WHERE season = ?) t",
         [season],
     ).fetchall()
     team_ids = [r[0] for r in rows if r[0]]

--- a/ingestion/ingest_superligaen.py
+++ b/ingestion/ingest_superligaen.py
@@ -135,8 +135,8 @@ def fetch_leagues() -> list:
 def fetch_teams(season: int) -> list:
     return api_get("teams", {"league": LEAGUE_ID, "season": season})["response"]
 
-def fetch_venues() -> list:
-    return api_get("venues", {"league": LEAGUE_ID})["response"]
+def fetch_venues(season: int) -> list:
+    return api_get("venues", {"league": LEAGUE_ID, "season": season})["response"]
 
 def fetch_rounds(season: int) -> list:
     return api_get("fixtures/rounds", {"league": LEAGUE_ID, "season": season})["response"]
@@ -486,7 +486,7 @@ def load_reference_and_team_data(conn, season: int) -> None:
     for table, fetcher, key_col, key_val in (
         ("api_football__leagues", fetch_leagues,               "league_id", LEAGUE_ID),
         ("api_football__teams",   lambda: fetch_teams(season), "season",    season),
-        ("api_football__venues",  fetch_venues,                "league_id", LEAGUE_ID),
+        ("api_football__venues",  lambda: fetch_venues(season), "league_id", LEAGUE_ID),
         ("api_football__rounds",  lambda: fetch_rounds(season),"season",    season),
     ):
         try:


### PR DESCRIPTION
## Summary

- Enforce delete-before-insert idempotency across all load modes to prevent duplicate rows on re-runs
- Pass `season` parameter to the venues endpoint (was missing, causing incorrect data)
- Fix team ID extraction from `bronze.api_football__teams`: `raw_json` stores an array of team objects, so the previous `$.team.id` path returned nothing — fix unnests the array first via `json_extract + unnest`, then extracts `.team.id` from each row

## Test plan

- [ ] Run `--full-load --season 2025` and verify per-team data loads (coaches, squads, transfers, etc.)
- [ ] Re-run the same season and confirm no duplicate rows in any bronze table
- [ ] Run incremental (`--lookback 2`) and verify idempotency on repeat runs
- [ ] Check `bronze.api_football__venues` has season-scoped data

🤖 Generated with [Claude Code](https://claude.com/claude-code)