### PR TITLE
feat: dashboard redesign — match results, team analytics, polished UI

### DIFF
--- a/dashboards/pages/index.md
+++ b/dashboards/pages/index.md
@@ -6,45 +6,67 @@ title: Superligaen
 select * from superligaen.league_info
 ```
 
-```sql kpis
-select * from superligaen.kpis
+```sql extended_kpis
+select
+    count(*)                            as total_matches,
+    sum(total_goals)                    as total_goals,
+    round(avg(total_goals), 2)          as avg_goals_per_match,
+    round(avg(total_xg), 2)             as avg_xg_per_match,
+    sum(total_yellow_cards)             as total_yellow_cards,
+    sum(total_red_cards)                as total_red_cards,
+    round(avg(total_shots_on_goal), 1)  as avg_shots_on_goal,
+    max(season)                         as season
+from superligaen.match_results_by_match
+where season = (select max(season) from superligaen.match_results_by_match)
 ```
 
 ```sql leader
 select * from superligaen.current_leader
 ```
 
-<div class="flex items-center justify-center gap-6 my-8 flex-wrap">
-  <img src="{league[0].league_country_flag}" alt="Denmark" class="h-8 rounded shadow-md" />
-  <img src="{league[0].league_logo}" alt="Superligaen" class="h-16" />
-  <div class="text-center">
-    <div class="text-4xl font-extrabold tracking-tight">Superligaen</div>
-    <div class="text-gray-400 text-sm mt-1">Danish Football Premier League &middot; {kpis[0].season} Season</div>
+<div class="rounded-2xl border border-gray-300 bg-gray-100 p-8 mb-6">
+  <div class="flex items-center justify-center gap-6 flex-wrap">
+    <img src="{league[0].league_country_flag}" alt="Denmark" class="h-10 rounded shadow-lg" />
+    <div class="bg-white rounded-2xl p-3 shadow-lg">
+      <img src="{league[0].league_logo}" alt="Superligaen" class="h-16" />
+    </div>
+    <div class="text-center">
+      <div class="text-5xl font-extrabold tracking-tight text-gray-800">Superligaen</div>
+      <div class="text-gray-500 text-base mt-2">Danish Football Premier League &middot; {extended_kpis[0].season} Season</div>
+    </div>
+    <img src="{league[0].league_country_flag}" alt="Denmark" class="h-10 rounded shadow-lg" />
   </div>
-  <img src="{league[0].league_country_flag}" alt="Denmark" class="h-8 rounded shadow-md" />
 </div>
 
-<div class="grid grid-cols-2 md:grid-cols-4 gap-4 mb-8">
-  <BigValue data={kpis}   value=total_goals        title="Goals Scored"      />
-  <BigValue data={leader} value=team_name           title="Current Leader"    />
-  <BigValue data={kpis}   value=total_red_cards     title="Red Cards"         />
-  <BigValue data={kpis}   value=avg_shots_per_match title="Avg Shots / Match" />
+<div class="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
+  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4"><BigValue data={extended_kpis} value=total_matches       title="Matches Played"    /></div>
+  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4"><BigValue data={extended_kpis} value=total_goals         title="Goals Scored"      /></div>
+  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4"><BigValue data={extended_kpis} value=avg_goals_per_match title="Avg Goals / Match" /></div>
+  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4"><BigValue data={leader}        value=team_name           title="Current Leader"    /></div>
+  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4"><BigValue data={extended_kpis} value=avg_xg_per_match    title="Avg xG / Match"    /></div>
+  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4"><BigValue data={extended_kpis} value=avg_shots_on_goal   title="Avg Shots on Goal" /></div>
+  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4"><BigValue data={extended_kpis} value=total_yellow_cards  title="Yellow Cards"      /></div>
+  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4"><BigValue data={extended_kpis} value=total_red_cards     title="Red Cards"         /></div>
 </div>
 
----
+<div class="grid grid-cols-1 md:grid-cols-3 gap-4">
 
-<div class="grid grid-cols-1 md:grid-cols-2 gap-4 mt-6">
-
-<a href="/standings" class="block no-underline rounded-xl border border-gray-700 bg-gray-900 p-6 hover:border-blue-500 hover:shadow-lg hover:bg-gray-800 transition-all duration-200 group">
+<a href="/standings" class="block no-underline rounded-xl border border-gray-300 bg-gray-100 p-6 hover:border-blue-500 hover:shadow-lg hover:bg-gray-200 transition-all duration-200 group">
   <div class="text-4xl">🏆</div>
   <div class="text-lg font-bold mt-3 mb-1 group-hover:text-blue-400 transition-colors">Standings</div>
   <div class="text-gray-400 text-sm">Championship, Relegation &amp; Regular Season tables</div>
 </a>
 
