### PR TITLE
fix: cap incremental fixture lookahead to 4 weeks

### DIFF
--- a/ingestion/run.py
+++ b/ingestion/run.py
@@ -85,7 +85,7 @@ def run(
 
     else:
         from_date = (date.today() - timedelta(days=lookback_days)).isoformat()
-        log.info("Incremental load — from: %s (to end of season)", from_date)
+        log.info("Incremental load — from: %s (to 4 weeks ahead)", from_date)
 
         for league in leagues:
             lid = league["id"]
@@ -100,9 +100,8 @@ def run(
             # Group 2 — season data (full refresh of current season)
             load_season(conn, lid, current_season, incremental=True)
 
-            # Group 3 — fixtures from lookback date onwards (includes upcoming)
-            # API requires both `from` and `to`; use end of season as upper bound
-            to_date = f"{current_season + 1}-07-31"
+            # Group 3 — fixtures from lookback date to 4 weeks ahead
+            to_date = (date.today() + timedelta(weeks=4)).isoformat()
             delete_fixture_window(conn, lid, from_date)
             load_fixtures(conn, lid, current_season, from_date=from_date, to_date=to_date)
 


### PR DESCRIPTION
## Summary
- Changes `to_date` in the incremental load from end-of-season to today + 4 weeks
- Prevents fetching the entire remaining season's fixtures on each daily run, which was burning through the free tier API quota (~100 req/day)

## Test plan
- [ ] Merge and re-run the master pipeline workflow
- [ ] Confirm fixture call count is significantly reduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)