### PR TITLE
fix: drop match_round_number, use match_date for ordering (closes #48)

### DIFF
--- a/dashboards/pages/match-results.md
+++ b/dashboards/pages/match-results.md
@@ -15,7 +15,7 @@ order by season desc
 
 ```sql results
 select
-    match_date, round, match_round_number, match_name, score,
+    match_date, round, match_name, score,
     total_goals, total_shots_on_goal, total_xg,
     total_yellow_cards, total_red_cards, total_corners
 from superligaen.match_results_by_match
@@ -38,12 +38,12 @@ where season = ${inputs.season.value}
 
 ```sql goals_by_round
 select
-    match_round_number  as round,
-    sum(total_goals)    as goals
+    match_date,
+    sum(total_goals) as goals
 from superligaen.match_results_by_match
 where season = ${inputs.season.value}
-group by match_round_number
-order by round asc
+group by match_date
+order by match_date asc
 ```
 
 ---

--- a/dashboards/pages/team-analytics.md
+++ b/dashboards/pages/team-analytics.md
@@ -32,7 +32,7 @@ where team_name = '${inputs.team.value}'
 select * from superligaen.team_analytics_form
 where team_name = '${inputs.team.value}'
   and season = ${inputs.season.value}
-order by match_date asc, match_round_number asc
+order by match_date asc
 ```
 
 ```sql home_away
@@ -73,19 +73,19 @@ order by side desc
 ## Points Progression
 
 ```sql points_trend
-select match_round_number as round, cumulative_points, result, opponent, gf, ga
+select match_date, cumulative_points, result, opponent, gf, ga
 from superligaen.team_analytics_form
 where team_name = '${inputs.team.value}'
   and season = ${inputs.season.value}
-order by round asc
+order by match_date asc
 ```
 
 <LineChart
     data={points_trend}
-    x=round
+    x=match_date
     y=cumulative_points
-    title="Cumulative Points by Round"
-    xAxisTitle="Round"
+    title="Cumulative Points over Time"
+    xAxisTitle="Date"
     yAxisTitle="Points"
     lineColor="#3b82f6"
 />
@@ -135,7 +135,7 @@ limit 10
 
 <BarChart
     data={form}
-    x=match_round_number
+    x=match_date
     y=gf
     title="Goals Scored by Round"
     xAxisTitle="Round"
@@ -145,7 +145,7 @@ limit 10
 
 <BarChart
     data={form}
-    x=match_round_number
+    x=match_date
     y=xg
     title="xG by Round"
     xAxisTitle="Round"
@@ -185,7 +185,7 @@ where team_name = '${inputs.team.value}' and season = ${inputs.season.value}
 
 <BarChart
     data={form}
-    x=match_round_number
+    x=match_date
     y=ga
     title="Goals Conceded by Round"
     xAxisTitle="Round"
@@ -195,7 +195,7 @@ where team_name = '${inputs.team.value}' and season = ${inputs.season.value}
 
 <BarChart
     data={form}
-    x=match_round_number
+    x=match_date
     y=saves
     title="Goalkeeper Saves by Round"
     xAxisTitle="Round"
@@ -216,7 +216,7 @@ where team_name = '${inputs.team.value}' and season = ${inputs.season.value}
 
 <BarChart
     data={form}
-    x=match_round_number
+    x=match_date
     y=possession
     title="Possession % by Round"
     xAxisTitle="Round"
@@ -226,7 +226,7 @@ where team_name = '${inputs.team.value}' and season = ${inputs.season.value}
 
 <BarChart
     data={form}
-    x=match_round_number
+    x=match_date
     y=pass_accuracy
     title="Pass Accuracy % by Round"
     xAxisTitle="Round"
@@ -247,7 +247,7 @@ where team_name = '${inputs.team.value}' and season = ${inputs.season.value}
 
 <BarChart
     data={form}
-    x=match_round_number
+    x=match_date
     y=fouls
     title="Fouls by Round"
     xAxisTitle="Round"
@@ -257,7 +257,7 @@ where team_name = '${inputs.team.value}' and season = ${inputs.season.value}
 
 <BarChart
     data={form}
-    x=match_round_number
+    x=match_date
     y={['yellow_cards', 'red_cards']}
     title="Cards by Round"
     xAxisTitle="Round"

--- a/dashboards/sources/superligaen/match_results_by_match.sql
+++ b/dashboards/sources/superligaen/match_results_by_match.sql
@@ -9,12 +9,11 @@ select
     sum(f.corner_kicks)                             as total_corners,
     round(sum(f.expected_goals::double), 2)         as total_xg,
     sum(f.goals_scored)                             as total_goals,
-    m.match_round_number,
     m.season
 from superligaen.gold.fct_match_results f
 join superligaen.gold.dim_match        m on m.match_sk        = f.match_sk
 join superligaen.gold.dim_date         d on d.date_sk         = f.date_sk
 join superligaen.gold.dim_match_result r on r.match_result_sk = f.match_result_sk
 where r.match_result in ('Win', 'Draw', 'Loss')
-group by d.full_date, m.match_round_name, m.match_round_number, m.match_name, m.match_result, m.season
+group by d.full_date, m.match_round_name, m.match_name, m.match_result, m.season
 order by d.full_date desc

--- a/dashboards/sources/superligaen/team_analytics_form.sql
+++ b/dashboards/sources/superligaen/team_analytics_form.sql
@@ -2,7 +2,6 @@ select
     t.team_name,
     d.full_date                                                             as match_date,
     m.match_round_name                                                      as round,
-    m.match_round_number,
     ot.opponent_team_name                                                   as opponent,
     ts.team_side                                                            as side,
     f.goals_scored                                                          as gf,
@@ -24,7 +23,7 @@ select
     round(f.passes_accurate::double / nullif(f.total_passes, 0) * 100, 1)  as pass_accuracy,
     sum(f.points_earned) over (
         partition by t.team_name, m.season
-        order by d.full_date, m.match_round_number
+        order by d.full_date
         rows between unbounded preceding and current row
     )                                                                       as cumulative_points,
     m.season
@@ -36,4 +35,4 @@ join superligaen.gold.dim_match         m   on m.match_sk         = f.match_sk
 join superligaen.gold.dim_match_result  r   on r.match_result_sk  = f.match_result_sk
 join superligaen.gold.dim_team_side     ts  on ts.team_side_sk    = f.team_side_sk
 where r.match_result in ('Win', 'Draw', 'Loss')
-order by t.team_name, m.season, d.full_date, m.match_round_number
+order by t.team_name, m.season, d.full_date

--- a/transformations/gold/dim_match.sql
+++ b/transformations/gold/dim_match.sql
@@ -2,6 +2,8 @@
 -- One row per fixture. Captures round, season, and current match status.
 -- SK is stable: new matches get the next available SK; existing matches keep theirs.
 -- match_status, match_result, and match_short_name are updated on every run.
+-- match_round_number removed: regex extraction was inconsistent across phases.
+-- Use match_date (dim_date) for ordering; match_round_name for display.
 CREATE SCHEMA IF NOT EXISTS {db}.gold;
 
 CREATE TABLE IF NOT EXISTS {db}.gold.dim_match (
@@ -9,7 +11,6 @@ CREATE TABLE IF NOT EXISTS {db}.gold.dim_match (
     match_id           INTEGER,
     season             INTEGER,
     match_round_name   VARCHAR,
-    match_round_number INTEGER,
     match_round_type   VARCHAR,
     match_status       VARCHAR,
     match_name         VARCHAR,
@@ -26,9 +27,9 @@ ALTER TABLE {db}.gold.dim_match ADD COLUMN IF NOT EXISTS match_result      VARCH
 -- Sentinels (idempotent)
 INSERT INTO {db}.gold.dim_match
 SELECT * FROM (VALUES
-    (-1, NULL::INTEGER, NULL::INTEGER, 'Unknown Match',        NULL::INTEGER, 'Unknown',       'Unknown Match',        'Unknown Match',        'Unknown',        NULL::VARCHAR),
-    (-2, NULL::INTEGER, NULL::INTEGER, 'Not Applicable Match', NULL::INTEGER, 'Not Applicable','Not Applicable Match', 'Not Applicable Match', 'Not Applicable', NULL::VARCHAR)
-) t(match_sk, match_id, season, round_name, round_number, round_type, match_status, match_name, match_short_name, match_result)
+    (-1, NULL::INTEGER, NULL::INTEGER, 'Unknown Match',        'Unknown',       'Unknown Match',        'Unknown Match',        'Unknown',        NULL::VARCHAR),
+    (-2, NULL::INTEGER, NULL::INTEGER, 'Not Applicable Match', 'Not Applicable','Not Applicable Match', 'Not Applicable Match', 'Not Applicable', NULL::VARCHAR)
+) t(match_sk, match_id, season, round_name, round_type, match_status, match_name, match_short_name, match_result)
 WHERE t.match_sk NOT IN (SELECT match_sk FROM {db}.gold.dim_match);
 
 -- Insert new matches not yet in the dim
@@ -39,7 +40,6 @@ SELECT
     src.fixture_id                                              AS match_id,
     src.season,
     src.league_round                                            AS match_round_name,
-    TRY_CAST(regexp_extract(src.league_round, '(\d+)$', 1) AS INTEGER) AS match_round_number,
     SPLIT_PART(src.league_round, ' - ', 1)                     AS match_round_type,
     src.status_long                                             AS match_status,
     src.home_team_name || ' - ' || src.away_team_name           AS match_name,


### PR DESCRIPTION
## Summary
- Removes `match_round_number` from `dim_match` — the regex extraction was inconsistent across season phases (Regular/Championship/Relegation groups all emit different numbering), causing the points progression chart to render out of order
- All ordering now uses `match_date` from `dim_date`, which is reliable
- `match_round_name` is kept as the descriptive display attribute

## Changes
- `transformations/gold/dim_match.sql` — column removed from DDL and INSERT
- `team_analytics_form.sql` — window function orders by date only
- `match_results_by_match.sql` — removed from GROUP BY and SELECT
- `team-analytics.md` — points trend x-axis → `match_date`
- `match-results.md` — goals chart x-axis → `match_date`, removed from results query

## Test plan
- [ ] Points progression chart renders correctly for all teams across seasons
- [ ] Goals by round chart shows dates on x-axis without gaps
- [ ] Gold pipeline runs cleanly after the dim_match DDL change

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)