### PR TITLE
fix: replace Netlify deploy hook with CLI build+deploy (closes #52)

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -136,7 +136,7 @@ jobs:
         run: python transformations/run_gold.py --full-load
 
   # ---------------------------------------------------------------------------
-  # Dashboard — trigger Netlify rebuild after gold is fresh
+  # Dashboard — build and deploy to Netlify after gold is fresh
   # ---------------------------------------------------------------------------
   publish:
     name: Publish dashboard (Netlify)
@@ -144,5 +144,33 @@ jobs:
     needs: gold
 
     steps:
-      - name: Trigger Netlify deploy hook
-        run: curl -s -X POST "${{ secrets.NETLIFY_DEPLOY_HOOK }}"
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install dependencies
+        working-directory: dashboards
+        run: npm install
+
+      - name: Build sources
+        working-directory: dashboards
+        env:
+          MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
+        run: npm run sources
+
+      - name: Build dashboard
+        working-directory: dashboards
+        env:
+          MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
+        run: npm run build
+
+      - name: Deploy to Netlify
+        working-directory: dashboards
+        env:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+        run: npx netlify-cli deploy --dir=build --prod

--- a/.github/workflows/netlify.yml
+++ b/.github/workflows/netlify.yml
@@ -1,4 +1,4 @@
-name: Trigger Netlify deploy
+name: Deploy to Netlify
 
 on:
   workflow_dispatch:
@@ -6,8 +6,36 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
-      - name: Trigger Netlify deploy hook
-        run: |
-          curl --fail -s -X POST "${{ secrets.NETLIFY_DEPLOY_HOOK }}"
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install dependencies
+        working-directory: dashboards
+        run: npm install
+
+      - name: Build sources
+        working-directory: dashboards
+        env:
+          MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
+        run: npm run sources
+
+      - name: Build dashboard
+        working-directory: dashboards
+        env:
+          MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
+        run: npm run build
+
+      - name: Deploy to Netlify
+        working-directory: dashboards
+        env:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+        run: npx netlify-cli deploy --dir=build --prod


### PR DESCRIPTION
## Summary
- Replaces `curl` deploy hook with a full build+deploy via `netlify-cli` in both the standalone deploy workflow and the nightly pipeline publish job
- Netlify builds are now stopped — GitHub Actions owns the full build and deploy

## New secrets required
Add these to GitHub repo secrets before merging:
- `NETLIFY_AUTH_TOKEN` — Personal Access Token from Netlify User Settings → Applications
- `NETLIFY_SITE_ID` — API ID from Netlify Site Configuration → General

## Test plan
- [ ] Add the two secrets to GitHub
- [ ] Trigger "Deploy to Netlify" workflow manually and verify site updates
- [ ] Verify nightly pipeline publish job completes successfully

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)