### PR TITLE
Remove invalid layout key from evidence.config.yaml

### DIFF
--- a/dashboards/evidence.config.yaml
+++ b/dashboards/evidence.config.yaml
@@ -2,9 +2,6 @@ appearance:
   default: system
   switcher: true
 
-layout:
-  sidebar: false
-
 theme:
   colorPalettes:
     default:


### PR DESCRIPTION
## Summary
- Removes the `layout: sidebar: false` block that was causing Cloudflare build failures (`Invalid evidence.config.yaml: layout: Invalid input`)
- Sidebar hiding is handled via per-page `sidebar: never` frontmatter instead

## Test plan
- [ ] Merge and trigger Cloudflare deploy — build should pass