### PR TITLE
fix: remove build config from netlify.toml

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,11 +1,3 @@
-[build]
-  base = "dashboards"
-  command = "npm run sources && npm run build"
-  publish = "build"
-
-[build.environment]
-  NODE_VERSION = "20"
-
 [[headers]]
   for = "/*"
   [headers.values]


### PR DESCRIPTION
## Summary
- `netlify-cli deploy` was picking up the `[build]` section in `netlify.toml` and re-running `npm run sources && npm run build` — which fails on the runner because there's no token file in that context
- Since builds are now fully owned by GitHub Actions, the `[build]` section is no longer needed

## Test plan
- [ ] Merge and trigger "Deploy to Netlify" workflow — should build once in CI and deploy cleanly without a second build attempt

🤖 Generated with [Claude Code](https://claude.com/claude-code)