### PR TITLE
fix: use block scalar in run command (YAML parse error)

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -160,7 +160,8 @@ jobs:
         working-directory: dashboards
         env:
           MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
-        run: printf 'token: "%s"\n' "$MOTHERDUCK_TOKEN" > sources/superligaen/connection.options.yaml
+        run: |
+          printf 'token: "%s"\n' "$MOTHERDUCK_TOKEN" > sources/superligaen/connection.options.yaml
 
       - name: Build sources
         working-directory: dashboards

--- a/.github/workflows/netlify.yml
+++ b/.github/workflows/netlify.yml
@@ -25,7 +25,8 @@ jobs:
         working-directory: dashboards
         env:
           MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
-        run: printf 'token: "%s"\n' "$MOTHERDUCK_TOKEN" > sources/superligaen/connection.options.yaml
+        run: |
+          printf 'token: "%s"\n' "$MOTHERDUCK_TOKEN" > sources/superligaen/connection.options.yaml
 
       - name: Build sources
         working-directory: dashboards


### PR DESCRIPTION
## Summary
- The `run:` command contained `token: ` (colon + space) inside the printf argument
- YAML plain scalars forbid `: ` — GitHub Actions YAML parser rejected both workflow files
- Fix: wrap the command in a `|` block scalar so contents are treated literally

## Test plan
- [ ] Merge and verify `.github/workflows/netlify.yml` and `master.yml` no longer fail on push with "workflow file issue"
- [ ] Trigger "Deploy to Netlify" workflow manually and confirm it runs through to deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)