### PR TITLE
fix: resolve data quality issues #29 #30 #31 #32

### DIFF
--- a/transformations/gold/dim_match.sql
+++ b/transformations/gold/dim_match.sql
@@ -1,43 +1,86 @@
 -- Dimension: match
 -- One row per fixture. Captures round, season, and current match status.
 -- SK is stable: new matches get the next available SK; existing matches keep theirs.
--- match_status is updated on every run as fixtures progress (e.g. NS -> FT).
+-- match_status, match_result, and match_short_name are updated on every run.
 CREATE SCHEMA IF NOT EXISTS {db}.gold;
 
 CREATE TABLE IF NOT EXISTS {db}.gold.dim_match (
-    match_sk          INTEGER NOT NULL,
-    match_id          INTEGER,
-    season            INTEGER,
-    match_round_name  VARCHAR,
+    match_sk           INTEGER NOT NULL,
+    match_id           INTEGER,
+    season             INTEGER,
+    match_round_name   VARCHAR,
     match_round_number INTEGER,
-    match_status      VARCHAR
+    match_round_type   VARCHAR,
+    match_status       VARCHAR,
+    match_name         VARCHAR,
+    match_short_name   VARCHAR,
+    match_result       VARCHAR
 );
+
+-- Add new columns to existing tables (idempotent)
+ALTER TABLE {db}.gold.dim_match ADD COLUMN IF NOT EXISTS match_round_type  VARCHAR;
+ALTER TABLE {db}.gold.dim_match ADD COLUMN IF NOT EXISTS match_name        VARCHAR;
+ALTER TABLE {db}.gold.dim_match ADD COLUMN IF NOT EXISTS match_short_name  VARCHAR;
+ALTER TABLE {db}.gold.dim_match ADD COLUMN IF NOT EXISTS match_result      VARCHAR;
 
 -- Sentinels (idempotent)
 INSERT INTO {db}.gold.dim_match
 SELECT * FROM (VALUES
-    (-1, NULL::INTEGER, NULL::INTEGER, 'Unknown Match',        NULL::INTEGER, 'Unknown Match'),
-    (-2, NULL::INTEGER, NULL::INTEGER, 'Not Applicable Match', NULL::INTEGER, 'Not Applicable Match')
-) t(match_sk, match_id, season, round_name, round_number, match_status)
+    (-1, NULL::INTEGER, NULL::INTEGER, 'Unknown Match',        NULL::INTEGER, 'Unknown',       'Unknown Match',        'Unknown Match',        'Unknown',        NULL::VARCHAR),
+    (-2, NULL::INTEGER, NULL::INTEGER, 'Not Applicable Match', NULL::INTEGER, 'Not Applicable','Not Applicable Match', 'Not Applicable Match', 'Not Applicable', NULL::VARCHAR)
+) t(match_sk, match_id, season, round_name, round_number, round_type, match_status, match_name, match_short_name, match_result)
 WHERE t.match_sk NOT IN (SELECT match_sk FROM {db}.gold.dim_match);
 
 -- Insert new matches not yet in the dim
 INSERT INTO {db}.gold.dim_match
 SELECT
     (SELECT COALESCE(MAX(match_sk), 0) FROM {db}.gold.dim_match WHERE match_sk > 0)
-        + ROW_NUMBER() OVER (ORDER BY src.fixture_id) AS match_sk,
-    src.fixture_id                                     AS match_id,
+        + ROW_NUMBER() OVER (ORDER BY src.fixture_id)          AS match_sk,
+    src.fixture_id                                              AS match_id,
     src.season,
-    src.league_round                                   AS match_round_name,
+    src.league_round                                            AS match_round_name,
     TRY_CAST(regexp_extract(src.league_round, '(\d+)$', 1) AS INTEGER) AS match_round_number,
-    src.status_short                                   AS match_status
+    SPLIT_PART(src.league_round, ' - ', 1)                     AS match_round_type,
+    src.status_long                                             AS match_status,
+    src.home_team_name || ' - ' || src.away_team_name           AS match_name,
+    COALESCE(ht.team_code, src.home_team_name) || ' - ' || COALESCE(at.team_code, src.away_team_name) AS match_short_name,
+    CASE
+        WHEN src.status_short IN ('FT', 'AET', 'PEN')
+        THEN src.goals_home::VARCHAR || ' - ' || src.goals_away::VARCHAR
+    END                                                         AS match_result
 FROM {db}.silver.fixtures src
