### PR TITLE
Add response logging to Vercel deploy hook

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -145,4 +145,6 @@ jobs:
 
     steps:
       - name: Trigger Vercel deployment
-        run: curl -X POST "${{ secrets.VERCEL_DEPLOY_HOOK }}"
+        run: |
+          response=$(curl -sf -X POST "${{ secrets.VERCEL_DEPLOY_HOOK }}")
+          echo "Response: $response"

--- a/.github/workflows/vercel.yml
+++ b/.github/workflows/vercel.yml
@@ -9,4 +9,6 @@ jobs:
 
     steps:
       - name: Trigger Vercel deployment
-        run: curl -X POST "${{ secrets.VERCEL_DEPLOY_HOOK }}"
+        run: |
+          response=$(curl -sf -X POST "${{ secrets.VERCEL_DEPLOY_HOOK }}")
+          echo "Response: $response"


### PR DESCRIPTION
## Summary
- Adds `-sf` flags and logs the curl response so we can see whether the hook URL is valid and what Vercel returns
- A successful Vercel deploy hook returns `{"job":{"id":"...","state":"PENDING"}}` — if we see an error or empty response instead, the hook URL needs to be recreated in Vercel project settings

## Test plan
- [ ] Merge, trigger "Deploy to Vercel" workflow, check the step output for the response JSON