-<a href="/match-results" class="block no-underline rounded-xl border border-gray-700 bg-gray-900 p-6 hover:border-blue-500 hover:shadow-lg hover:bg-gray-800 transition-all duration-200 group">
+<a href="/match-results" class="block no-underline rounded-xl border border-gray-300 bg-gray-100 p-6 hover:border-blue-500 hover:shadow-lg hover:bg-gray-200 transition-all duration-200 group">
   <div class="text-4xl">⚽</div>
   <div class="text-lg font-bold mt-3 mb-1 group-hover:text-blue-400 transition-colors">Match Results</div>
-  <div class="text-gray-400 text-sm">Full match history, results and scorelines by team</div>
+  <div class="text-gray-400 text-sm">Full match history, scorelines and analytics by round</div>
+</a>
+
+<a href="/team-analytics" class="block no-underline rounded-xl border border-gray-300 bg-gray-100 p-6 hover:border-blue-500 hover:shadow-lg hover:bg-gray-200 transition-all duration-200 group">
+  <div class="text-4xl">📊</div>
+  <div class="text-lg font-bold mt-3 mb-1 group-hover:text-blue-400 transition-colors">Team Analytics</div>
+  <div class="text-gray-400 text-sm">Deep-dive KPIs, form, shooting accuracy &amp; discipline</div>
 </a>
 
 </div>

--- a/dashboards/pages/match-results.md
+++ b/dashboards/pages/match-results.md
@@ -2,47 +2,109 @@
 title: Match Results
 ---
 
-<a href="/" class="inline-flex items-center gap-1 text-sm text-gray-400 hover:text-white no-underline mb-6 transition-colors">← Back to Home</a>
+<a href="/" class="inline-flex items-center gap-1 text-sm text-gray-500 hover:text-gray-800 no-underline mb-6 transition-colors">← Back to Home</a>
 
 ```sql seasons
-select distinct season from superligaen.match_results
+select distinct season from superligaen.match_results_by_match
 order by season desc
-```
-
-```sql teams
-select distinct team_name as team from superligaen.match_results
-order by team_name
 ```
 
 <Dropdown data={seasons} name=season value=season label=season>
     <DropdownOption value=2025 valueLabel="2025"/>
 </Dropdown>
 
-<Dropdown data={teams} name=team value=team label=team>
-    <DropdownOption value="All Teams" valueLabel="All Teams"/>
-</Dropdown>
-
 ```sql results
 select
-    match_date, round, team_name as team, opponent,
-    side, gf, ga, result, pts, stadium
-from superligaen.match_results
+    match_date, round, match_round_number, match_name, score,
+    total_goals, total_shots_on_goal, total_xg,
+    total_yellow_cards, total_red_cards, total_corners
+from superligaen.match_results_by_match
 where season = ${inputs.season.value}
-  and (team_name = '${inputs.team.value}' or '${inputs.team.value}' = 'All Teams')
 order by match_date desc
 ```
 
-## Results — {inputs.season.value}
+```sql season_kpis
+select
+    count(*)                            as total_matches,
+    sum(total_goals)                    as total_goals,
+    round(avg(total_goals), 2)          as avg_goals_per_match,
+    round(avg(total_xg), 2)             as avg_xg_per_match,
+    sum(total_yellow_cards)             as total_yellow_cards,
+    sum(total_red_cards)                as total_red_cards,
+    round(avg(total_shots_on_goal), 1)  as avg_shots_on_goal
+from superligaen.match_results_by_match
+where season = ${inputs.season.value}
+```
+
+```sql goals_by_round
+select
+    match_round_number  as round,
+    sum(total_goals)    as goals
+from superligaen.match_results_by_match
+where season = ${inputs.season.value}
+group by match_round_number
+order by round asc
+```
+
+---
+
+## Season {inputs.season.value} at a Glance
+
+<div class="grid grid-cols-2 md:grid-cols-4 gap-4 mb-4">
+  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4"><BigValue data={season_kpis} value=total_matches       title="Matches Played"    /></div>
+  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4"><BigValue data={season_kpis} value=total_goals          title="Goals Scored"      /></div>
+  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4"><BigValue data={season_kpis} value=avg_goals_per_match  title="Avg Goals / Match" /></div>
+  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4"><BigValue data={season_kpis} value=avg_xg_per_match     title="Avg xG / Match"    /></div>
+  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4"><BigValue data={season_kpis} value=avg_shots_on_goal    title="Avg Shots on Goal" /></div>
+  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4"><BigValue data={season_kpis} value=total_yellow_cards   title="Yellow Cards"      /></div>
+  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4"><BigValue data={season_kpis} value=total_red_cards      title="Red Cards"         /></div>
+</div>
+
+---
+
+## Goals by Round
+
+<BarChart
+    data={goals_by_round}
+    x=round
+    y=goals
+    title="Total Goals per Round"
+    xAxisTitle="Round"
+    yAxisTitle="Goals"
+    colorPalette={['#22c55e']}
+/>
+
+---
+
+## Match Results — {inputs.season.value}
 
 <DataTable data={results} rows=20 search=true>