+LEFT JOIN (
+    SELECT DISTINCT ON (team_id) team_id, team_code
+    FROM {db}.silver.teams
+    ORDER BY team_id, season DESC
+) ht ON ht.team_id = src.home_team_id
+LEFT JOIN (
+    SELECT DISTINCT ON (team_id) team_id, team_code
+    FROM {db}.silver.teams
+    ORDER BY team_id, season DESC
+) at ON at.team_id = src.away_team_id
 WHERE src.fixture_id NOT IN (
     SELECT match_id FROM {db}.gold.dim_match WHERE match_id IS NOT NULL
 );
 
--- Update match_status for existing matches (changes as fixtures are played)
+-- Update mutable fields for existing matches
 UPDATE {db}.gold.dim_match tgt
-SET match_status = src.status_short
+SET
+    match_status     = src.status_long,
+    match_short_name = COALESCE(ht.team_code, src.home_team_name) || ' - ' || COALESCE(at.team_code, src.away_team_name),
+    match_result     = CASE
+                           WHEN src.status_short IN ('FT', 'AET', 'PEN')
+                           THEN src.goals_home::VARCHAR || ' - ' || src.goals_away::VARCHAR
+                       END
 FROM {db}.silver.fixtures src
+LEFT JOIN (
+    SELECT DISTINCT ON (team_id) team_id, team_code
+    FROM {db}.silver.teams
+    ORDER BY team_id, season DESC
+) ht ON ht.team_id = src.home_team_id
+LEFT JOIN (
+    SELECT DISTINCT ON (team_id) team_id, team_code
+    FROM {db}.silver.teams
+    ORDER BY team_id, season DESC
+) at ON at.team_id = src.away_team_id
 WHERE tgt.match_id = src.fixture_id;

