### PR TITLE
fix(#85): purge stale abbreviated/country-suffixed referee names

### DIFF
--- a/dbt/models/gold/dims/dim_referee.sql
+++ b/dbt/models/gold/dims/dim_referee.sql
@@ -5,6 +5,7 @@
         unique_key='referee_name',
         merge_update_columns=['referee_name'],
         post_hook=[
+            "DELETE FROM {{ this }} WHERE referee_name LIKE '%, %' OR regexp_matches(referee_name, '^[A-Z]\\. ')",
             "INSERT INTO {{ this }} SELECT * FROM (VALUES (-1, 'Unknown Referee'), (-2, 'Not Applicable Referee')) t(referee_sk, referee_name) WHERE t.referee_sk NOT IN (SELECT referee_sk FROM {{ this }})"
         ]
     )


### PR DESCRIPTION
## Summary
- Adds a `post_hook` DELETE to `dim_referee` that removes rows matching the two stale patterns:
  - Names with a comma (`'%, %'`) — e.g. `'Aydin Uslu, Denmark'`
  - Single-initial abbreviations (`'^[A-Z]\. '`) — e.g. `'A. Uslu'`
- These rows were ingested before `silver.fixtures` had its referee normalisation CASE statement; the `merge` strategy keeps them alive because it never deletes rows absent from the source
- The DELETE is idempotent — once the stale rows are gone it becomes a no-op

## Deployment note
After merge, trigger the gold job (`dbt run --select gold.dim_referee`). The post_hook will purge the bad rows on the next run — no full-refresh needed.

## Test plan
- [ ] CI dbt compile passes
- [ ] After running gold, verify `SELECT * FROM superligaen.gold.dim_referee WHERE referee_name IN ('A. Uslu', 'Aydin Uslu, Denmark')` returns 0 rows

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)