### PR TITLE
fix: correct Netlify publish path

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,7 +1,7 @@
 [build]
   base    = "dashboards"
   command = "npm run build"
-  publish = "dashboards/build"
+  publish = "build"
 
 [build.environment]
   NODE_VERSION = "20"


### PR DESCRIPTION
When `base = "dashboards"` is set, Netlify resolves `publish` relative to `base`. So `publish = "dashboards/build"` was expanding to `dashboards/dashboards/build`. Fix is `publish = "build"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)