--- a/transformations/silver/fixture_statistics.sql
+++ b/transformations/silver/fixture_statistics.sql
@@ -56,7 +56,7 @@ SELECT * FROM (
         MAX(CASE WHEN stat->>'$.type' = 'Offsides'          THEN TRY_CAST(stat->>'$.value' AS INTEGER)                        END) AS offsides,
         MAX(CASE WHEN stat->>'$.type' = 'Ball Possession'   THEN TRY_CAST(REPLACE(stat->>'$.value', '%', '') AS DECIMAL(5,2)) END) AS ball_possession_pct,
         MAX(CASE WHEN stat->>'$.type' = 'Yellow Cards'      THEN TRY_CAST(stat->>'$.value' AS INTEGER)                        END) AS yellow_cards,
-        MAX(CASE WHEN stat->>'$.type' = 'Red Cards'         THEN TRY_CAST(stat->>'$.value' AS INTEGER)                        END) AS red_cards,
+        COALESCE(MAX(CASE WHEN stat->>'$.type' = 'Red Cards' THEN TRY_CAST(stat->>'$.value' AS INTEGER)                        END), 0) AS red_cards,
         MAX(CASE WHEN stat->>'$.type' = 'Goalkeeper Saves'  THEN TRY_CAST(stat->>'$.value' AS INTEGER)                        END) AS goalkeeper_saves,
         MAX(CASE WHEN stat->>'$.type' = 'Total passes'      THEN TRY_CAST(stat->>'$.value' AS INTEGER)                        END) AS total_passes,
         MAX(CASE WHEN stat->>'$.type' = 'Passes accurate'   THEN TRY_CAST(stat->>'$.value' AS INTEGER)                        END) AS passes_accurate,

--- a/transformations/silver/fixtures.sql
+++ b/transformations/silver/fixtures.sql
@@ -52,16 +52,51 @@ CREATE TABLE IF NOT EXISTS {db}.silver.fixtures (
 DELETE FROM {db}.silver.fixtures WHERE {delete_filter};
 
 INSERT INTO {db}.silver.fixtures
+WITH venue_lookup AS (
+    -- Build a name -> id map from bronze venues to backfill nulls in fixture API responses
+    SELECT
+        (elem->>'$.name')::VARCHAR    AS venue_name,
+        MIN((elem->>'$.id')::INTEGER) AS venue_id
+    FROM {db}.bronze.api_football__venues v,
+    UNNEST(v.raw_json::JSON[]) AS t(elem)
+    WHERE elem->>'$.id' IS NOT NULL
+    GROUP BY (elem->>'$.name')::VARCHAR
+)
 SELECT * FROM (
     SELECT
         (raw_json->>'$.fixture.id')::INTEGER          AS fixture_id,
-        raw_json->>'$.fixture.referee'                AS referee,
+        CASE TRIM(SPLIT_PART(raw_json->>'$.fixture.referee', ',', 1))
+            WHEN 'A. Uslu'                THEN 'Aydin Uslu'
+            WHEN 'C. Theouli'             THEN 'Chrysovalantis Theouli'
+            WHEN 'F. Svendsen'            THEN 'Frederik Svendsen'
+            WHEN 'J. A. Sundberg'         THEN 'Jacob A. Sundberg'
+            WHEN 'J. Sundberg'            THEN 'Jacob A. Sundberg'
+            WHEN 'J. Burchardt'           THEN 'Jorgen Daugbjerg Burchardt'
+            WHEN 'J. Hansen'              THEN 'Jonas Hansen'
+            WHEN 'J. Karlsen'             THEN 'Jacob Karlsen'
+            WHEN 'J. Kehlet'              THEN 'Jakob Kehlet'
+            WHEN 'J. Maae'                THEN 'Jens Maae'
+            WHEN 'K. Athanasiou'          THEN 'Kyriakos Athanasiou'
+            WHEN 'L. Graagaard'           THEN 'Lasse Laebel Graagaard'
+            WHEN 'M. Antoniou'            THEN 'Menelaos Antoniou'
+            WHEN 'M. Kristoffersen'       THEN 'Mads Kristoffer Kristoffersen'
+            WHEN 'M. Krogh'               THEN 'Morten Krogh'
+            WHEN 'M. Redder'              THEN 'Mikkel Redder'
+            WHEN 'M. Tykgaard'            THEN 'Michael Tykgaard'
+            WHEN 'P. Kjærsgaard-Andersen' THEN 'Peter Kjaersgaard-Andersen'
+            WHEN 'S. Putros'              THEN 'Sandi Putros'
+            WHEN 'S. Rasmussen'           THEN 'Simon Duerland Rasmussen'
+            ELSE TRIM(SPLIT_PART(raw_json->>'$.fixture.referee', ',', 1))
+        END                                           AS referee,
         raw_json->>'$.fixture.timezone'               AS timezone,
         (raw_json->>'$.fixture.date')::TIMESTAMPTZ    AS kick_off,
         (raw_json->>'$.fixture.timestamp')::BIGINT    AS kick_off_ts,
         (raw_json->>'$.fixture.periods.first')::INTEGER  AS period_first,
         (raw_json->>'$.fixture.periods.second')::INTEGER AS period_second,
-        (raw_json->>'$.fixture.venue.id')::INTEGER    AS venue_id,
+        COALESCE(
+            (raw_json->>'$.fixture.venue.id')::INTEGER,
+            vl.venue_id
+        )                                             AS venue_id,
         raw_json->>'$.fixture.venue.name'             AS venue_name,
         raw_json->>'$.fixture.venue.city'             AS venue_city,
         raw_json->>'$.fixture.status.long'            AS status_long,
@@ -96,4 +131,5 @@ SELECT * FROM (
         (raw_json->>'$.score.penalty.away')::INTEGER   AS score_pen_away,
         ingested_at
     FROM {db}.bronze.api_football__fixtures
+    LEFT JOIN venue_lookup vl ON vl.venue_name = (raw_json->>'$.fixture.venue.name')::VARCHAR
 ) _src WHERE {insert_filter};


### PR DESCRIPTION
## Summary

- **#29 Clean Referee Data**: Strip `, Country` suffix and expand abbreviated names (e.g. `A. Uslu` → `Aydin Uslu`, `J. Sundberg` → `Jacob A. Sundberg`) in `silver.fixtures` via a CASE mapping
- **#30 dim_match user-friendly fields**: Added `match_name` (`Home - Away`), `match_short_name` (team codes), `match_result` (final score), `match_round_type` (derived from round prefix); `match_status` now stores human-readable `status_long` instead of the code
- **#31 Red cards null**: Wrapped extraction in `COALESCE(..., 0)` — API omits the field when there are no red cards, which should be 0 not NULL
- **#32 venue_id nulls**: Added a `venue_lookup` CTE in `silver/fixtures.sql` that joins `bronze.api_football__venues` to backfill missing venue IDs by name match — keeps silver tables independent (no cross-silver dependency)

## Test plan

- [ ] Run silver full reload and confirm `silver.fixtures.referee` has no more abbreviated or `, Country` forms
- [ ] Confirm `silver.fixtures.venue_id` null count drops from 40 → ~15 (Parken and Vejlby Stadion cases resolved; alternate name spellings remain null)
- [ ] Confirm `silver.fixture_statistics.red_cards` has no more nulls
- [ ] Run gold dim_match and confirm new columns populated: `match_name`, `match_short_name`, `match_result`, `match_round_type`, and `match_status` shows "Match Finished" etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)