### PR TITLE
feat: add --db flag to target dev or prod database

### DIFF
--- a/ingestion/ingest_superligaen.py
+++ b/ingestion/ingest_superligaen.py
@@ -214,9 +214,10 @@ def fetch_odds(fixture_id: int) -> list:
 # MotherDuck
 # ---------------------------------------------------------------------------
 
-def connect() -> duckdb.DuckDBPyConnection:
+def connect(target_db: str | None = None) -> duckdb.DuckDBPyConnection:
     token = os.environ["MOTHERDUCK_TOKEN"]
-    target_db = os.environ.get("TARGET_DB", "superligaen_dev")
+    if target_db is None:
+        target_db = os.environ.get("TARGET_DB", "superligaen_dev")
     conn = duckdb.connect(f"md:{target_db}?motherduck_token={token}")
     log.info("Connected to MotherDuck: %s", target_db)
     return conn
@@ -538,8 +539,8 @@ def load_reference_and_team_data(conn, season: int) -> None:
 # Main
 # ---------------------------------------------------------------------------
 
-def run(lookback_days: int = 2, full_load: bool = False, season: int | None = None) -> None:
-    conn = connect()
+def run(lookback_days: int = 2, full_load: bool = False, season: int | None = None, target_db: str | None = None) -> None:
+    conn = connect(target_db)
     ensure_schema_and_tables(conn)
 
     if full_load:
@@ -613,5 +614,7 @@ if __name__ == "__main__":
     parser.add_argument("--season", type=int, default=None,
                         help="Season year for --full-load (e.g. 2023). "
                              "Omit to load all seasons %d-%d." % (FIRST_SEASON, CURRENT_SEASON))
+    parser.add_argument("--db", dest="target_db", default=None,
+                        help="Target MotherDuck database (default: $TARGET_DB env var or 'superligaen_dev')")
     args = parser.parse_args()
-    run(lookback_days=args.lookback, full_load=args.full_load, season=args.season)
+    run(lookback_days=args.lookback, full_load=args.full_load, season=args.season, target_db=args.target_db)


### PR DESCRIPTION
## Summary

- Adds a `--db` CLI argument to specify the MotherDuck target database at runtime
- Priority: `--db` flag > `$TARGET_DB` env var > `superligaen_dev` (default)
- No behaviour change when the flag is omitted — existing env var and default still work

## Usage

```bash
# dev (unchanged behaviour)
python ingestion/ingest_superligaen.py --lookback 2

# prod
python ingestion/ingest_superligaen.py --lookback 2 --db superligaen

# full historical load into prod
python ingestion/ingest_superligaen.py --full-load --season 2025 --db superligaen
```

## Test plan

- [ ] Run without `--db` and confirm it connects to `superligaen_dev`
- [ ] Run with `--db superligaen_dev` and confirm same result
- [ ] Run with `--db superligaen` (prod) and confirm correct DB in the log output

🤖 Generated with [Claude Code](https://claude.com/claude-code)