### PR TITLE
feat: redesign dashboard as app hub with KPI ribbon and navigation cards

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -134,3 +134,15 @@ jobs:
           MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
           TARGET_DB: ${{ github.event.inputs.target_db || 'superligaen' }}
         run: python transformations/run_gold.py --full-load
+
+  # ---------------------------------------------------------------------------
+  # Dashboard — trigger Netlify rebuild after gold is fresh
+  # ---------------------------------------------------------------------------
+  publish:
+    name: Publish dashboard (Netlify)
+    runs-on: ubuntu-latest
+    needs: gold
+
+    steps:
+      - name: Trigger Netlify deploy hook
+        run: curl -s -X POST "${{ secrets.NETLIFY_DEPLOY_HOOK }}"

--- a/dashboards/pages/index.md
+++ b/dashboards/pages/index.md
@@ -1,106 +1,50 @@
 ---
-title: Superligaen Dashboard
+title: Superligaen
 ---
 
-```sql seasons
-select distinct season from superligaen.team_season_stats
-order by season desc
+```sql league
+select * from superligaen.league_info
 ```
 
-<Dropdown data={seasons} name=season value=season label=season>
-    <DropdownOption value=2025 valueLabel="2025"/>
-</Dropdown>
-
-```sql standings
-select
-    team_name   as team,
-    gp, w, d, l, gf, ga, gd, pts,
-    round_group
-from superligaen.team_season_stats
-where season = ${inputs.season.value}
-order by round_group, pts desc, gd desc, gf desc
+```sql kpis
+select * from superligaen.kpis
 ```
 
-```sql championship
-select team, gp, w, d, l, gf, ga, gd, pts
-from ${standings}
-where round_group = 'Championship Group'
+```sql leader
+select * from superligaen.current_leader
 ```
 
-```sql relegation
-select team, gp, w, d, l, gf, ga, gd, pts
-from ${standings}
-where round_group = 'Relegation Group'
-```
+<div class="flex items-center justify-center gap-6 my-8 flex-wrap">
+  <img src="{league[0].league_country_flag}" alt="Denmark" class="h-8 rounded shadow-md" />
+  <img src="{league[0].league_logo}" alt="Superligaen" class="h-16" />
+  <div class="text-center">
+    <div class="text-4xl font-extrabold tracking-tight">Superligaen</div>
+    <div class="text-gray-400 text-sm mt-1">Danish Football Premier League &middot; {kpis[0].season} Season</div>
+  </div>
+  <img src="{league[0].league_country_flag}" alt="Denmark" class="h-8 rounded shadow-md" />
+</div>
 
-```sql regular
-select team_name as team, gp, w, d, l, gf, ga, gd, pts
-from superligaen.team_regular_season_stats
-where season = ${inputs.season.value}
-```
+<div class="grid grid-cols-2 md:grid-cols-4 gap-4 mb-8">
+  <BigValue data={kpis}   value=total_goals        title="Goals Scored"      />
+  <BigValue data={leader} value=team_name           title="Current Leader"    />
+  <BigValue data={kpis}   value=total_red_cards     title="Red Cards"         />
+  <BigValue data={kpis}   value=avg_shots_per_match title="Avg Shots / Match" />
+</div>
 
-## {inputs.season.value} Season Standings
+---
 
-{#if championship.length > 0}
+<div class="grid grid-cols-1 md:grid-cols-2 gap-4 mt-6">
 
-### Championship Group
+<a href="/standings" class="block no-underline rounded-xl border border-gray-700 bg-gray-900 p-6 hover:border-blue-500 hover:shadow-lg hover:bg-gray-800 transition-all duration-200 group">
+  <div class="text-4xl">🏆</div>
+  <div class="text-lg font-bold mt-3 mb-1 group-hover:text-blue-400 transition-colors">Standings</div>
+  <div class="text-gray-400 text-sm">Championship, Relegation &amp; Regular Season tables</div>
+</a>
 
-<DataTable data={championship} rows=20>
-    <Column id=team/>
-    <Column id=gp  title="GP"/>
-    <Column id=w   title="W"/>
-    <Column id=d   title="D"/>
-    <Column id=l   title="L"/>
-    <Column id=gf  title="GF"/>
-    <Column id=ga  title="GA"/>
-    <Column id=gd  title="GD"/>
-    <Column id=pts title="Pts" contentType=colorscale colorScale=positive/>
-</DataTable>
+<a href="/match-results" class="block no-underline rounded-xl border border-gray-700 bg-gray-900 p-6 hover:border-blue-500 hover:shadow-lg hover:bg-gray-800 transition-all duration-200 group">
+  <div class="text-4xl">⚽</div>
+  <div class="text-lg font-bold mt-3 mb-1 group-hover:text-blue-400 transition-colors">Match Results</div>
+  <div class="text-gray-400 text-sm">Full match history, results and scorelines by team</div>
+</a>
 
-{/if}
-
-{#if relegation.length > 0}
-
-### Relegation Group
-
-<DataTable data={relegation} rows=20>
-    <Column id=team/>
-    <Column id=gp  title="GP"/>
-    <Column id=w   title="W"/>
-    <Column id=d   title="D"/>
-    <Column id=l   title="L"/>
-    <Column id=gf  title="GF"/>
-    <Column id=ga  title="GA"/>
-    <Column id=gd  title="GD"/>
-    <Column id=pts title="Pts" contentType=colorscale colorScale=positive/>
-</DataTable>
-
-{/if}
-
-{#if regular.length > 0}
-
-### Regular Season
-
-<DataTable data={regular} rows=20>
-    <Column id=team/>
-    <Column id=gp  title="GP"/>
-    <Column id=w   title="W"/>
-    <Column id=d   title="D"/>
-    <Column id=l   title="L"/>
-    <Column id=gf  title="GF"/>
-    <Column id=ga  title="GA"/>
-    <Column id=gd  title="GD"/>
-    <Column id=pts title="Pts" contentType=colorscale colorScale=positive/>
-</DataTable>
-
-{/if}
-
-<BarChart
-    data={standings}
-    x=team
-    y=pts
-    title="Points — {inputs.season.value}"
-    yAxisTitle="Points"
-    xAxisTitle="Team"
-    sort=false
-/>
+</div>

--- a/dashboards/pages/match-results.md
+++ b/dashboards/pages/match-results.md
@@ -2,6 +2,8 @@
 title: Match Results
 ---
 
+<a href="/" class="inline-flex items-center gap-1 text-sm text-gray-400 hover:text-white no-underline mb-6 transition-colors">← Back to Home</a>
+
 ```sql seasons
 select distinct season from superligaen.match_results
 order by season desc

