### PR TITLE
fix: update match_results source to use dim_opponent_team

### DIFF
--- a/dashboards/sources/superligaen/match_results.sql
+++ b/dashboards/sources/superligaen/match_results.sql
@@ -3,7 +3,7 @@ select
     m.match_round_name           as round,
     m.season,
     t.team_name,
-    ot.team_name                 as opponent,
+    ot.opponent_team_name        as opponent,
     ts.team_side                 as side,
     f.goals_scored               as gf,
     f.goals_conceded             as ga,
@@ -12,7 +12,7 @@ select
     st.stadium_name              as stadium
 from gold.fct_match_results f
 join gold.dim_team          t   on t.team_sk            = f.team_sk
-join gold.dim_team          ot  on ot.team_sk           = f.opponent_sk
+join gold.dim_opponent_team ot  on ot.opponent_team_sk   = f.opponent_team_sk
 join gold.dim_date          d   on d.date_sk            = f.date_sk
 join gold.dim_match         m   on m.match_sk           = f.match_sk
 join gold.dim_match_result  r   on r.match_result_sk    = f.match_result_sk


### PR DESCRIPTION
## Summary

- Updates `dashboards/sources/superligaen/match_results.sql` to join `gold.dim_opponent_team` on `opponent_team_sk` instead of the temporary `dim_team` alias workaround
- Required after prod `fct_match_results` was rebuilt with the `opponent_team_sk` column rename

## Test plan

- [ ] Run `npm run dev` in `dashboards/` and verify the Match Results page loads opponent names correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)