### PR TITLE
fix: add npm run sources to Netlify build command

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,6 @@
 [build]
   base    = "dashboards"
-  command = "echo \"token: $MOTHERDUCK_TOKEN\" > sources/superligaen/connection.options.yaml && npm run build"
+  command = "echo \"token: $MOTHERDUCK_TOKEN\" > sources/superligaen/connection.options.yaml && npm run sources && npm run build"
   publish = "build"
 
 [build.environment]


### PR DESCRIPTION
'npm run build' alone doesn't fetch data — 'npm run sources' must run first to query MotherDuck and cache the results. Without it the build produces an empty site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)