### PR TITLE
feat: add standalone Netlify deploy workflow

### DIFF
--- a/.github/workflows/netlify.yml
+++ b/.github/workflows/netlify.yml
@@ -1,0 +1,13 @@
+name: Trigger Netlify deploy
+
+on:
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Trigger Netlify deploy hook
+        run: |
+          curl --fail -s -X POST "${{ secrets.NETLIFY_DEPLOY_HOOK }}"


### PR DESCRIPTION
## Summary
- Adds a `workflow_dispatch`-only workflow that triggers the Netlify deploy hook
- Same curl call as the publish step in the nightly pipeline, but runnable independently from the Actions tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)