### PR TITLE
Add season_name attribute (2025/26 format)

### DIFF
--- a/dashboards/pages/index.md
+++ b/dashboards/pages/index.md
@@ -15,7 +15,8 @@ select
     (select count(distinct team_name)
      from superligaen.team_analytics_form
      where season = (select max(season) from superligaen.match_results_by_match)) as total_teams,
-    max(season)                                                           as season
+    max(season)                                                           as season,
+    max(season_name)                                                      as season_name
 from superligaen.match_results_by_match
 where season = (select max(season) from superligaen.match_results_by_match)
 ```

--- a/dashboards/pages/index.md
+++ b/dashboards/pages/index.md
@@ -34,7 +34,7 @@ select * from superligaen.current_leader
       <div class="text-3xl md:text-5xl font-extrabold tracking-tight text-white">Superligaen</div>
       <div class="text-gray-400 text-xs md:text-sm mt-2 md:mt-3 uppercase tracking-widest">Danish Football Premier League</div>
       <div class="inline-block mt-2 px-3 py-1 rounded-full bg-blue-500/20 border border-blue-400/30 text-blue-300 text-sm font-semibold">
-        Current Season: {kpis[0].season}
+        Current Season: {kpis[0].season_name}
       </div>
     </div>
     <img src="{league[0].league_country_flag}" alt="Denmark" class="h-7 md:h-10 rounded-lg shadow-lg opacity-90" />

--- a/dashboards/pages/match-results.md
+++ b/dashboards/pages/match-results.md
@@ -7,12 +7,12 @@ title: Match Results
 <a href="/" class="inline-flex items-center gap-1 text-sm text-gray-500 hover:text-gray-800 no-underline mb-6 transition-colors">← Back to Home</a>
 
 ```sql seasons
-select distinct season from superligaen.match_results_by_match
+select distinct season, season_name from superligaen.match_results_by_match
 order by season desc
 ```
 
-<Dropdown data={seasons} name=season value=season label=season>
-    <DropdownOption value=2025 valueLabel="2025"/>
+<Dropdown data={seasons} name=season value=season label=season_name>
+    <DropdownOption value=2025 valueLabel="2025/26"/>
 </Dropdown>
 
 ```sql results
@@ -51,7 +51,7 @@ order by match_round_number asc
 
 ---
 
-## Season {inputs.season.value} at a Glance
+## Season {inputs.season.label} at a Glance
 
 <div class="grid grid-cols-2 md:grid-cols-4 gap-4 mb-4">
   <div class="rounded-xl border border-gray-300 bg-gray-100 p-4 text-center"><BigValue data={season_kpis} value=total_matches       title="Matches Played"    /></div>
@@ -71,7 +71,7 @@ order by match_round_number asc
     data={goals_over_time}
     x=match_round_number
     y={['goals','xg']}
-    title="Goals vs xG — {inputs.season.value}"
+    title="Goals vs xG — {inputs.season.label}"
     xAxisTitle="Round"
     yAxisTitle="Goals"
     colorPalette={['#22c55e','#3b82f6']}
@@ -79,7 +79,7 @@ order by match_round_number asc
 
 ---
 
-## Match Results — {inputs.season.value}
+## Match Results — {inputs.season.label}
 
 <DataTable data={results} rows=20 search=true>
     <Column id=match_date          title="Date"           />

--- a/dashboards/pages/standings.md
+++ b/dashboards/pages/standings.md
@@ -7,12 +7,12 @@ title: Standings
 <a href="/" class="inline-flex items-center gap-1 text-sm text-gray-500 hover:text-gray-800 no-underline mb-6 transition-colors">← Back to Home</a>
 
 ```sql seasons
-select distinct season from superligaen.team_season_stats
+select distinct season, season_name from superligaen.team_season_stats
 order by season desc
 ```
 
-<Dropdown data={seasons} name=season value=season label=season>
-    <DropdownOption value=2025 valueLabel="2025"/>
+<Dropdown data={seasons} name=season value=season label=season_name>
+    <DropdownOption value=2025 valueLabel="2025/26"/>
 </Dropdown>
 
 ```sql standings

--- a/dashboards/pages/standings.md
+++ b/dashboards/pages/standings.md
@@ -22,7 +22,7 @@ select
     gp, w, d, l, gf, ga, gd, pts,
     round_group
 from superligaen.team_season_stats
-where season = ${inputs.season.label}
+where season = ${inputs.season.value}
 order by round_group, pts desc, gd desc, gf desc
 ```
 
