### PR TITLE
Add upcoming fixtures page with H2H and form guide

### DIFF
--- a/dashboards/pages/index.md
+++ b/dashboards/pages/index.md
@@ -69,4 +69,11 @@ select * from superligaen.current_leader
   <div class="text-gray-400 text-sm">Deep-dive KPIs, form, shooting accuracy &amp; discipline</div>
 </a>
 
+<a href="/upcoming-matches" class="block no-underline rounded-xl border border-gray-300 bg-gray-100 p-6 hover:border-blue-500 hover:shadow-lg hover:bg-gray-200 transition-all duration-200 group">
+  <div class="text-4xl">📅</div>
+  <div class="text-lg font-bold mt-3 mb-1 group-hover:text-blue-400 transition-colors">Upcoming Fixtures</div>
+  <div class="text-gray-400 text-sm">Head-to-head history &amp; form guide for upcoming matches</div>
+</a>
+
 </div>
+

--- a/dashboards/pages/match-results.md
+++ b/dashboards/pages/match-results.md
@@ -92,20 +92,3 @@ order by match_date asc
     <Column id=total_corners       title="Corners"        contentType=colorscale colorPalette={['white','#a855f7']} align=center />
 </DataTable>
 
----
-
-## Upcoming Matches
-
-```sql upcoming
-select match_date, round, match_name, stadium
-from superligaen.upcoming_matches
-where season = ${inputs.season.value}
-order by match_date asc
-```
-
-<DataTable data={upcoming} rows=20>
-    <Column id=match_date title="Date"     />
-    <Column id=round      title="Round"    />
-    <Column id=match_name title="Match"    wrap=true />
-    <Column id=stadium    title="Stadium"  />
-</DataTable>

--- a/dashboards/pages/match-results.md
+++ b/dashboards/pages/match-results.md
@@ -38,13 +38,13 @@ where season = ${inputs.season.value}
 
 ```sql goals_over_time
 select
-    match_date,
+    match_round_number,
     sum(total_goals) as goals,
     round(sum(total_xg::double), 2) as xg
 from superligaen.match_results_by_match
 where season = ${inputs.season.value}
-group by match_date
-order by match_date asc
+group by match_round_number
+order by match_round_number asc
 ```
 
 ---
@@ -67,10 +67,10 @@ order by match_date asc
 
 <LineChart
     data={goals_over_time}
-    x=match_date
+    x=match_round_number
     y={['goals','xg']}
     title="Goals vs xG — {inputs.season.value}"
-    xAxisTitle="Date"
+    xAxisTitle="Round"
     yAxisTitle="Goals"
     colorPalette={['#22c55e','#3b82f6']}
 />

