### PR TITLE
Add contents:write permission to Vercel publish jobs

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -142,6 +142,8 @@ jobs:
     name: Publish dashboard (Vercel)
     runs-on: ubuntu-latest
     needs: gold
+    permissions:
+      contents: write
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/vercel.yml
+++ b/.github/workflows/vercel.yml
@@ -6,6 +6,8 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Fixes `403 Permission denied` when GitHub Actions tries to push to `publish_dashboard/vercel` branch
- `GITHUB_TOKEN` requires explicit `contents: write` permission to push branches

## Test plan
- [ ] Merge and run "Deploy to Vercel" workflow — should push to `publish_dashboard/vercel` and trigger Vercel build