### PR TITLE
fix: write MotherDuck token file before Evidence build

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -156,6 +156,12 @@ jobs:
         working-directory: dashboards
         run: npm install
 
+      - name: Write MotherDuck token
+        working-directory: dashboards
+        env:
+          MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
+        run: printf 'token: "%s"\n' "$MOTHERDUCK_TOKEN" > sources/superligaen/connection.options.yaml
+
       - name: Build sources
         working-directory: dashboards
         env:

--- a/.github/workflows/netlify.yml
+++ b/.github/workflows/netlify.yml
@@ -21,6 +21,12 @@ jobs:
         working-directory: dashboards
         run: npm install
 
+      - name: Write MotherDuck token
+        working-directory: dashboards
+        env:
+          MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
+        run: printf 'token: "%s"\n' "$MOTHERDUCK_TOKEN" > sources/superligaen/connection.options.yaml
+
       - name: Build sources
         working-directory: dashboards
         env:


### PR DESCRIPTION
## Summary
- Adds a "Write MotherDuck token" step to both `netlify.yml` and `master.yml` (publish job)
- Writes `sources/superligaen/connection.options.yaml` from the `MOTHERDUCK_TOKEN` secret before `npm run sources`
- Mirrors the pattern used in the old working Netlify build command

## Test plan
- [ ] Merge and trigger the "Deploy to Netlify" workflow manually — `npm run sources` should no longer fail with a missing token file
- [ ] Verify the nightly pipeline publish job completes successfully on next run

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)