### PR TITLE
fix: add COOP/COEP headers for DuckDB-WASM on Netlify

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -5,3 +5,10 @@
 
 [build.environment]
   NODE_VERSION = "20"
+
+# DuckDB-WASM requires SharedArrayBuffer which needs these headers
+[[headers]]
+  for = "/*"
+  [headers.values]
+    Cross-Origin-Opener-Policy   = "same-origin"
+    Cross-Origin-Embedder-Policy = "require-corp"


### PR DESCRIPTION
DuckDB-WASM requires `SharedArrayBuffer` to run in the browser. Netlify doesn't set the required security headers by default, causing the Evidence dashboard to show "Timeout while initializing database".

Adds to `netlify.toml`:
```
Cross-Origin-Opener-Policy: same-origin
Cross-Origin-Embedder-Policy: require-corp
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)