### PR TITLE
Replace Vercel deploy hook with vercel-deploy-only branch

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -136,7 +136,7 @@ jobs:
         run: python transformations/run_gold.py --full-load
 
   # ---------------------------------------------------------------------------
-  # Dashboard — trigger Vercel rebuild after gold is fresh
+  # Dashboard — push to vercel-deploy-only to trigger Vercel rebuild
   # ---------------------------------------------------------------------------
   publish:
     name: Publish dashboard (Vercel)
@@ -144,5 +144,15 @@ jobs:
     needs: gold
 
     steps:
-      - name: Trigger Vercel deployment
-        run: curl -X POST "${{ secrets.VERCEL_DEPLOY_HOOK }}"
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push to Vercel deploy branch
+        run: |
+          git config user.email "github-actions@github.com"
+          git config user.name "GitHub Actions"
+          git checkout -B vercel-deploy-only origin/main
+          git commit --allow-empty -m "chore: nightly data refresh $(date -u '+%Y-%m-%d %H:%M UTC')"
+          git push origin vercel-deploy-only --force

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -136,7 +136,7 @@ jobs:
         run: python transformations/run_gold.py --full-load
 
   # ---------------------------------------------------------------------------
-  # Dashboard — push to vercel-deploy-only to trigger Vercel rebuild
+  # Dashboard — push to publish_dashboard/vercel to trigger Vercel rebuild
   # ---------------------------------------------------------------------------
   publish:
     name: Publish dashboard (Vercel)
@@ -153,6 +153,6 @@ jobs:
         run: |
           git config user.email "github-actions@github.com"
           git config user.name "GitHub Actions"
-          git checkout -B vercel-deploy-only origin/main
+          git checkout -B publish_dashboard/vercel origin/main
           git commit --allow-empty -m "chore: nightly data refresh $(date -u '+%Y-%m-%d %H:%M UTC')"
-          git push origin vercel-deploy-only --force
+          git push origin publish_dashboard/vercel --force

--- a/.github/workflows/vercel.yml
+++ b/.github/workflows/vercel.yml
@@ -8,8 +8,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Trigger Vercel deployment
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push to Vercel deploy branch
         run: |
-          echo "Calling hook..."
-          curl -v -X POST "${{ secrets.VERCEL_DEPLOY_HOOK }}" 2>&1
-          echo "Exit code: $?"
+          git config user.email "github-actions@github.com"
+          git config user.name "GitHub Actions"
+          git checkout -B vercel-deploy-only origin/main
+          git commit --allow-empty -m "chore: manual deploy $(date -u '+%Y-%m-%d %H:%M UTC')"
+          git push origin vercel-deploy-only --force

--- a/.github/workflows/vercel.yml
+++ b/.github/workflows/vercel.yml
@@ -17,6 +17,6 @@ jobs:
         run: |
           git config user.email "github-actions@github.com"
           git config user.name "GitHub Actions"
-          git checkout -B vercel-deploy-only origin/main
+          git checkout -B publish_dashboard/vercel origin/main
           git commit --allow-empty -m "chore: manual deploy $(date -u '+%Y-%m-%d %H:%M UTC')"
-          git push origin vercel-deploy-only --force
+          git push origin publish_dashboard/vercel --force


### PR DESCRIPTION
## Summary
- Drops the `VERCEL_DEPLOY_HOOK` curl approach entirely
- Both `vercel.yml` (manual) and `master.yml` (nightly) now push an empty timestamped commit to `vercel-deploy-only` branch
- Vercel watches `vercel-deploy-only` as its production branch — every push triggers a fresh build
- Empty commit guarantees a new SHA every time, so Vercel always rebuilds even when no code changed (critical for nightly data refresh)

## Before merging
- Set Vercel production branch to `vercel-deploy-only` if not already done

## Test plan
- [ ] Merge and run "Deploy to Vercel" workflow manually — a new deployment should appear in Vercel