### PR TITLE
fix: extend silver fixture window to 4 weeks ahead

### DIFF
--- a/transformations/run_silver.py
+++ b/transformations/run_silver.py
@@ -177,9 +177,9 @@ def run(
         lid        = league_id or _default_league(conn, db)
         cur_season = _current_season(conn, db, lid)
         from_date  = (date.today() - timedelta(days=lookback_days)).isoformat()
-        to_date    = date.today().isoformat()
+        to_date    = (date.today() + timedelta(weeks=4)).isoformat()
         season_scope  = f"league_id = {lid} AND season = {cur_season}"
-        fixture_scope = f"kick_off >= '{from_date}' AND kick_off < '{to_date}'"
+        fixture_scope = f"kick_off >= '{from_date}' AND kick_off <= '{to_date}'"
         log.info(
             "=== Incremental silver load — %s.silver  league=%d  season=%d  from=%s ===",
             db, lid, cur_season, from_date,


### PR DESCRIPTION
## Summary
- Silver incremental run was using `to_date = today`, cutting off all upcoming fixtures
- Bronze ingests up to 4 weeks ahead — silver now matches with `to_date = today + 4 weeks`

## Test plan
- [ ] Merge and re-run the master pipeline workflow
- [ ] Confirm upcoming fixtures appear in `silver.fixtures`

🤖 Generated with [Claude Code](https://claude.com/claude-code)