--- a/dashboards/pages/standings.md
+++ b/dashboards/pages/standings.md
@@ -1,0 +1,108 @@
+---
+title: Standings
+---
+
+<a href="/" class="inline-flex items-center gap-1 text-sm text-gray-400 hover:text-white no-underline mb-6 transition-colors">← Back to Home</a>
+
+```sql seasons
+select distinct season from superligaen.team_season_stats
+order by season desc
+```
+
+<Dropdown data={seasons} name=season value=season label=season>
+    <DropdownOption value=2025 valueLabel="2025"/>
+</Dropdown>
+
+```sql standings
+select
+    team_name   as team,
+    gp, w, d, l, gf, ga, gd, pts,
+    round_group
+from superligaen.team_season_stats
+where season = ${inputs.season.value}
+order by round_group, pts desc, gd desc, gf desc
+```
+
+```sql championship
+select team, gp, w, d, l, gf, ga, gd, pts
+from ${standings}
+where round_group = 'Championship Group'
+```
+
+```sql relegation
+select team, gp, w, d, l, gf, ga, gd, pts
+from ${standings}
+where round_group = 'Relegation Group'
+```
+
+```sql regular
+select team_name as team, gp, w, d, l, gf, ga, gd, pts
+from superligaen.team_regular_season_stats
+where season = ${inputs.season.value}
+```
+
+## {inputs.season.value} Season Standings
+
+{#if championship.length > 0}
+
+### Championship Group
+
+<DataTable data={championship} rows=20>
+    <Column id=team/>
+    <Column id=gp  title="GP"/>
+    <Column id=w   title="W"/>
+    <Column id=d   title="D"/>
+    <Column id=l   title="L"/>
+    <Column id=gf  title="GF"/>
+    <Column id=ga  title="GA"/>
+    <Column id=gd  title="GD"/>
+    <Column id=pts title="Pts" contentType=colorscale colorScale=positive/>
+</DataTable>
+
+{/if}
+
+{#if relegation.length > 0}
+
+### Relegation Group
+
+<DataTable data={relegation} rows=20>
+    <Column id=team/>
+    <Column id=gp  title="GP"/>
+    <Column id=w   title="W"/>
+    <Column id=d   title="D"/>
+    <Column id=l   title="L"/>
+    <Column id=gf  title="GF"/>
+    <Column id=ga  title="GA"/>
+    <Column id=gd  title="GD"/>
+    <Column id=pts title="Pts" contentType=colorscale colorScale=positive/>
+</DataTable>
+
+{/if}
+
+{#if regular.length > 0}
+
+### Regular Season
+
+<DataTable data={regular} rows=20>
+    <Column id=team/>
+    <Column id=gp  title="GP"/>
+    <Column id=w   title="W"/>
+    <Column id=d   title="D"/>
+    <Column id=l   title="L"/>
+    <Column id=gf  title="GF"/>
+    <Column id=ga  title="GA"/>
+    <Column id=gd  title="GD"/>
+    <Column id=pts title="Pts" contentType=colorscale colorScale=positive/>
+</DataTable>
+
+{/if}
+
+<BarChart
+    data={standings}
+    x=team
+    y=pts
+    title="Points — {inputs.season.value}"
+    yAxisTitle="Points"
+    xAxisTitle="Team"
+    sort=false
+/>

--- a/dashboards/sources/superligaen/current_leader.sql
+++ b/dashboards/sources/superligaen/current_leader.sql
@@ -1,0 +1,12 @@
+select
+    t.team_name,
+    sum(f.points_earned)::integer as pts
+from gold.fct_match_results f
+join gold.dim_team         t on t.team_sk        = f.team_sk
+join gold.dim_match        m on m.match_sk       = f.match_sk
+join gold.dim_match_result r on r.match_result_sk = f.match_result_sk
+where m.season = (select max(season) from gold.dim_match where season is not null)
+  and r.match_result in ('Win', 'Draw', 'Loss')
+group by t.team_name
+order by pts desc
+limit 1

--- a/dashboards/sources/superligaen/kpis.sql
+++ b/dashboards/sources/superligaen/kpis.sql
@@ -1,0 +1,14 @@
+select
+    sum(case when f.team_side_sk = 1 then f.goals_scored else 0 end)::integer  as total_goals,
+    sum(f.red_cards)::integer                                                   as total_red_cards,
+    round(
+        sum(f.total_shots)::decimal / nullif(count(distinct f.match_sk), 0),
+        1
+    )                                                                           as avg_shots_per_match,
+    max(m.season)                                                               as season
+from gold.fct_match_results f
+join gold.dim_match        m on m.match_sk        = f.match_sk
+join gold.dim_match_result r on r.match_result_sk = f.match_result_sk
+where m.season = (select max(season) from gold.dim_match where season is not null)
+  and r.match_result in ('Win', 'Draw', 'Loss')
+  and f.total_shots is not null

--- a/dashboards/sources/superligaen/league_info.sql
+++ b/dashboards/sources/superligaen/league_info.sql
@@ -1,0 +1,7 @@
+select
+    league_name,
+    league_logo,
+    league_country_flag
+from gold.dim_league
+where league_id = 119
+limit 1

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,7 @@
+[build]
+  base    = "dashboards"
+  command = "npm run build"
+  publish = "dashboards/build"
+
+[build.environment]
+  NODE_VERSION = "20"


### PR DESCRIPTION
## Summary

- **`index.md`** (hub): league header with logo + Denmark flag pulled from `gold.dim_league`, KPI ribbon (Goals Scored, Current Leader, Red Cards, Avg Shots/Match), and a navigation card grid linking to sub-pages. Cards use Tailwind hover effects (border highlight, shadow, bg shift).
- **`standings.md`** (new): standings content moved from the old `index.md`; back-to-home button added at the top.
- **`match-results.md`**: back-to-home button added.
- **3 new source queries**: `league_info.sql`, `kpis.sql`, `current_leader.sql`

## Back-to-home pattern
All sub-pages use:
```html
<a href="/" class="inline-flex items-center gap-1 text-sm text-gray-400 hover:text-white no-underline mb-6 transition-colors">← Back to Home</a>
```

## Test plan
- [ ] Hub loads with league logo, flag and correct KPI values for 2025
- [ ] Standings and Match Results cards navigate to correct sub-pages
- [ ] Back to Home button returns to hub from both sub-pages
- [ ] KPIs: Goals=253, Leader=Aarhus, Red Cards=21, Avg Shots≈26.x

🤖 Generated with [Claude Code](https://claude.com/claude-code)