--- a/dashboards/pages/upcoming-matches.md
+++ b/dashboards/pages/upcoming-matches.md
@@ -1,0 +1,176 @@
+---
+title: Upcoming Fixtures
+---
+
+<a href="/" class="inline-flex items-center gap-1 text-sm text-gray-500 hover:text-gray-800 no-underline mb-6 transition-colors">← Back to Home</a>
+
+```sql upcoming
+select
+    strftime(match_date, '%Y-%m-%d')                                              as match_date,
+    round,
+    match_name,
+    home_team,
+    away_team,
+    match_key,
+    CASE WHEN stadium LIKE '%Unknown%' OR stadium LIKE '%Applicable%'
+         THEN 'TBD' ELSE stadium END                                               as stadium,
+    season
+from superligaen.upcoming_matches
+order by match_date asc
+```
+
+## Upcoming Fixtures
+
+<DataTable data={upcoming} rows=10>
+    <Column id=match_date  title="Date"    />
+    <Column id=round       title="Round"   />
+    <Column id=home_team   title="Home"    />
+    <Column id=away_team   title="Away"    />
+    <Column id=stadium     title="Stadium" />
+</DataTable>
+
+---
+
+## Match Analysis
+
+<Dropdown data={upcoming} name=match value=match_key label=match_name />
+
+```sql match_info
+select
+    home_team,
+    away_team,
+    strftime(match_date, '%d %b %Y')                          as match_date,
+    round,
+    CASE WHEN stadium LIKE '%Unknown%' OR stadium LIKE '%Applicable%'
+         THEN 'TBD' ELSE stadium END                          as stadium
+from superligaen.upcoming_matches
+where match_key = '${inputs.match.value}'
+limit 1
+```
+
+```sql h2h
+select
+    season::INTEGER::VARCHAR as season,
+    match_date,
+    round,
+    match_short_name    as match,
+    score,
+    total_goals         as goals,
+    total_shots_on_goal as shots_on_goal,
+    total_xg            as xg
+from superligaen.match_results_by_match
+where
+    (match_name = SPLIT_PART('${inputs.match.value}', '|||', 1) || ' - ' || SPLIT_PART('${inputs.match.value}', '|||', 2))
+ or (match_name = SPLIT_PART('${inputs.match.value}', '|||', 2) || ' - ' || SPLIT_PART('${inputs.match.value}', '|||', 1))
+order by match_date desc
+```
+
+```sql h2h_stats
+select
+    SUM(CASE WHEN (team_name = SPLIT_PART('${inputs.match.value}', '|||', 1) AND result = 'Win')
+              OR  (team_name = SPLIT_PART('${inputs.match.value}', '|||', 2) AND result = 'Loss') THEN 1 ELSE 0 END) as team1_wins,
+    SUM(CASE WHEN result = 'Draw' THEN 1 ELSE 0 END)                                                                as draws,
+    SUM(CASE WHEN (team_name = SPLIT_PART('${inputs.match.value}', '|||', 2) AND result = 'Win')
+              OR  (team_name = SPLIT_PART('${inputs.match.value}', '|||', 1) AND result = 'Loss') THEN 1 ELSE 0 END) as team2_wins
+from superligaen.team_analytics_form
+where side = 'Home'
+  and (
+      (team_name = SPLIT_PART('${inputs.match.value}', '|||', 1) and opponent = SPLIT_PART('${inputs.match.value}', '|||', 2))
+   or (team_name = SPLIT_PART('${inputs.match.value}', '|||', 2) and opponent = SPLIT_PART('${inputs.match.value}', '|||', 1))
+  )
+```
+
+```sql home_form
+select
+    strftime(match_date, '%Y-%m-%d') as match_date,
+    match_name                       as match,
+    score
+from superligaen.match_results_by_match
+where match_name LIKE SPLIT_PART('${inputs.match.value}', '|||', 1) || ' - %'
+   or match_name LIKE '% - ' || SPLIT_PART('${inputs.match.value}', '|||', 1)
+order by match_date desc
+limit 5
+```
+
+```sql away_form
+select
+    strftime(match_date, '%Y-%m-%d') as match_date,
+    match_name                       as match,
+    score
+from superligaen.match_results_by_match
+where match_name LIKE SPLIT_PART('${inputs.match.value}', '|||', 2) || ' - %'
+   or match_name LIKE '% - ' || SPLIT_PART('${inputs.match.value}', '|||', 2)
+order by match_date desc
+limit 5
+```
+
+<div class="rounded-2xl border border-gray-200 bg-gray-50 p-6 mb-6 text-center">
+  <div class="text-xs text-gray-400 uppercase tracking-widest mb-3">{match_info[0].round} &middot; {match_info[0].match_date} &middot; {match_info[0].stadium}</div>
+  <div class="flex items-center justify-center gap-6">
+    <div>
+      <div class="text-xl font-bold text-gray-800">{match_info[0].home_team}</div>
+      <div class="text-xs text-blue-400 font-semibold uppercase tracking-widest mt-1">Home</div>
+    </div>
+    <div class="text-2xl font-black text-gray-300">vs</div>
+    <div>
+      <div class="text-xl font-bold text-gray-800">{match_info[0].away_team}</div>
+      <div class="text-xs text-red-400 font-semibold uppercase tracking-widest mt-1">Away</div>
+    </div>
+  </div>
+</div>
+
+---
+
+### Head-to-Head History
+
+<div class="grid grid-cols-3 gap-4 mb-6">
+  <div class="rounded-xl border border-blue-200 bg-blue-50 p-4 text-center">
+    <div class="text-3xl font-black text-blue-600">{h2h_stats[0].team1_wins}</div>
+    <div class="text-xs text-blue-400 mt-1 font-semibold uppercase tracking-wide">{match_info[0].home_team} Wins</div>
+  </div>
+  <div class="rounded-xl border border-gray-200 bg-gray-100 p-4 text-center">
+    <div class="text-3xl font-black text-gray-500">{h2h_stats[0].draws}</div>
+    <div class="text-xs text-gray-400 mt-1 font-semibold uppercase tracking-wide">Draws</div>
+  </div>
+  <div class="rounded-xl border border-red-200 bg-red-50 p-4 text-center">
+    <div class="text-3xl font-black text-red-500">{h2h_stats[0].team2_wins}</div>
+    <div class="text-xs text-red-400 mt-1 font-semibold uppercase tracking-wide">{match_info[0].away_team} Wins</div>
+  </div>
+</div>
+
+<DataTable data={h2h} rows=20>
+    <Column id=season         title="Season" />
+    <Column id=match_date     title="Date"   />
+    <Column id=round          title="Round"  />
+    <Column id=match          title="Match"  />
+    <Column id=score          title="Score"  align=center />
+    <Column id=goals          title="Goals"  contentType=colorscale colorPalette={['white','#22c55e']} align=center />
+    <Column id=shots_on_goal  title="SoG"    contentType=bar colorPalette={['#6366f1']} />
+    <Column id=xg             title="xG"     contentType=colorscale colorPalette={['white','#3b82f6']} />
+</DataTable>
+
+---
+
+### Form Guide — Last 5 Matches
+
+<div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+
+<div class="rounded-xl border border-gray-200 bg-gray-50 p-4">
+  <div class="text-base font-bold text-gray-700 mb-3">{match_info[0].home_team}</div>
+  <DataTable data={home_form} rows=5>
+      <Column id=match_date  title="Date"  />
+      <Column id=match       title="Match" />
+      <Column id=score       title="Score" align=center />
+  </DataTable>
+</div>
+
+<div class="rounded-xl border border-gray-200 bg-gray-50 p-4">
+  <div class="text-base font-bold text-gray-700 mb-3">{match_info[0].away_team}</div>
+  <DataTable data={away_form} rows=5>
+      <Column id=match_date  title="Date"  />
+      <Column id=match       title="Match" />
+      <Column id=score       title="Score" align=center />
+  </DataTable>
+</div>
+
+</div>

