### PR TITLE
Fix percentage formatting in team analytics

### DIFF
--- a/dashboards/pages/team-analytics.md
+++ b/dashboards/pages/team-analytics.md
@@ -56,14 +56,14 @@ order by side desc
   <div class="rounded-xl border border-gray-300 bg-gray-100 p-4 text-center"><BigValue data={kpis} value=goals_for        title="Goals Scored"    /></div>
   <div class="rounded-xl border border-gray-300 bg-gray-100 p-4 text-center"><BigValue data={kpis} value=goals_against    title="Goals Conceded"  /></div>
   <div class="rounded-xl border border-gray-300 bg-gray-100 p-4 text-center"><BigValue data={kpis} value=goal_difference  title="Goal Difference" /></div>
-  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4 text-center"><BigValue data={kpis} value=win_rate_pct     title="Win Rate"        fmt=pct0 /></div>
+  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4 text-center"><BigValue data={kpis} value=win_rate_pct     title="Win Rate"        fmt='0.0"%"' /></div>
 </div>
 
 <div class="grid grid-cols-2 md:grid-cols-4 gap-4 mb-4">
-  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4 text-center"><BigValue data={kpis} value=avg_possession       title="Avg Possession"    fmt=pct0 /></div>
-  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4 text-center"><BigValue data={kpis} value=avg_pass_accuracy    title="Pass Accuracy"     fmt=pct0 /></div>
-  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4 text-center"><BigValue data={kpis} value=shot_conversion_pct  title="Shot Conversion"   fmt=pct0 /></div>
-  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4 text-center"><BigValue data={kpis} value=on_target_conversion_pct title="On-Target Conv." fmt=pct0 /></div>
+  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4 text-center"><BigValue data={kpis} value=avg_possession       title="Avg Possession"    fmt='0.0"%"' /></div>
+  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4 text-center"><BigValue data={kpis} value=avg_pass_accuracy    title="Pass Accuracy"     fmt='0.0"%"' /></div>
+  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4 text-center"><BigValue data={kpis} value=shot_conversion_pct  title="Shot Conversion"   fmt='0.0"%"' /></div>
+  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4 text-center"><BigValue data={kpis} value=on_target_conversion_pct title="On-Target Conv." fmt='0.0"%"' /></div>
   <div class="rounded-xl border border-gray-300 bg-gray-100 p-4 text-center"><BigValue data={kpis} value=total_xg             title="Total xG"          /></div>
   <div class="rounded-xl border border-gray-300 bg-gray-100 p-4 text-center"><BigValue data={kpis} value=xg_overperformance   title="xG Overperformance" /></div>
   <div class="rounded-xl border border-gray-300 bg-gray-100 p-4 text-center"><BigValue data={kpis} value=aggression_index     title="Aggression Index"  /></div>
@@ -118,7 +118,7 @@ limit 10
     <Column id=result       title="Result"     />
     <Column id=xg           title="xG"         />
     <Column id=shots_on_goal title="SoG"       />
-    <Column id=possession   title="Poss %"     />
+    <Column id=possession   title="Poss %"     fmt='0.0"%"' />
     <Column id=fouls        title="Fouls"      />
     <Column id=yellow_cards title="YC"         />
     <Column id=red_cards    title="RC"         />
@@ -132,7 +132,7 @@ limit 10
   <div class="rounded-xl border border-gray-300 bg-gray-100 p-4 text-center"><BigValue data={kpis} value=avg_xg_per_match      title="xG per Match"        /></div>
   <div class="rounded-xl border border-gray-300 bg-gray-100 p-4 text-center"><BigValue data={kpis} value=avg_shots_on_goal     title="Shots on Goal/Match" /></div>
   <div class="rounded-xl border border-gray-300 bg-gray-100 p-4 text-center"><BigValue data={kpis} value=avg_goals_scored      title="Goals Scored/Match"  /></div>
-  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4 text-center"><BigValue data={kpis} value=shot_conversion_pct   title="Shot Conversion %"   fmt=pct0 /></div>
+  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4 text-center"><BigValue data={kpis} value=shot_conversion_pct   title="Shot Conversion %"   fmt='0.0"%"' /></div>
 </div>
 
 <BarChart
@@ -210,8 +210,8 @@ where team_name = '${inputs.team.value}' and season = ${inputs.season.value}
 ## Passing & Possession
 
 <div class="grid grid-cols-2 md:grid-cols-4 gap-4 mb-4">
-  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4 text-center"><BigValue data={kpis} value=avg_possession     title="Avg Possession %"  fmt=pct0 /></div>
-  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4 text-center"><BigValue data={kpis} value=avg_pass_accuracy  title="Avg Pass Accuracy" fmt=pct0 /></div>
+  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4 text-center"><BigValue data={kpis} value=avg_possession     title="Avg Possession %"  fmt='0.0"%"' /></div>
+  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4 text-center"><BigValue data={kpis} value=avg_pass_accuracy  title="Avg Pass Accuracy" fmt='0.0"%"' /></div>
   <div class="rounded-xl border border-gray-300 bg-gray-100 p-4 text-center"><BigValue data={kpis} value=avg_corners        title="Corners/Match"               /></div>
   <div class="rounded-xl border border-gray-300 bg-gray-100 p-4 text-center"><BigValue data={kpis} value=avg_offsides       title="Offsides/Match"              /></div>
 </div>
@@ -279,11 +279,11 @@ where team_name = '${inputs.team.value}' and season = ${inputs.season.value}
     <Column id=losses             title="L"                />
     <Column id=goals_for          title="GF"               />
     <Column id=goals_against      title="GA"               />
-    <Column id=win_rate_pct       title="Win %"            />
-    <Column id=avg_possession     title="Avg Poss %"       />
+    <Column id=win_rate_pct       title="Win %"            fmt='0.0"%"' />
+    <Column id=avg_possession     title="Avg Poss %"       fmt='0.0"%"' />
     <Column id=avg_shots_on_goal  title="Avg SoG"          />
     <Column id=avg_xg             title="Avg xG"           />
-    <Column id=shot_conversion_pct title="Shot Conv %"     />
+    <Column id=shot_conversion_pct title="Shot Conv %"     fmt='0.0"%"' />
     <Column id=avg_fouls          title="Avg Fouls"        />
     <Column id=yellow_cards       title="YC"               />
     <Column id=red_cards          title="RC"               />


### PR DESCRIPTION
## Summary
- `fmt=pct0` multiplies by 100 before adding `%` (designed for 0–1 fractions), but all percentage columns are stored on a 0–100 scale — causing values like 54.8% to display as 5,480%
- Replaced with `fmt='0.0"%"'` (Excel literal `%` format) which appends `%` without any multiplication
- Applied to all `BigValue` and `Column` components using percentage fields: win rate, possession, pass accuracy, shot conversion, on-target conversion

## Test plan
- [ ] Win Rate, Avg Possession, Pass Accuracy, Shot Conversion should show e.g. "54.8%" not "5,480%"