### PR TITLE
fix: pin duckdb to 1.5.1 for MotherDuck compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-duckdb>=0.10.0
+duckdb==1.5.1
 dbt-duckdb>=1.7.0
 requests>=2.31.0
 python-dotenv>=1.0.0


### PR DESCRIPTION
## Summary
- Pins `duckdb` to `==1.5.1` in `requirements.txt`
- MotherDuck does not yet support DuckDB v1.5.2, causing the silver transformation job to fail in CI

## Test plan
- [ ] Merge and re-run the master pipeline workflow in GitHub Actions
- [ ] Confirm silver transformation completes without the `motherduck_duckdb_cpp_init` error

🤖 Generated with [Claude Code](https://claude.com/claude-code)