### PR TITLE
fix: add dbt deps to gold job in master.yml

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -131,6 +131,12 @@ jobs:
       - name: Install dependencies
         run: pip install -r requirements.txt
 
+      - name: dbt deps
+        working-directory: dbt
+        env:
+          MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
+        run: dbt deps
+
       - name: Build gold (incremental)
         if: ${{ github.event.inputs.full_load != 'true' }}
         working-directory: dbt


### PR DESCRIPTION
Gold job in master.yml was missing `dbt deps` — caused nightly pipeline to fail with 'packages not installed' error after the dbt migration merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)