### PR TITLE
feat: add sync-dev-db workflow to copy prod to dev

### DIFF
--- a/.github/workflows/sync-dev-db.yml
+++ b/.github/workflows/sync-dev-db.yml
@@ -1,0 +1,26 @@
+name: Sync dev database from prod
+
+on:
+  workflow_dispatch:
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Copy superligaen → superligaen_dev
+        env:
+          MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
+        run: python scripts/sync_dev_db.py

--- a/scripts/sync_dev_db.py
+++ b/scripts/sync_dev_db.py
@@ -31,10 +31,10 @@ def main():
 
     # Discover all base tables in prod
     prod_tables = con.execute(f"""
-        SELECT table_schema, table_name
-        FROM {PROD_DB}.information_schema.tables
-        WHERE table_type = 'BASE TABLE'
-        ORDER BY table_schema, table_name
+        SELECT schema_name, table_name
+        FROM duckdb_tables()
+        WHERE database_name = '{PROD_DB}'
+        ORDER BY schema_name, table_name
     """).fetchall()
 
     if not prod_tables:
@@ -43,12 +43,12 @@ def main():
 
     log.info("Found %d tables in %s", len(prod_tables), PROD_DB)
 
-    # Drop existing tables in dev (in reverse to respect any dependencies)
+    # Drop existing tables in dev
     dev_tables = con.execute(f"""
-        SELECT table_schema, table_name
-        FROM {DEV_DB}.information_schema.tables
-        WHERE table_type = 'BASE TABLE'
-        ORDER BY table_schema, table_name DESC
+        SELECT schema_name, table_name
+        FROM duckdb_tables()
+        WHERE database_name = '{DEV_DB}'
+        ORDER BY schema_name, table_name DESC
     """).fetchall()
 
     for schema, table in dev_tables:

--- a/scripts/sync_dev_db.py
+++ b/scripts/sync_dev_db.py
@@ -1,0 +1,75 @@
+"""
+Syncs superligaen_dev from superligaen (prod).
+
+Steps:
+  1. Discover all schemas and tables in prod
+  2. Drop all existing tables in dev
+  3. Recreate each table in dev as a full copy from prod
+"""
+
+import logging
+import os
+
+import duckdb
+from dotenv import load_dotenv
+
+load_dotenv()
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(message)s")
+log = logging.getLogger(__name__)
+
+PROD_DB = "superligaen"
+DEV_DB  = "superligaen_dev"
+
+
+def connect():
+    token = os.environ["MOTHERDUCK_TOKEN"]
+    return duckdb.connect(f"md:?motherduck_token={token}")
+
+
+def main():
+    con = connect()
+
+    # Discover all base tables in prod
+    prod_tables = con.execute(f"""
+        SELECT table_schema, table_name
+        FROM {PROD_DB}.information_schema.tables
+        WHERE table_type = 'BASE TABLE'
+        ORDER BY table_schema, table_name
+    """).fetchall()
+
+    if not prod_tables:
+        log.error("No tables found in %s — aborting", PROD_DB)
+        raise SystemExit(1)
+
+    log.info("Found %d tables in %s", len(prod_tables), PROD_DB)
+
+    # Drop existing tables in dev (in reverse to respect any dependencies)
+    dev_tables = con.execute(f"""
+        SELECT table_schema, table_name
+        FROM {DEV_DB}.information_schema.tables
+        WHERE table_type = 'BASE TABLE'
+        ORDER BY table_schema, table_name DESC
+    """).fetchall()
+
+    for schema, table in dev_tables:
+        log.info("Dropping %s.%s.%s", DEV_DB, schema, table)
+        con.execute(f"DROP TABLE IF EXISTS {DEV_DB}.{schema}.{table}")
+
+    # Ensure schemas exist in dev
+    schemas = {row[0] for row in prod_tables}
+    for schema in schemas:
+        con.execute(f"CREATE SCHEMA IF NOT EXISTS {DEV_DB}.{schema}")
+
+    # Copy each table from prod to dev
+    for schema, table in prod_tables:
+        log.info("Copying %s.%s -> %s.%s", PROD_DB, f"{schema}.{table}", DEV_DB, f"{schema}.{table}")
+        con.execute(f"""
+            CREATE OR REPLACE TABLE {DEV_DB}.{schema}.{table} AS
+            SELECT * FROM {PROD_DB}.{schema}.{table}
+        """)
+
+    log.info("Sync complete — %d tables copied from %s to %s", len(prod_tables), PROD_DB, DEV_DB)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Adds `scripts/sync_dev_db.py` — dynamically discovers all tables in `superligaen`, drops existing tables in `superligaen_dev`, and recreates them as full copies
- Adds `sync-dev-db.yml` GitHub Action — manual trigger only (`workflow_dispatch`)

## How it works
1. Queries `information_schema.tables` in prod to discover schemas/tables dynamically
2. Drops all existing tables in dev
3. Recreates each table with `CREATE OR REPLACE TABLE ... AS SELECT * FROM prod`

## Test plan
- [ ] Run workflow from Actions tab
- [ ] Verify row counts match between prod and dev after run

🤖 Generated with [Claude Code](https://claude.com/claude-code)