### PR TITLE
fix: include upcoming fixtures in daily incremental load

### DIFF
--- a/ingestion/ingest_fixtures.py
+++ b/ingestion/ingest_fixtures.py
@@ -60,16 +60,24 @@ def load_fixtures(conn, league_id: int, season: int,
             log.warning("Failed fixture %d (%s vs %s): %s", fixture_id, home, away, exc)
 
 
-def delete_fixture_window(conn, league_id: int, from_date: str, to_date: str) -> None:
-    """Delete fixtures and all detail rows within the date window for a league."""
-    fixture_ids = [
-        row[0] for row in conn.execute(
+def delete_fixture_window(conn, league_id: int, from_date: str, to_date: str | None = None) -> None:
+    """Delete fixtures and all detail rows from from_date onwards (or within a window if to_date given)."""
+    if to_date:
+        query = (
             f"SELECT fixture_id FROM bronze.{FIXTURE_TABLE} "
             "WHERE json_extract_string(raw_json, '$.league.id')::integer = ? "
-            "AND json_extract_string(raw_json, '$.fixture.date')::date BETWEEN ?::date AND ?::date",
-            [league_id, from_date, to_date],
-        ).fetchall()
-    ]
+            "AND json_extract_string(raw_json, '$.fixture.date')::date BETWEEN ?::date AND ?::date"
+        )
+        params = [league_id, from_date, to_date]
+    else:
+        query = (
+            f"SELECT fixture_id FROM bronze.{FIXTURE_TABLE} "
+            "WHERE json_extract_string(raw_json, '$.league.id')::integer = ? "
+            "AND json_extract_string(raw_json, '$.fixture.date')::date >= ?::date"
+        )
+        params = [league_id, from_date]
+
+    fixture_ids = [row[0] for row in conn.execute(query, params).fetchall()]
     if fixture_ids:
         placeholders = ", ".join("?" * len(fixture_ids))
         for table in [FIXTURE_TABLE] + FIXTURE_DETAIL_TABLES:

--- a/ingestion/run.py
+++ b/ingestion/run.py
@@ -85,8 +85,7 @@ def run(
 
     else:
         from_date = (date.today() - timedelta(days=lookback_days)).isoformat()
-        to_date   = date.today().isoformat()
-        log.info("Incremental load — window: %s to %s", from_date, to_date)
+        log.info("Incremental load — from: %s (no end date — includes upcoming fixtures)", from_date)
 
         for league in leagues:
             lid = league["id"]
@@ -101,9 +100,9 @@ def run(
             # Group 2 — season data (full refresh of current season)
             load_season(conn, lid, current_season, incremental=True)
 
-            # Group 3 — fixtures in date window only
-            delete_fixture_window(conn, lid, from_date, to_date)
-            load_fixtures(conn, lid, current_season, from_date=from_date, to_date=to_date)
+            # Group 3 — fixtures from lookback date onwards (includes upcoming)
+            delete_fixture_window(conn, lid, from_date)
+            load_fixtures(conn, lid, current_season, from_date=from_date)
 
             # Group 4 — per-team data (current season)
             load_teams(conn, lid, current_season)


### PR DESCRIPTION
## Summary

- Daily incremental was capping fixture fetches at `today`, so upcoming matches were never ingested unless a full load had been run
- Removed the `to_date` upper bound — incremental now fetches all fixtures from `(today - lookback)` onwards, including future scheduled matches
- `delete_fixture_window` updated to match: deletes from `from_date` onwards when no `to_date` is given

## Test plan

- [ ] Run `python ingestion/run.py --lookback 2` and confirm upcoming fixtures appear in `bronze.api_football__fixtures`
- [ ] Re-run and confirm idempotency — same fixtures replaced cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)