@@ -43,7 +43,7 @@ select
     row_number() over (order by pts desc, gd desc, gf desc) as rank,
     team_name as team, gp, w, d, l, gf, ga, gd, pts
 from superligaen.team_regular_season_stats
-where season = ${inputs.season.label}
+where season = ${inputs.season.value}
 ```
 
 ```sql all_teams

--- a/dashboards/pages/standings.md
+++ b/dashboards/pages/standings.md
@@ -22,7 +22,7 @@ select
     gp, w, d, l, gf, ga, gd, pts,
     round_group
 from superligaen.team_season_stats
-where season = ${inputs.season.value}
+where season = ${inputs.season.label}
 order by round_group, pts desc, gd desc, gf desc
 ```
 
@@ -43,7 +43,7 @@ select
     row_number() over (order by pts desc, gd desc, gf desc) as rank,
     team_name as team, gp, w, d, l, gf, ga, gd, pts
 from superligaen.team_regular_season_stats
-where season = ${inputs.season.value}
+where season = ${inputs.season.label}
 ```
 
 ```sql all_teams
@@ -51,7 +51,7 @@ select team, pts, gf, ga, round_group from ${standings}
 order by round_group, pts desc
 ```
 
-## {inputs.season.value} Season Standings
+## {inputs.season.label} Season Standings
 
 {#if championship.length > 0}
 
@@ -117,7 +117,7 @@ order by round_group, pts desc
     x=team
     y=pts
     series=round_group
-    title="Points by Team — {inputs.season.value}"
+    title="Points by Team — {inputs.season.label}"
     yAxisTitle="Points"
     xAxisTitle="Team"
     sort=false
@@ -128,7 +128,7 @@ order by round_group, pts desc
     data={all_teams}
     x=team
     y={['gf','ga']}
-    title="Goals For vs Goals Against — {inputs.season.value}"
+    title="Goals For vs Goals Against — {inputs.season.label}"
     yAxisTitle="Goals"
     xAxisTitle="Team"
     sort=false

--- a/dashboards/pages/team-analytics.md
+++ b/dashboards/pages/team-analytics.md
@@ -7,7 +7,7 @@ title: Team Analytics
 <a href="/" class="inline-flex items-center gap-1 text-sm text-gray-500 hover:text-gray-800 no-underline mb-6 transition-colors">← Back to Home</a>
 
 ```sql seasons
-select distinct season from superligaen.team_analytics_kpis
+select distinct season, season_name from superligaen.team_analytics_kpis
 order by season desc
 ```
 
@@ -16,8 +16,8 @@ select distinct team_name as team from superligaen.team_analytics_kpis
 order by team_name
 ```
 
-<Dropdown data={seasons} name=season value=season label=season>
-    <DropdownOption value=2025 valueLabel="2025"/>
+<Dropdown data={seasons} name=season value=season label=season_name>
+    <DropdownOption value=2025 valueLabel="2025/26"/>
 </Dropdown>
 
 <Dropdown data={teams} name=team value=team label=team>

--- a/dashboards/pages/upcoming-matches.md
+++ b/dashboards/pages/upcoming-matches.md
@@ -52,7 +52,7 @@ limit 1
 
 ```sql h2h
 select
-    season::INTEGER::VARCHAR as season,
+    season_name             as season,
     match_date,
     round,
     match_short_name    as match,

--- a/dashboards/sources/superligaen/kpis.sql
+++ b/dashboards/sources/superligaen/kpis.sql
@@ -5,7 +5,8 @@ select
         sum(f.total_shots)::decimal / nullif(count(distinct f.match_sk), 0),
         1
     )                                                                           as avg_shots_per_match,
-    max(m.season)                                                               as season
+    max(m.season)                                                               as season,
+    max(m.season_name)                                                          as season_name
 from superligaen.gold.fct_match_results f
 join superligaen.gold.dim_match        m on m.match_sk        = f.match_sk
 join superligaen.gold.dim_match_result r on r.match_result_sk = f.match_result_sk

