### PR TITLE
fix: write connection.options.yaml from MOTHERDUCK_TOKEN at build time

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,6 @@
 [build]
   base    = "dashboards"
-  command = "npm run build"
+  command = "echo \"token: $MOTHERDUCK_TOKEN\" > sources/superligaen/connection.options.yaml && npm run build"
   publish = "build"
 
 [build.environment]


### PR DESCRIPTION
`connection.options.yaml` is gitignored so the MotherDuck token never reaches the Netlify build environment. The Evidence MotherDuck connector has no built-in env var mapping — it reads `opts.token` directly from the options file.

Fix: prepend the build command with a one-liner that writes the file from `MOTHERDUCK_TOKEN` env var before `npm run build` runs.

**Required:** rename the Netlify env var back to `MOTHERDUCK_TOKEN`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)