### PR TITLE
fix: rename reserved keyword alias 'at' to 'awt' in dim_match.sql

### DIFF
--- a/transformations/gold/dim_match.sql
+++ b/transformations/gold/dim_match.sql
@@ -43,7 +43,7 @@ SELECT
     SPLIT_PART(src.league_round, ' - ', 1)                     AS match_round_type,
     src.status_long                                             AS match_status,
     src.home_team_name || ' - ' || src.away_team_name           AS match_name,
-    COALESCE(ht.team_code, src.home_team_name) || ' - ' || COALESCE(at.team_code, src.away_team_name) AS match_short_name,
+    COALESCE(ht.team_code, src.home_team_name) || ' - ' || COALESCE(awt.team_code, src.away_team_name) AS match_short_name,
     CASE
         WHEN src.status_short IN ('FT', 'AET', 'PEN')
         THEN src.goals_home::VARCHAR || ' - ' || src.goals_away::VARCHAR
@@ -58,7 +58,7 @@ LEFT JOIN (
     SELECT DISTINCT ON (team_id) team_id, team_code
     FROM {db}.silver.teams
     ORDER BY team_id, season DESC
-) at ON at.team_id = src.away_team_id
+) awt ON awt.team_id = src.away_team_id
 WHERE src.fixture_id NOT IN (
     SELECT match_id FROM {db}.gold.dim_match WHERE match_id IS NOT NULL
 );
@@ -67,7 +67,7 @@ WHERE src.fixture_id NOT IN (
 UPDATE {db}.gold.dim_match tgt
 SET
     match_status     = src.status_long,
-    match_short_name = COALESCE(ht.team_code, src.home_team_name) || ' - ' || COALESCE(at.team_code, src.away_team_name),
+    match_short_name = COALESCE(ht.team_code, src.home_team_name) || ' - ' || COALESCE(awt.team_code, src.away_team_name),
     match_result     = CASE
                            WHEN src.status_short IN ('FT', 'AET', 'PEN')
                            THEN src.goals_home::VARCHAR || ' - ' || src.goals_away::VARCHAR
@@ -82,5 +82,5 @@ LEFT JOIN (
     SELECT DISTINCT ON (team_id) team_id, team_code
     FROM {db}.silver.teams
     ORDER BY team_id, season DESC
-) at ON at.team_id = src.away_team_id
+) awt ON awt.team_id = src.away_team_id
 WHERE tgt.match_id = src.fixture_id;


### PR DESCRIPTION
## Summary

- `at` is a reserved keyword in DuckDB — using it as a subquery alias causes a `ParserException` at deploy time
- Renamed the away team alias from `at` to `awt` in both the INSERT and UPDATE blocks of `dim_match.sql`

## Root cause

The original dim_match.sql introduced in #33 used `at` as the alias for the away team subquery. DuckDB reserves `at` for `TIMESTAMP AT TIME ZONE` syntax, so the parser rejects it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)