-    <Column id=match_date title="Date"/>
-    <Column id=round      title="Round"/>
-    <Column id=team       title="Team"/>
-    <Column id=opponent   title="Opponent"/>
-    <Column id=side       title="Side"/>
-    <Column id=gf         title="GF"/>
-    <Column id=ga         title="GA"/>
-    <Column id=result     title="Result"/>
-    <Column id=pts        title="Pts"/>
-    <Column id=stadium    title="Stadium"/>
+    <Column id=match_date          title="Date"           />
+    <Column id=round               title="Round"          />
+    <Column id=match_name          title="Match"          wrap=true />
+    <Column id=score               title="Score"          align=center />
+    <Column id=total_goals         title="Goals"          contentType=colorscale colorPalette={['white','#22c55e']} align=center />
+    <Column id=total_shots_on_goal title="Shots on Goal"  contentType=bar       colorPalette={['#6366f1']} />
+    <Column id=total_xg            title="xG"             contentType=colorscale colorPalette={['white','#3b82f6']} />
+    <Column id=total_yellow_cards  title="YC"             contentType=colorscale colorPalette={['white','#eab308']} align=center />
+    <Column id=total_red_cards     title="RC"             contentType=colorscale colorPalette={['white','#ef4444']} align=center />
+    <Column id=total_corners       title="Corners"        contentType=colorscale colorPalette={['white','#a855f7']} align=center />
+</DataTable>
+
+---
+
+## Upcoming Matches
+
+```sql upcoming
+select match_date, round, match_name, stadium
+from superligaen.upcoming_matches
+where season = ${inputs.season.value}
+order by match_date asc
+```
+
+<DataTable data={upcoming} rows=20>
+    <Column id=match_date title="Date"     />
+    <Column id=round      title="Round"    />
+    <Column id=match_name title="Match"    wrap=true />
+    <Column id=stadium    title="Stadium"  />
 </DataTable>

--- a/dashboards/pages/standings.md
+++ b/dashboards/pages/standings.md
@@ -2,7 +2,7 @@
 title: Standings
 ---
 
-<a href="/" class="inline-flex items-center gap-1 text-sm text-gray-400 hover:text-white no-underline mb-6 transition-colors">← Back to Home</a>
+<a href="/" class="inline-flex items-center gap-1 text-sm text-gray-500 hover:text-gray-800 no-underline mb-6 transition-colors">← Back to Home</a>
 
 ```sql seasons
 select distinct season from superligaen.team_season_stats
@@ -15,6 +15,7 @@ order by season desc
 
 ```sql standings
 select
+    row_number() over (partition by round_group order by pts desc, gd desc, gf desc) as rank,
     team_name   as team,
     gp, w, d, l, gf, ga, gd, pts,
     round_group
@@ -24,85 +25,111 @@ order by round_group, pts desc, gd desc, gf desc
 ```
 
 ```sql championship
-select team, gp, w, d, l, gf, ga, gd, pts
+select rank, team, gp, w, d, l, gf, ga, gd, pts
 from ${standings}
 where round_group = 'Championship Group'
 ```
 
 ```sql relegation
-select team, gp, w, d, l, gf, ga, gd, pts
+select rank, team, gp, w, d, l, gf, ga, gd, pts
 from ${standings}
 where round_group = 'Relegation Group'
 ```
 
 ```sql regular
-select team_name as team, gp, w, d, l, gf, ga, gd, pts
+select
+    row_number() over (order by pts desc, gd desc, gf desc) as rank,
+    team_name as team, gp, w, d, l, gf, ga, gd, pts
 from superligaen.team_regular_season_stats
 where season = ${inputs.season.value}