--- a/dashboards/sources/superligaen/match_results_by_match.sql
+++ b/dashboards/sources/superligaen/match_results_by_match.sql
@@ -2,6 +2,7 @@ select
     d.full_date                                     as match_date,
     m.match_round_name                              as round,
     m.match_name,
+    m.match_short_name,
     m.match_result                                  as score,
     sum(f.shots_on_goal)                            as total_shots_on_goal,
     sum(f.yellow_cards)                             as total_yellow_cards,
@@ -15,5 +16,5 @@ join superligaen.gold.dim_match        m on m.match_sk        = f.match_sk
 join superligaen.gold.dim_date         d on d.date_sk         = f.date_sk
 join superligaen.gold.dim_match_result r on r.match_result_sk = f.match_result_sk
 where r.match_result in ('Win', 'Draw', 'Loss')
-group by d.full_date, m.match_round_name, m.match_name, m.match_result, m.season
+group by d.full_date, m.match_round_name, m.match_name, m.match_short_name, m.match_result, m.season
 order by d.full_date desc

--- a/dashboards/sources/superligaen/match_results_by_match.sql
+++ b/dashboards/sources/superligaen/match_results_by_match.sql
@@ -1,6 +1,7 @@
 select
     d.full_date                                     as match_date,
     m.match_round_name                              as round,