--- a/dashboards/sources/superligaen/match_results_by_match.sql
+++ b/dashboards/sources/superligaen/match_results_by_match.sql
@@ -11,11 +11,12 @@ select
     sum(f.corner_kicks)                             as total_corners,
     round(sum(f.expected_goals::double), 2)         as total_xg,
     sum(f.goals_scored)                             as total_goals,
-    m.season
+    m.season,
+    m.season_name
 from superligaen.gold.fct_match_results f
 join superligaen.gold.dim_match        m on m.match_sk        = f.match_sk
 join superligaen.gold.dim_date         d on d.date_sk         = f.date_sk
 join superligaen.gold.dim_match_result r on r.match_result_sk = f.match_result_sk
 where r.match_result in ('Win', 'Draw', 'Loss')
-group by d.full_date, m.match_round_name, m.match_round_number, m.match_name, m.match_short_name, m.match_result, m.season
+group by d.full_date, m.match_round_name, m.match_round_number, m.match_name, m.match_short_name, m.match_result, m.season, m.season_name
 order by d.full_date desc

--- a/dashboards/sources/superligaen/team_analytics_form.sql
+++ b/dashboards/sources/superligaen/team_analytics_form.sql
@@ -27,7 +27,8 @@ select
         order by d.full_date
         rows between unbounded preceding and current row
     )                                                                       as cumulative_points,
-    m.season
+    m.season,
+    m.season_name
 from superligaen.gold.fct_match_results f
 join superligaen.gold.dim_team          t   on t.team_sk          = f.team_sk
 join superligaen.gold.dim_opponent_team ot  on ot.opponent_team_sk = f.opponent_team_sk

--- a/dashboards/sources/superligaen/team_analytics_home_away.sql
+++ b/dashboards/sources/superligaen/team_analytics_home_away.sql
@@ -2,6 +2,7 @@ select
     t.team_name,
     ts.team_side                                                                    as side,
     m.season,
+    m.season_name,
     count(*)                                                                        as matches,
     sum(f.points_earned)                                                            as points,
     count(*) filter (where r.match_result = 'Win')                                  as wins,
@@ -24,5 +25,5 @@ join superligaen.gold.dim_match         m   on m.match_sk         = f.match_sk
 join superligaen.gold.dim_match_result  r   on r.match_result_sk  = f.match_result_sk
 join superligaen.gold.dim_team_side     ts  on ts.team_side_sk    = f.team_side_sk
 where r.match_result in ('Win', 'Draw', 'Loss')
-group by t.team_name, ts.team_side, m.season
+group by t.team_name, ts.team_side, m.season, m.season_name
 order by t.team_name, m.season, ts.team_side

--- a/dashboards/sources/superligaen/team_analytics_kpis.sql
+++ b/dashboards/sources/superligaen/team_analytics_kpis.sql
@@ -1,6 +1,7 @@
 select
     t.team_name,
     m.season,
+    m.season_name,
     count(*)                                                                        as matches_played,
     sum(f.points_earned)                                                            as total_points,
     count(*) filter (where r.match_result = 'Win')                                  as wins,
@@ -39,5 +40,5 @@ join superligaen.gold.dim_team         t  on t.team_sk          = f.team_sk
 join superligaen.gold.dim_match        m  on m.match_sk         = f.match_sk
 join superligaen.gold.dim_match_result r  on r.match_result_sk  = f.match_result_sk
 where r.match_result in ('Win', 'Draw', 'Loss')
-group by t.team_name, m.season
+group by t.team_name, m.season, m.season_name
 order by m.season desc, total_points desc

--- a/dashboards/sources/superligaen/team_regular_season_stats.sql
+++ b/dashboards/sources/superligaen/team_regular_season_stats.sql
@@ -1,6 +1,7 @@
 select
     t.team_name,
     m.season,
+    m.season_name,
     count(*)                                                            as gp,
     sum(case when f.match_result_sk = 1 then 1 else 0 end)             as w,
     sum(case when f.match_result_sk = 2 then 1 else 0 end)             as d,
