### PR TITLE
feat: add master pipeline workflow (bronze → silver)

### DIFF
--- a/.github/workflows/ingest.yml
+++ b/.github/workflows/ingest.yml
@@ -1,8 +1,6 @@
 name: Daily ingestion
 
 on:
-  schedule:
-    - cron: "0 23 * * *"  # 23:00 UTC = midnight Danish time (CET) — after matches finish
   workflow_dispatch:
     inputs:
       full_load:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -1,0 +1,103 @@
+name: Nightly pipeline
+
+on:
+  schedule:
+    - cron: "0 23 * * *"  # 23:00 UTC = midnight Danish time (CET) — after matches finish
+  workflow_dispatch:
+    inputs:
+      full_load:
+        description: "Set to 'true' to run a full historical load"
+        required: false
+        default: "false"
+      league:
+        description: "League ID (e.g. 119). Leave empty to load all leagues."
+        required: false
+        default: ""
+      season:
+        description: "Season year for full load (e.g. 2025). Leave empty to load all seasons."
+        required: false
+        default: ""
+      lookback:
+        description: "Days to look back for incremental runs (default: 2)"
+        required: false
+        default: "2"
+      target_db:
+        description: "Target MotherDuck database (e.g. superligaen). Leave empty to use default (superligaen)."
+        required: false
+        default: ""
+
+jobs:
+  # ---------------------------------------------------------------------------
+  # Bronze — ingest raw API data
+  # ---------------------------------------------------------------------------
+  ingest:
+    name: Bronze ingestion
+    runs-on: ubuntu-latest
+    timeout-minutes: 360  # 6h max — covers one full season load
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Run ingestion (incremental)
+        if: ${{ github.event.inputs.full_load != 'true' }}
+        env:
+          MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
+          API_FOOTBALL_KEY: ${{ secrets.API_FOOTBALL_KEY }}
+          TARGET_DB: ${{ github.event.inputs.target_db || 'superligaen' }}
+        run: python ingestion/run.py --lookback ${{ github.event.inputs.lookback || '2' }}
+
+      - name: Run ingestion (full load)
+        if: ${{ github.event.inputs.full_load == 'true' }}
+        env:
+          MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
+          API_FOOTBALL_KEY: ${{ secrets.API_FOOTBALL_KEY }}
+          TARGET_DB: ${{ github.event.inputs.target_db || 'superligaen' }}
+        run: |
+          ARGS="--full-load"
+          [ -n "${{ github.event.inputs.league }}" ] && ARGS="$ARGS --league ${{ github.event.inputs.league }}"
+          [ -n "${{ github.event.inputs.season }}" ] && ARGS="$ARGS --season ${{ github.event.inputs.season }}"
+          python ingestion/run.py $ARGS
+
+  # ---------------------------------------------------------------------------
+  # Silver — transform bronze JSON into structured tables
+  # ---------------------------------------------------------------------------
+  transform:
+    name: Silver transformation
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    needs: ingest  # only runs if ingest succeeds
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Run silver transformation (incremental)
+        if: ${{ github.event.inputs.full_load != 'true' }}
+        env:
+          MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
+          TARGET_DB: ${{ github.event.inputs.target_db || 'superligaen' }}
+        run: python transformations/run_silver.py --lookback ${{ github.event.inputs.lookback || '2' }}
+
+      - name: Run silver transformation (full / seasonal load)
+        if: ${{ github.event.inputs.full_load == 'true' }}
+        env:
+          MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
+          TARGET_DB: ${{ github.event.inputs.target_db || 'superligaen' }}
+        run: |
+          ARGS="--full-load"
+          [ -n "${{ github.event.inputs.league }}" ] && ARGS="$ARGS --league ${{ github.event.inputs.league }}"
+          [ -n "${{ github.event.inputs.season }}" ] && ARGS="$ARGS --season ${{ github.event.inputs.season }}"
+          python transformations/run_silver.py $ARGS


### PR DESCRIPTION
## Summary

- Adds `master.yml` — the nightly cron workflow that runs bronze ingestion then silver transformation sequentially
- Removes the `schedule` trigger from `ingest.yml` so the cron lives in one place only
- `ingest.yml` and `transform.yml` keep `workflow_dispatch` for running individual layers manually

## Pipeline structure

```
master.yml (cron + manual)
  └── ingest   (Bronze ingestion)
  └── transform (Silver transformation, needs: ingest)
  └── [gold]   (future, needs: transform)
```

Silver only runs if bronze succeeds (`needs: ingest`), so a failed fetch won't overwrite good silver data.

## Test plan

- [ ] Trigger `master.yml` via workflow_dispatch against `superligaen_dev` to verify both jobs run in sequence
- [ ] Confirm `ingest.yml` no longer appears in scheduled runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)