+    m.match_round_number,
     m.match_name,
     m.match_short_name,
     m.match_result                                  as score,
@@ -16,5 +17,5 @@ join superligaen.gold.dim_match        m on m.match_sk        = f.match_sk
 join superligaen.gold.dim_date         d on d.date_sk         = f.date_sk
 join superligaen.gold.dim_match_result r on r.match_result_sk = f.match_result_sk
 where r.match_result in ('Win', 'Draw', 'Loss')
-group by d.full_date, m.match_round_name, m.match_name, m.match_short_name, m.match_result, m.season
+group by d.full_date, m.match_round_name, m.match_round_number, m.match_name, m.match_short_name, m.match_result, m.season
 order by d.full_date desc

--- a/dashboards/sources/superligaen/upcoming_matches.sql
+++ b/dashboards/sources/superligaen/upcoming_matches.sql
@@ -1,14 +1,21 @@
 select
-    d.full_date             as match_date,
-    m.match_round_name      as round,
+    d.full_date                                                               as match_date,
+    m.match_round_name                                                        as round,
     m.match_name,
-    st.stadium_name         as stadium,
+    MAX(CASE WHEN ts.team_side = 'Home' THEN t.team_name END)                as home_team,
+    MAX(CASE WHEN ts.team_side = 'Away' THEN t.team_name END)                as away_team,
+    MAX(CASE WHEN ts.team_side = 'Home' THEN t.team_name END)
+        || '|||'
+        || MAX(CASE WHEN ts.team_side = 'Away' THEN t.team_name END)         as match_key,
+    st.stadium_name                                                           as stadium,
     m.season
 from superligaen.gold.fct_match_results f
-join superligaen.gold.dim_match        m  on m.match_sk    = f.match_sk
-join superligaen.gold.dim_date         d  on d.date_sk     = f.date_sk
-join superligaen.gold.dim_stadium      st on st.stadium_sk = f.stadium_sk
+join superligaen.gold.dim_match        m  on m.match_sk       = f.match_sk
+join superligaen.gold.dim_date         d  on d.date_sk        = f.date_sk
+join superligaen.gold.dim_stadium      st on st.stadium_sk    = f.stadium_sk
 join superligaen.gold.dim_match_result r  on r.match_result_sk = f.match_result_sk
+join superligaen.gold.dim_team         t  on t.team_sk        = f.team_sk
+join superligaen.gold.dim_team_side    ts on ts.team_side_sk  = f.team_side_sk
 where r.match_result = 'Pending'
-group by all
+group by d.full_date, m.match_round_name, m.match_name, st.stadium_name, m.season
 order by d.full_date asc


### PR DESCRIPTION
## Summary
- New `/upcoming-matches` page: fixtures table, match selector dropdown, head-to-head history (stats summary + detailed table), and side-by-side last-5 form guide for both teams
- `upcoming_matches` source extended with `home_team`, `away_team`, `match_key` columns
- `match_results_by_match` source extended with `match_short_name`
- Home page: added Upcoming Fixtures nav card, removed Next Fixtures section
- Match Results page: removed Upcoming Matches section (moved to dedicated page)

## Test plan
- [ ] Home page shows Upcoming Fixtures card linking to `/upcoming-matches`
- [ ] Upcoming fixtures table shows 10 rows with `yyyy-mm-dd` dates
- [ ] Match selector dropdown updates H2H and form sections
- [ ] H2H summary shows W/D/W counts correctly
- [ ] H2H table shows season (no decimals), date, short match name, score, goals, SoG, xG
- [ ] Form guide shows last 5 matches for each team with long match name and score
- [ ] Match Results page no longer has Upcoming section

🤖 Generated with [Claude Code](https://claude.com/claude-code)