### PR TITLE
Improve mobile responsiveness

### DIFF
--- a/dashboards/pages/index.md
+++ b/dashboards/pages/index.md
@@ -24,20 +24,20 @@ where season = (select max(season) from superligaen.match_results_by_match)
 select * from superligaen.current_leader
 ```
 
-<div class="relative rounded-2xl bg-gradient-to-br from-gray-900 via-gray-800 to-gray-900 p-10 mb-6 shadow-xl">
+<div class="relative rounded-2xl bg-gradient-to-br from-gray-900 via-gray-800 to-gray-900 p-6 md:p-10 mb-6 shadow-xl">
   <div class="absolute top-4 right-4 bg-white/10 rounded-xl p-2 backdrop-blur">
-    <img src="{league[0].league_logo}" alt="Superligaen" class="h-12" />
+    <img src="{league[0].league_logo}" alt="Superligaen" class="h-8 md:h-12" />
   </div>
-  <div class="flex items-center justify-center gap-6">
-    <img src="{league[0].league_country_flag}" alt="Denmark" class="h-10 rounded-lg shadow-lg opacity-90" />
+  <div class="flex items-center justify-center gap-4 md:gap-6">
+    <img src="{league[0].league_country_flag}" alt="Denmark" class="h-7 md:h-10 rounded-lg shadow-lg opacity-90" />
     <div class="text-center">
-      <div class="text-5xl font-extrabold tracking-tight text-white">Superligaen</div>
-      <div class="text-gray-400 text-sm mt-3 uppercase tracking-widest">Danish Football Premier League</div>
+      <div class="text-3xl md:text-5xl font-extrabold tracking-tight text-white">Superligaen</div>
+      <div class="text-gray-400 text-xs md:text-sm mt-2 md:mt-3 uppercase tracking-widest">Danish Football Premier League</div>
       <div class="inline-block mt-2 px-3 py-1 rounded-full bg-blue-500/20 border border-blue-400/30 text-blue-300 text-sm font-semibold">
         Current Season: {kpis[0].season}
       </div>
     </div>
-    <img src="{league[0].league_country_flag}" alt="Denmark" class="h-10 rounded-lg shadow-lg opacity-90" />
+    <img src="{league[0].league_country_flag}" alt="Denmark" class="h-7 md:h-10 rounded-lg shadow-lg opacity-90" />
   </div>
 </div>
 

--- a/dashboards/pages/upcoming-matches.md
+++ b/dashboards/pages/upcoming-matches.md
@@ -106,16 +106,16 @@ order by match_date desc
 limit 5
 ```
 
-<div class="rounded-2xl border border-gray-200 bg-gray-50 p-6 mb-6 text-center">
+<div class="rounded-2xl border border-gray-200 bg-gray-50 p-4 md:p-6 mb-6 text-center">
   <div class="text-xs text-gray-400 uppercase tracking-widest mb-3">{match_info[0].round} &middot; {match_info[0].match_date} &middot; {match_info[0].stadium}</div>
-  <div class="flex items-center justify-center gap-6">
-    <div>
-      <div class="text-xl font-bold text-gray-800">{match_info[0].home_team}</div>
+  <div class="flex items-center justify-center gap-4 md:gap-6">
+    <div class="flex-1 min-w-0">
+      <div class="text-base md:text-xl font-bold text-gray-800 truncate">{match_info[0].home_team}</div>
       <div class="text-xs text-blue-400 font-semibold uppercase tracking-widest mt-1">Home</div>
     </div>
-    <div class="text-2xl font-black text-gray-300">vs</div>
-    <div>
-      <div class="text-xl font-bold text-gray-800">{match_info[0].away_team}</div>
+    <div class="text-xl md:text-2xl font-black text-gray-300 shrink-0">vs</div>
+    <div class="flex-1 min-w-0">
+      <div class="text-base md:text-xl font-bold text-gray-800 truncate">{match_info[0].away_team}</div>
       <div class="text-xs text-red-400 font-semibold uppercase tracking-widest mt-1">Away</div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- **Home banner**: padding `p-10 → p-6 md:p-10`, title `text-5xl → text-3xl md:text-5xl`, flags/logo scaled down on small screens
- **Upcoming matches banner**: team names use `flex-1 min-w-0 truncate` to prevent overflow on narrow screens; `vs` divider uses `shrink-0`
- All KPI grids already used `grid-cols-2 md:grid-cols-4` — no changes needed there
- DataTable and chart components from Evidence handle their own overflow

## Test plan
- [ ] Check home page on mobile viewport — banner should fit without overflow
- [ ] Check upcoming matches page on mobile — team names should truncate cleanly