### PR TITLE
fix(#84): fall back to home team venue when fixture venue is null

### DIFF
--- a/dbt/models/silver/fixtures.sql
+++ b/dbt/models/silver/fixtures.sql
@@ -15,6 +15,12 @@ WITH venue_lookup AS (
     WHERE elem->>'$.id' IS NOT NULL
     GROUP BY (elem->>'$.name')::VARCHAR
 ),
+home_team_venue AS (
+    SELECT DISTINCT ON (team_id) team_id, venue_id
+    FROM {{ ref('teams') }}
+    WHERE venue_id IS NOT NULL
+    ORDER BY team_id, season DESC
+),
 src AS (
     SELECT
         (raw_json->>'$.fixture.id')::INTEGER          AS fixture_id,
@@ -48,7 +54,8 @@ src AS (
         (raw_json->>'$.fixture.periods.second')::INTEGER AS period_second,
         COALESCE(
             (raw_json->>'$.fixture.venue.id')::INTEGER,
-            vl.venue_id
+            vl.venue_id,
+            htv.venue_id
         )                                             AS venue_id,
         raw_json->>'$.fixture.venue.name'             AS venue_name,
         raw_json->>'$.fixture.venue.city'             AS venue_city,
@@ -84,7 +91,8 @@ src AS (
         (raw_json->>'$.score.penalty.away')::INTEGER   AS score_pen_away,
         ingested_at
     FROM {{ source('bronze', 'api_football__fixtures') }}
-    LEFT JOIN venue_lookup vl ON vl.venue_name = (raw_json->>'$.fixture.venue.name')::VARCHAR
+    LEFT JOIN venue_lookup vl  ON vl.venue_name = (raw_json->>'$.fixture.venue.name')::VARCHAR
+    LEFT JOIN home_team_venue htv ON htv.team_id = (raw_json->>'$.teams.home.id')::INTEGER
 )
 SELECT * FROM src
 {% if is_incremental() %}


### PR DESCRIPTION
## Summary
- Adds a `home_team_venue` CTE to `silver/fixtures.sql` that looks up the venue_id for the home team from `silver.teams`
- Extends the `COALESCE` for `venue_id` to use it as a 3rd fallback: raw API venue id → name-matched venue → home team venue
- Eliminates `NULL` venue_ids that previously caused Unknown Stadium rows in the gold layer

## Deployment note
Run `dbt run --select silver.fixtures gold.dim_stadium --full-refresh` on prod to backfill existing fixtures with null venues.

## Test plan
- [ ] CI dbt compile passes
- [ ] Run `dbt run --select silver.fixtures --full-refresh --target dev` and verify no null venue_ids remain for completed fixtures

Closes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)