+```
+
+```sql all_teams
+select team, pts, gf, ga, round_group from ${standings}
+order by round_group, pts desc
 ```
 
 ## {inputs.season.value} Season Standings
 
 {#if championship.length > 0}
 
-### Championship Group
+### 🏆 Championship Group
 
 <DataTable data={championship} rows=20>
-    <Column id=team/>
-    <Column id=gp  title="GP"/>
-    <Column id=w   title="W"/>
-    <Column id=d   title="D"/>
-    <Column id=l   title="L"/>
-    <Column id=gf  title="GF"/>
-    <Column id=ga  title="GA"/>
-    <Column id=gd  title="GD"/>
-    <Column id=pts title="Pts" contentType=colorscale colorScale=positive/>
+    <Column id=rank title="#"   align=center />
+    <Column id=team title="Team"             />
+    <Column id=gp   title="GP"  align=center />
+    <Column id=w    title="W"   align=center />
+    <Column id=d    title="D"   align=center />
+    <Column id=l    title="L"   align=center />
+    <Column id=gf   title="GF"  align=center />
+    <Column id=ga   title="GA"  align=center />
+    <Column id=gd   title="GD"  align=center />
+    <Column id=pts  title="Pts" align=center contentType=colorscale colorPalette={['white','#6366f1']} />
 </DataTable>
 
 {/if}
 
 {#if relegation.length > 0}
 
-### Relegation Group
+### ⬇️ Relegation Group
 
 <DataTable data={relegation} rows=20>
-    <Column id=team/>
-    <Column id=gp  title="GP"/>
-    <Column id=w   title="W"/>
-    <Column id=d   title="D"/>
-    <Column id=l   title="L"/>
-    <Column id=gf  title="GF"/>
-    <Column id=ga  title="GA"/>
-    <Column id=gd  title="GD"/>
-    <Column id=pts title="Pts" contentType=colorscale colorScale=positive/>
+    <Column id=rank title="#"   align=center />
+    <Column id=team title="Team"             />
+    <Column id=gp   title="GP"  align=center />
+    <Column id=w    title="W"   align=center />
+    <Column id=d    title="D"   align=center />
+    <Column id=l    title="L"   align=center />
+    <Column id=gf   title="GF"  align=center />
+    <Column id=ga   title="GA"  align=center />
+    <Column id=gd   title="GD"  align=center />
+    <Column id=pts  title="Pts" align=center contentType=colorscale colorPalette={['white','#6366f1']} />
 </DataTable>
 
 {/if}
 
 {#if regular.length > 0}
 
-### Regular Season
+### 📋 Regular Season
 
 <DataTable data={regular} rows=20>
-    <Column id=team/>
-    <Column id=gp  title="GP"/>
-    <Column id=w   title="W"/>
-    <Column id=d   title="D"/>
-    <Column id=l   title="L"/>
-    <Column id=gf  title="GF"/>
-    <Column id=ga  title="GA"/>
-    <Column id=gd  title="GD"/>
-    <Column id=pts title="Pts" contentType=colorscale colorScale=positive/>
+    <Column id=rank title="#"   align=center />
+    <Column id=team title="Team"             />
+    <Column id=gp   title="GP"  align=center />
+    <Column id=w    title="W"   align=center />
+    <Column id=d    title="D"   align=center />
+    <Column id=l    title="L"   align=center />
+    <Column id=gf   title="GF"  align=center />
+    <Column id=ga   title="GA"  align=center />
+    <Column id=gd   title="GD"  align=center />
+    <Column id=pts  title="Pts" align=center contentType=colorscale colorPalette={['white','#6366f1']} />
 </DataTable>
 
 {/if}
 
+---
+
 <BarChart
-    data={standings}
+    data={all_teams}
     x=team
     y=pts
-    title="Points — {inputs.season.value}"
+    series=round_group
+    title="Points by Team — {inputs.season.value}"
     yAxisTitle="Points"
     xAxisTitle="Team"
     sort=false
+    swapXY=true
+/>
+
+<BarChart
+    data={all_teams}
+    x=team
+    y={['gf','ga']}
+    title="Goals For vs Goals Against — {inputs.season.value}"
+    yAxisTitle="Goals"
+    xAxisTitle="Team"
+    sort=false
+    swapXY=true
+    colorPalette={['#22c55e','#ef4444']}
 />

--- a/dashboards/pages/team-analytics.md
+++ b/dashboards/pages/team-analytics.md
@@ -1,0 +1,304 @@
+---
+title: Team Analytics
+---
+
+<a href="/" class="inline-flex items-center gap-1 text-sm text-gray-500 hover:text-gray-800 no-underline mb-6 transition-colors">← Back to Home</a>
+
+```sql seasons
+select distinct season from superligaen.team_analytics_kpis
+order by season desc
+```
+
+```sql teams
+select distinct team_name as team from superligaen.team_analytics_kpis
+order by team_name
+```
+
+<Dropdown data={seasons} name=season value=season label=season>
+    <DropdownOption value=2025 valueLabel="2025"/>
+</Dropdown>
+
+<Dropdown data={teams} name=team value=team label=team>
+    <DropdownOption value="FC Copenhagen" valueLabel="FC Copenhagen"/>
+</Dropdown>
+
+```sql kpis
+select * from superligaen.team_analytics_kpis
+where team_name = '${inputs.team.value}'
+  and season = ${inputs.season.value}
+```
+
+```sql form
+select * from superligaen.team_analytics_form
+where team_name = '${inputs.team.value}'
+  and season = ${inputs.season.value}
+order by match_date asc, match_round_number asc
+```
+
+```sql home_away
+select * from superligaen.team_analytics_home_away
+where team_name = '${inputs.team.value}'
+  and season = ${inputs.season.value}
+order by side desc
+```
+
+---
+
+## {inputs.team.value} — Season Overview
+
+<div class="grid grid-cols-2 md:grid-cols-4 gap-4 mb-4">
+  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4"><BigValue data={kpis} value=total_points     title="Points"          /></div>
+  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4"><BigValue data={kpis} value=wins             title="Wins"            /></div>
+  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4"><BigValue data={kpis} value=draws            title="Draws"           /></div>
+  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4"><BigValue data={kpis} value=losses           title="Losses"          /></div>
+  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4"><BigValue data={kpis} value=goals_for        title="Goals Scored"    /></div>
+  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4"><BigValue data={kpis} value=goals_against    title="Goals Conceded"  /></div>
+  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4"><BigValue data={kpis} value=goal_difference  title="Goal Difference" /></div>
+  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4"><BigValue data={kpis} value=win_rate_pct     title="Win Rate"        fmt=pct0 /></div>
+</div>
+
+<div class="grid grid-cols-2 md:grid-cols-4 gap-4 mb-4">
+  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4"><BigValue data={kpis} value=avg_possession       title="Avg Possession"    fmt=pct0 /></div>
+  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4"><BigValue data={kpis} value=avg_pass_accuracy    title="Pass Accuracy"     fmt=pct0 /></div>
+  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4"><BigValue data={kpis} value=shot_conversion_pct  title="Shot Conversion"   fmt=pct0 /></div>
+  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4"><BigValue data={kpis} value=on_target_conversion_pct title="On-Target Conv." fmt=pct0 /></div>
+  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4"><BigValue data={kpis} value=total_xg             title="Total xG"          /></div>
+  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4"><BigValue data={kpis} value=xg_overperformance   title="xG Overperformance" /></div>
+  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4"><BigValue data={kpis} value=aggression_index     title="Aggression Index"  /></div>
+  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4"><BigValue data={kpis} value=avg_saves            title="Avg Saves/Match"   /></div>
+</div>
+
+---
+
+## Points Progression
+
+```sql points_trend
+select match_round_number as round, cumulative_points, result, opponent, gf, ga
+from superligaen.team_analytics_form
+where team_name = '${inputs.team.value}'
+  and season = ${inputs.season.value}
+order by round asc
+```
+
+<LineChart
+    data={points_trend}
+    x=round
+    y=cumulative_points
+    title="Cumulative Points by Round"
+    xAxisTitle="Round"
+    yAxisTitle="Points"
+    lineColor="#3b82f6"
+/>
+
+---
+
+## Form Guide
+
+```sql recent_form
+select
+    match_date, round, opponent, side,
+    gf, ga, result, xg, shots_on_goal, possession, fouls,
+    yellow_cards, red_cards
+from superligaen.team_analytics_form
+where team_name = '${inputs.team.value}'
+  and season = ${inputs.season.value}
+order by match_date desc
+limit 10
+```
+
+<DataTable data={recent_form} rows=10>
+    <Column id=match_date   title="Date"       />
+    <Column id=round        title="Round"      />
+    <Column id=opponent     title="Opponent"   />
+    <Column id=side         title="Side"       />
+    <Column id=gf           title="GF"         />
+    <Column id=ga           title="GA"         />
+    <Column id=result       title="Result"     />
+    <Column id=xg           title="xG"         />
+    <Column id=shots_on_goal title="SoG"       />
+    <Column id=possession   title="Poss %"     />
+    <Column id=fouls        title="Fouls"      />
+    <Column id=yellow_cards title="YC"         />
+    <Column id=red_cards    title="RC"         />
+</DataTable>
+
+---
+
+## Attack
+
+<div class="grid grid-cols-2 md:grid-cols-4 gap-4 mb-4">
+  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4"><BigValue data={kpis} value=avg_xg_per_match      title="xG per Match"        /></div>
+  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4"><BigValue data={kpis} value=avg_shots_on_goal     title="Shots on Goal/Match" /></div>
+  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4"><BigValue data={kpis} value=avg_goals_scored      title="Goals Scored/Match"  /></div>
+  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4"><BigValue data={kpis} value=shot_conversion_pct   title="Shot Conversion %"   fmt=pct0 /></div>
+</div>
+
+<BarChart
+    data={form}
+    x=match_round_number
+    y=gf
+    title="Goals Scored by Round"
+    xAxisTitle="Round"
+    yAxisTitle="Goals"
+    colorPalette={['#22c55e']}
+/>
+
+<BarChart
+    data={form}
+    x=match_round_number
+    y=xg
+    title="xG by Round"
+    xAxisTitle="Round"
+    yAxisTitle="xG"
+    colorPalette={['#3b82f6']}
+/>
+
+```sql shot_location
+select 'Inside Box' as location, shots_insidebox as shots
+from superligaen.team_analytics_kpis
+where team_name = '${inputs.team.value}' and season = ${inputs.season.value}
+union all
+select 'Outside Box', shots_outsidebox
+from superligaen.team_analytics_kpis
+where team_name = '${inputs.team.value}' and season = ${inputs.season.value}
+```
+
+<BarChart
+    data={shot_location}
+    x=location
+    y=shots
+    title="Shot Locations — Season Total"
+    xAxisTitle="Location"
+    yAxisTitle="Shots"
+    colorPalette={['#f59e0b', '#ef4444']}
+    swapXY=true
+/>
+
+---
+
+## Defence
+
+<div class="grid grid-cols-2 gap-4 mb-4">
+  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4"><BigValue data={kpis} value=avg_goals_conceded title="Goals Conceded/Match" /></div>
+  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4"><BigValue data={kpis} value=avg_saves          title="Saves/Match"          /></div>
+</div>
+
+<BarChart
+    data={form}
+    x=match_round_number
+    y=ga
+    title="Goals Conceded by Round"
+    xAxisTitle="Round"
+    yAxisTitle="Goals Conceded"
+    colorPalette={['#ef4444']}
+/>
+
+<BarChart
+    data={form}
+    x=match_round_number
+    y=saves
+    title="Goalkeeper Saves by Round"
+    xAxisTitle="Round"
+    yAxisTitle="Saves"
+    colorPalette={['#6366f1']}
+/>
+
+---
+
+## Passing & Possession
+
+<div class="grid grid-cols-2 md:grid-cols-4 gap-4 mb-4">
+  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4"><BigValue data={kpis} value=avg_possession     title="Avg Possession %"  fmt=pct0 /></div>
+  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4"><BigValue data={kpis} value=avg_pass_accuracy  title="Avg Pass Accuracy" fmt=pct0 /></div>
+  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4"><BigValue data={kpis} value=avg_corners        title="Corners/Match"               /></div>
+  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4"><BigValue data={kpis} value=avg_offsides       title="Offsides/Match"              /></div>
+</div>
+
+<BarChart
+    data={form}
+    x=match_round_number
+    y=possession
+    title="Possession % by Round"
+    xAxisTitle="Round"
+    yAxisTitle="Possession %"
+    colorPalette={['#14b8a6']}
+/>
+
+<BarChart
+    data={form}
+    x=match_round_number
+    y=pass_accuracy
+    title="Pass Accuracy % by Round"
+    xAxisTitle="Round"
+    yAxisTitle="Pass Accuracy %"
+    colorPalette={['#8b5cf6']}
+/>
+
+---
+
+## Discipline
+
+<div class="grid grid-cols-2 md:grid-cols-4 gap-4 mb-4">
+  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4"><BigValue data={kpis} value=avg_fouls        title="Fouls/Match"      /></div>
+  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4"><BigValue data={kpis} value=yellow_cards     title="Yellow Cards"     /></div>
+  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4"><BigValue data={kpis} value=red_cards        title="Red Cards"        /></div>
+  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4"><BigValue data={kpis} value=aggression_index title="Aggression Index" /></div>
+</div>
+
+<BarChart
+    data={form}
+    x=match_round_number
+    y=fouls
+    title="Fouls by Round"
+    xAxisTitle="Round"
+    yAxisTitle="Fouls"
+    colorPalette={['#f97316']}
+/>
+
+<BarChart
+    data={form}
+    x=match_round_number
+    y={['yellow_cards', 'red_cards']}
+    title="Cards by Round"
+    xAxisTitle="Round"
+    yAxisTitle="Cards"
+    colorPalette={['#eab308', '#dc2626']}
+/>
+
+---
+
+## Home vs Away
+
+<DataTable data={home_away}>
+    <Column id=side               title="Side"             />
+    <Column id=matches            title="MP"               />
+    <Column id=wins               title="W"                />
+    <Column id=draws              title="D"                />
+    <Column id=losses             title="L"                />
+    <Column id=goals_for          title="GF"               />
+    <Column id=goals_against      title="GA"               />
+    <Column id=win_rate_pct       title="Win %"            />
+    <Column id=avg_possession     title="Avg Poss %"       />
+    <Column id=avg_shots_on_goal  title="Avg SoG"          />
+    <Column id=avg_xg             title="Avg xG"           />
+    <Column id=shot_conversion_pct title="Shot Conv %"     />
+    <Column id=avg_fouls          title="Avg Fouls"        />
+    <Column id=yellow_cards       title="YC"               />
+    <Column id=red_cards          title="RC"               />
+    <Column id=avg_saves          title="Avg Saves"        />
+</DataTable>
+
+```sql home_away_chart
+select side, avg_shots_on_goal as "Shots on Goal", avg_xg as "xG", avg_possession / 10 as "Possession / 10", win_rate_pct / 10 as "Win Rate / 10"
+from superligaen.team_analytics_home_away
+where team_name = '${inputs.team.value}' and season = ${inputs.season.value}
+```
+
+<BarChart
+    data={home_away_chart}
+    x=side
+    y={['Shots on Goal', 'xG', 'Possession / 10', 'Win Rate / 10']}
+    title="Home vs Away — Key Metrics"
+    xAxisTitle="Side"
+    swapXY=false
+/>

--- a/dashboards/sources/superligaen/match_results_by_match.sql
+++ b/dashboards/sources/superligaen/match_results_by_match.sql
@@ -1,0 +1,20 @@
+select
+    d.full_date                                     as match_date,
+    m.match_round_name                              as round,
+    m.match_name,
+    m.match_result                                  as score,
+    sum(f.shots_on_goal)                            as total_shots_on_goal,
+    sum(f.yellow_cards)                             as total_yellow_cards,
+    sum(f.red_cards)                                as total_red_cards,
+    sum(f.corner_kicks)                             as total_corners,
+    round(sum(f.expected_goals::double), 2)         as total_xg,
+    sum(f.goals_scored)                             as total_goals,
+    m.match_round_number,
+    m.season
+from superligaen.gold.fct_match_results f
+join superligaen.gold.dim_match        m on m.match_sk        = f.match_sk
+join superligaen.gold.dim_date         d on d.date_sk         = f.date_sk
+join superligaen.gold.dim_match_result r on r.match_result_sk = f.match_result_sk
+where r.match_result in ('Win', 'Draw', 'Loss')
+group by d.full_date, m.match_round_name, m.match_round_number, m.match_name, m.match_result, m.season
+order by d.full_date desc

--- a/dashboards/sources/superligaen/team_analytics_form.sql
+++ b/dashboards/sources/superligaen/team_analytics_form.sql
@@ -1,0 +1,39 @@
+select
+    t.team_name,
+    d.full_date                                                             as match_date,
+    m.match_round_name                                                      as round,
+    m.match_round_number,
+    ot.opponent_team_name                                                   as opponent,
+    ts.team_side                                                            as side,
+    f.goals_scored                                                          as gf,
+    f.goals_conceded                                                        as ga,
+    r.match_result                                                          as result,
+    f.points_earned                                                         as pts,
+    round(f.expected_goals::double, 2)                                      as xg,
+    f.shots_on_goal,
+    f.total_shots,
+    f.shots_insidebox,
+    f.shots_outsidebox,
+    f.ball_possession_pct                                                   as possession,
+    f.yellow_cards,
+    f.red_cards,
+    f.fouls,
+    f.corner_kicks,
+    f.offsides,
+    f.goalkeeper_saves                                                      as saves,
+    round(f.passes_accurate::double / nullif(f.total_passes, 0) * 100, 1)  as pass_accuracy,
+    sum(f.points_earned) over (
+        partition by t.team_name, m.season
+        order by d.full_date, m.match_round_number
+        rows between unbounded preceding and current row
+    )                                                                       as cumulative_points,
+    m.season
+from superligaen.gold.fct_match_results f
+join superligaen.gold.dim_team          t   on t.team_sk          = f.team_sk
+join superligaen.gold.dim_opponent_team ot  on ot.opponent_team_sk = f.opponent_team_sk
+join superligaen.gold.dim_date          d   on d.date_sk          = f.date_sk
+join superligaen.gold.dim_match         m   on m.match_sk         = f.match_sk
+join superligaen.gold.dim_match_result  r   on r.match_result_sk  = f.match_result_sk
+join superligaen.gold.dim_team_side     ts  on ts.team_side_sk    = f.team_side_sk
+where r.match_result in ('Win', 'Draw', 'Loss')
+order by t.team_name, m.season, d.full_date, m.match_round_number

--- a/dashboards/sources/superligaen/team_analytics_home_away.sql
+++ b/dashboards/sources/superligaen/team_analytics_home_away.sql
@@ -1,0 +1,28 @@
+select
+    t.team_name,
+    ts.team_side                                                                    as side,
+    m.season,
+    count(*)                                                                        as matches,
+    sum(f.points_earned)                                                            as points,
+    count(*) filter (where r.match_result = 'Win')                                  as wins,
+    count(*) filter (where r.match_result = 'Draw')                                 as draws,
+    count(*) filter (where r.match_result = 'Loss')                                 as losses,
+    sum(f.goals_scored)                                                             as goals_for,
+    sum(f.goals_conceded)                                                           as goals_against,
+    round(avg(f.expected_goals::double), 2)                                         as avg_xg,
+    round(avg(f.ball_possession_pct::double), 1)                                    as avg_possession,
+    round(avg(f.shots_on_goal::double), 1)                                          as avg_shots_on_goal,
+    round(100.0 * sum(f.goals_scored) / nullif(sum(f.total_shots), 0), 1)          as shot_conversion_pct,
+    round(avg(f.fouls::double), 1)                                                  as avg_fouls,
+    sum(f.yellow_cards)                                                             as yellow_cards,
+    sum(f.red_cards)                                                                as red_cards,
+    round(avg(f.goalkeeper_saves::double), 1)                                       as avg_saves,
+    round(100.0 * count(*) filter (where r.match_result = 'Win') / count(*), 1)    as win_rate_pct
+from superligaen.gold.fct_match_results f
+join superligaen.gold.dim_team          t   on t.team_sk          = f.team_sk
+join superligaen.gold.dim_match         m   on m.match_sk         = f.match_sk
+join superligaen.gold.dim_match_result  r   on r.match_result_sk  = f.match_result_sk
+join superligaen.gold.dim_team_side     ts  on ts.team_side_sk    = f.team_side_sk
+where r.match_result in ('Win', 'Draw', 'Loss')
+group by t.team_name, ts.team_side, m.season
+order by t.team_name, m.season, ts.team_side

--- a/dashboards/sources/superligaen/team_analytics_kpis.sql
+++ b/dashboards/sources/superligaen/team_analytics_kpis.sql
@@ -1,0 +1,43 @@
+select
+    t.team_name,
+    m.season,
+    count(*)                                                                        as matches_played,
+    sum(f.points_earned)                                                            as total_points,
+    count(*) filter (where r.match_result = 'Win')                                  as wins,
+    count(*) filter (where r.match_result = 'Draw')                                 as draws,
+    count(*) filter (where r.match_result = 'Loss')                                 as losses,
+    sum(f.goals_scored)                                                             as goals_for,
+    sum(f.goals_conceded)                                                           as goals_against,
+    sum(f.goals_scored) - sum(f.goals_conceded)                                     as goal_difference,
+    round(avg(f.goals_scored::double), 2)                                           as avg_goals_scored,
+    round(avg(f.goals_conceded::double), 2)                                         as avg_goals_conceded,
+    round(sum(f.expected_goals::double), 2)                                         as total_xg,
+    round(avg(f.expected_goals::double), 2)                                         as avg_xg_per_match,
+    round(sum(f.goals_scored::double) - sum(f.expected_goals::double), 2)           as xg_overperformance,
+    round(avg(f.ball_possession_pct::double), 1)                                    as avg_possession,
+    round(avg(f.passes_accurate::double / nullif(f.total_passes, 0) * 100), 1)     as avg_pass_accuracy,
+    round(avg(f.shots_on_goal::double), 1)                                          as avg_shots_on_goal,
+    round(100.0 * sum(f.goals_scored) / nullif(sum(f.total_shots), 0), 1)          as shot_conversion_pct,
+    round(100.0 * sum(f.goals_scored) / nullif(sum(f.shots_on_goal), 0), 1)        as on_target_conversion_pct,
+    sum(f.shots_insidebox)                                                          as shots_insidebox,
+    sum(f.shots_outsidebox)                                                         as shots_outsidebox,
+    round(avg(f.goalkeeper_saves::double), 1)                                       as avg_saves,
+    round(avg(f.fouls::double), 1)                                                  as avg_fouls,
+    round(avg(f.corner_kicks::double), 1)                                           as avg_corners,
+    round(avg(f.offsides::double), 1)                                               as avg_offsides,
+    sum(f.yellow_cards)                                                             as yellow_cards,
+    sum(f.red_cards)                                                                as red_cards,
+    round(avg(f.yellow_cards::double), 2)                                           as avg_yellow_per_match,
+    round(avg(f.red_cards::double), 2)                                              as avg_red_per_match,
+    round(100.0 * count(*) filter (where r.match_result = 'Win') / count(*), 1)    as win_rate_pct,
+    round(
+        (sum(f.fouls) + sum(f.yellow_cards) * 5 + sum(f.red_cards) * 15)
+        ::double / count(*), 1
+    )                                                                               as aggression_index
+from superligaen.gold.fct_match_results f
+join superligaen.gold.dim_team         t  on t.team_sk          = f.team_sk
+join superligaen.gold.dim_match        m  on m.match_sk         = f.match_sk
+join superligaen.gold.dim_match_result r  on r.match_result_sk  = f.match_result_sk
+where r.match_result in ('Win', 'Draw', 'Loss')
+group by t.team_name, m.season
+order by m.season desc, total_points desc

--- a/dashboards/sources/superligaen/upcoming_matches.sql
+++ b/dashboards/sources/superligaen/upcoming_matches.sql
@@ -1,0 +1,14 @@
+select
+    d.full_date             as match_date,
+    m.match_round_name      as round,
+    m.match_name,
+    st.stadium_name         as stadium,
+    m.season
+from superligaen.gold.fct_match_results f
+join superligaen.gold.dim_match        m  on m.match_sk    = f.match_sk
+join superligaen.gold.dim_date         d  on d.date_sk     = f.date_sk
+join superligaen.gold.dim_stadium      st on st.stadium_sk = f.stadium_sk
+join superligaen.gold.dim_match_result r  on r.match_result_sk = f.match_result_sk
+where r.match_result = 'Pending'
+group by all
+order by d.full_date asc


### PR DESCRIPTION
## Summary
- New **Match Results** page: one row per match with score, xG, shots, cards, corners + upcoming fixtures table
- New **Team Analytics** page: 16 KPIs, points progression, form guide, attack/defence/passing/discipline charts, home vs away split
- Redesigned **Home** page: hero banner, 8 season KPIs in framed cards, 3 nav cards — fits one screen
- Polished **Standings** page: rank column, group labels, GF vs GA chart
- Consistent light theme (`bg-gray-100`) across all pages with framed BigValue cards

## Test plan
- [ ] Merge triggers Netlify rebuild via deploy hook
- [ ] Home page loads without scroll on a standard screen
- [ ] Team Analytics dropdowns (season + team) filter all charts correctly
- [ ] Match Results shows score cards and upcoming fixtures
- [ ] Standings shows all three groups with rank

🤖 Generated with [Claude Code](https://claude.com/claude-code)