@@ -14,5 +15,5 @@ join superligaen.gold.dim_team t   on t.team_sk  = f.team_sk
 join superligaen.gold.dim_match m  on m.match_sk = f.match_sk
 where f.match_result_sk in (1, 2, 3)
   and m.match_round_name like 'Regular Season%'
-group by t.team_name, m.season
+group by t.team_name, m.season, m.season_name
 order by m.season desc, pts desc, gd desc, gf desc

--- a/dashboards/sources/superligaen/team_season_stats.sql
+++ b/dashboards/sources/superligaen/team_season_stats.sql
@@ -1,6 +1,7 @@
 select
     t.team_name,
     m.season,
+    m.season_name,
     count(*)                                                            as gp,
     sum(case when f.match_result_sk = 1 then 1 else 0 end)             as w,
     sum(case when f.match_result_sk = 2 then 1 else 0 end)             as d,
@@ -18,5 +19,5 @@ from superligaen.gold.fct_match_results f
 join superligaen.gold.dim_team t   on t.team_sk  = f.team_sk
 join superligaen.gold.dim_match m  on m.match_sk = f.match_sk
 where f.match_result_sk in (1, 2, 3)
-group by t.team_name, m.season
+group by t.team_name, m.season, m.season_name
 order by m.season desc, round_group, pts desc, gd desc, gf desc

--- a/dashboards/sources/superligaen/upcoming_matches.sql
+++ b/dashboards/sources/superligaen/upcoming_matches.sql
@@ -8,7 +8,8 @@ select
         || '|||'
         || MAX(CASE WHEN ts.team_side = 'Away' THEN t.team_name END)         as match_key,
     st.stadium_name                                                           as stadium,
-    m.season
+    m.season,
+    m.season_name
 from superligaen.gold.fct_match_results f
 join superligaen.gold.dim_match        m  on m.match_sk       = f.match_sk
 join superligaen.gold.dim_date         d  on d.date_sk        = f.date_sk
@@ -17,5 +18,5 @@ join superligaen.gold.dim_match_result r  on r.match_result_sk = f.match_result_
 join superligaen.gold.dim_team         t  on t.team_sk        = f.team_sk
 join superligaen.gold.dim_team_side    ts on ts.team_side_sk  = f.team_side_sk
 where r.match_result = 'Pending'
-group by d.full_date, m.match_round_name, m.match_name, st.stadium_name, m.season
+group by d.full_date, m.match_round_name, m.match_name, st.stadium_name, m.season, m.season_name
 order by d.full_date asc

