### PR TITLE
fix: remove silver full load from deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,9 +7,9 @@ on:
 
 jobs:
   deploy:
-    name: Silver + Gold full load (prod)
+    name: Gold full load (prod)
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 30
 
     steps:
       - name: Checkout
@@ -22,12 +22,6 @@ jobs:
 
       - name: Install dependencies
         run: pip install -r requirements.txt
-
-      - name: Run silver (full load)
-        env:
-          MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
-          TARGET_DB: superligaen
-        run: python transformations/run_silver.py --full-load
 
       - name: Run gold (full load)
         env:


### PR DESCRIPTION
## Summary
- Remove silver full load from `deploy.yml` — was causing OOM on MotherDuck Pulse tier
- Deploy now only runs gold full load (lightweight, just rebuilds dims + fact from existing silver)
- Silver changes are handled by the nightly pipeline (`master.yml`)

## Test plan
- [ ] Deploy workflow completes without OOM error on next merge to main