### PR TITLE
fix: base64-encode MotherDuck token in connection.options.yaml

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -161,7 +161,7 @@ jobs:
         env:
           MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
         run: |
-          printf 'token: "%s"\n' "$MOTHERDUCK_TOKEN" > sources/superligaen/connection.options.yaml
+          echo "token: $(echo -n "$MOTHERDUCK_TOKEN" | base64 -w 0)" > sources/superligaen/connection.options.yaml
 
       - name: Build sources
         working-directory: dashboards

--- a/.github/workflows/netlify.yml
+++ b/.github/workflows/netlify.yml
@@ -26,7 +26,7 @@ jobs:
         env:
           MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
         run: |
-          printf 'token: "%s"\n' "$MOTHERDUCK_TOKEN" > sources/superligaen/connection.options.yaml
+          echo "token: $(echo -n "$MOTHERDUCK_TOKEN" | base64 -w 0)" > sources/superligaen/connection.options.yaml
 
       - name: Build sources
         working-directory: dashboards


### PR DESCRIPTION
## Summary
- Evidence's `loadConnectionOptions` calls `decodeBase64Deep()` on all values in `connection.options.yaml` — the token must be Base64-encoded, not raw
- Previous fix wrote the raw JWT; this encodes it with `base64 -w 0` (no line-wrap on Linux runners)
- Verified locally: roundtrip encode→decode produces the exact same token

## Test plan
- [ ] Merge and trigger "Deploy to Netlify" workflow manually — `npm run sources` should succeed and deploy to Netlify

🤖 Generated with [Claude Code](https://claude.com/claude-code)