--- a/transformations/gold/dim_match.sql
+++ b/transformations/gold/dim_match.sql
@@ -10,6 +10,7 @@ CREATE TABLE IF NOT EXISTS {db}.gold.dim_match (
     match_sk             INTEGER NOT NULL,
     match_id             INTEGER,
     season               INTEGER,
+    season_name          VARCHAR,
     match_round_name     VARCHAR,
     match_round_type     VARCHAR,
     match_round_number   INTEGER,
@@ -20,18 +21,19 @@ CREATE TABLE IF NOT EXISTS {db}.gold.dim_match (
 );
 
 -- Add new columns to existing tables (idempotent)
-ALTER TABLE {db}.gold.dim_match ADD COLUMN IF NOT EXISTS match_round_type    VARCHAR;
-ALTER TABLE {db}.gold.dim_match ADD COLUMN IF NOT EXISTS match_round_number  INTEGER;
-ALTER TABLE {db}.gold.dim_match ADD COLUMN IF NOT EXISTS match_name          VARCHAR;
-ALTER TABLE {db}.gold.dim_match ADD COLUMN IF NOT EXISTS match_short_name    VARCHAR;
-ALTER TABLE {db}.gold.dim_match ADD COLUMN IF NOT EXISTS match_result        VARCHAR;
+ALTER TABLE {db}.gold.dim_match ADD COLUMN IF NOT EXISTS season_name        VARCHAR;
+ALTER TABLE {db}.gold.dim_match ADD COLUMN IF NOT EXISTS match_round_type   VARCHAR;
+ALTER TABLE {db}.gold.dim_match ADD COLUMN IF NOT EXISTS match_round_number INTEGER;
+ALTER TABLE {db}.gold.dim_match ADD COLUMN IF NOT EXISTS match_name         VARCHAR;
+ALTER TABLE {db}.gold.dim_match ADD COLUMN IF NOT EXISTS match_short_name   VARCHAR;
+ALTER TABLE {db}.gold.dim_match ADD COLUMN IF NOT EXISTS match_result       VARCHAR;
 
 -- Sentinels (idempotent)
 INSERT INTO {db}.gold.dim_match
 SELECT * FROM (VALUES
-    (-1, NULL::INTEGER, NULL::INTEGER, 'Unknown Match',        'Unknown',       NULL::INTEGER, 'Unknown Match',        'Unknown Match',        'Unknown',        NULL::VARCHAR),
-    (-2, NULL::INTEGER, NULL::INTEGER, 'Not Applicable Match', 'Not Applicable',NULL::INTEGER, 'Not Applicable Match', 'Not Applicable Match', 'Not Applicable', NULL::VARCHAR)
-) t(match_sk, match_id, season, round_name, round_type, round_number, match_status, match_name, match_short_name, match_result)
+    (-1, NULL::INTEGER, NULL::INTEGER, NULL::VARCHAR, 'Unknown Match',        'Unknown',       NULL::INTEGER, 'Unknown Match',        'Unknown Match',        'Unknown',        NULL::VARCHAR),
+    (-2, NULL::INTEGER, NULL::INTEGER, NULL::VARCHAR, 'Not Applicable Match', 'Not Applicable',NULL::INTEGER, 'Not Applicable Match', 'Not Applicable Match', 'Not Applicable', NULL::VARCHAR)
+) t(match_sk, match_id, season, season_name, round_name, round_type, round_number, match_status, match_name, match_short_name, match_result)
 WHERE t.match_sk NOT IN (SELECT match_sk FROM {db}.gold.dim_match);
 
 -- Insert new matches not yet in the dim
@@ -54,6 +56,7 @@ SELECT
         + ROW_NUMBER() OVER (ORDER BY src.fixture_id)                        AS match_sk,
     src.fixture_id                                                            AS match_id,
     src.season,
+    src.season::VARCHAR || '/' || RIGHT((src.season + 1)::VARCHAR, 2)        AS season_name,
     src.league_round                                                          AS match_round_name,
     CASE SPLIT_PART(src.league_round, ' - ', 1)
         WHEN 'Championship Group' THEN 'Championship'
@@ -89,6 +92,7 @@ WHERE src.fixture_id NOT IN (
 -- Update mutable fields for existing matches
 UPDATE {db}.gold.dim_match tgt
 SET
+    season_name        = ranked.season_name,
     match_round_type   = ranked.match_round_type,
     match_round_number = ranked.match_round_number,
     match_status       = ranked.status_long,
@@ -111,6 +115,7 @@ FROM (
     )
     SELECT
         src.fixture_id,
+        src.season::VARCHAR || '/' || RIGHT((src.season + 1)::VARCHAR, 2)     AS season_name,
         CASE SPLIT_PART(src.league_round, ' - ', 1)
             WHEN 'Championship Group' THEN 'Championship'
             WHEN 'Championship Round' THEN 'Championship'


### PR DESCRIPTION
## Summary
- Adds `season_name` to `dim_match` computed as `season || '/' || last 2 digits of (season+1)` — e.g. `2025` → `2025/26`
- `ALTER TABLE ... ADD COLUMN IF NOT EXISTS` backfills existing rows on next gold run
- All source SQLs expose `season_name` alongside the integer `season` (used for filtering)
- Season dropdowns now display `2025/26` as the label while still filtering by `2025`
- Home banner pill shows `Current Season: 2025/26`
- Match Results page headings and chart titles use `2025/26`
- H2H history table Season column shows `2025/26`

## Test plan
- [ ] Run gold transformation to populate `season_name` on existing rows
- [ ] Verify dropdowns show `2025/26`, `2024/25`, etc.
- [ ] Verify home banner shows `Current Season: 2025/26`
- [ ] Verify H2H season column in Upcoming Fixtures shows `2025/26`