### PR TITLE
fix(#86): remove integer season from dim_match, rename season_name to season

### DIFF
--- a/dashboards/pages/index.md
+++ b/dashboards/pages/index.md
@@ -15,8 +15,7 @@ select
     (select count(distinct team_name)
      from superligaen.team_analytics_form
      where season = (select max(season) from superligaen.match_results_by_match)) as total_teams,
-    max(season)                                                           as season,
-    max(season_name)                                                      as season_name
+    max(season)                                                           as season
 from superligaen.match_results_by_match
 where season = (select max(season) from superligaen.match_results_by_match)
 ```
@@ -35,7 +34,7 @@ select * from superligaen.current_leader
       <div class="text-3xl md:text-5xl font-extrabold tracking-tight text-white">Superligaen</div>
       <div class="text-gray-400 text-xs md:text-sm mt-2 md:mt-3 uppercase tracking-widest">Danish Football Premier League</div>
       <div class="inline-block mt-2 px-3 py-1 rounded-full bg-blue-500/20 border border-blue-400/30 text-blue-300 text-sm font-semibold">
-        Current Season: {kpis[0].season_name}
+        Current Season: {kpis[0].season}
       </div>
     </div>
     <img src="{league[0].league_country_flag}" alt="Denmark" class="h-7 md:h-10 rounded-lg shadow-lg opacity-90" />

--- a/dashboards/pages/match-results.md
+++ b/dashboards/pages/match-results.md
@@ -7,12 +7,12 @@ title: Match Results
 <a href="/" class="inline-flex items-center gap-1 text-sm text-gray-500 hover:text-gray-800 no-underline mb-6 transition-colors">← Back to Home</a>
 
 ```sql seasons
-select distinct season, season_name from superligaen.match_results_by_match
+select distinct season from superligaen.match_results_by_match
 order by season desc
 ```
 
-<Dropdown data={seasons} name=season value=season label=season_name>
-    <DropdownOption value=2025 valueLabel="2025/26"/>
+<Dropdown data={seasons} name=season value=season label=season>
+    <DropdownOption value="2025/26" valueLabel="2025/26"/>
 </Dropdown>
 
 ```sql results
@@ -21,7 +21,7 @@ select
     total_goals, total_shots_on_goal, total_xg,
     total_yellow_cards, total_red_cards, total_corners
 from superligaen.match_results_by_match
-where season = ${inputs.season.value}
+where season = '${inputs.season.value}'
 order by match_date desc
 ```
 
@@ -35,7 +35,7 @@ select
     sum(total_red_cards)                as total_red_cards,
     round(avg(total_shots_on_goal), 1)  as avg_shots_on_goal
 from superligaen.match_results_by_match
-where season = ${inputs.season.value}
+where season = '${inputs.season.value}'
 ```
 
 ```sql goals_over_time
@@ -44,7 +44,7 @@ select
     sum(total_goals) as goals,
     round(sum(total_xg::double), 2) as xg
 from superligaen.match_results_by_match
-where season = ${inputs.season.value}
+where season = '${inputs.season.value}'
 group by match_round_number
 order by match_round_number asc
 ```

--- a/dashboards/pages/standings.md
+++ b/dashboards/pages/standings.md
@@ -7,12 +7,12 @@ title: Standings
 <a href="/" class="inline-flex items-center gap-1 text-sm text-gray-500 hover:text-gray-800 no-underline mb-6 transition-colors">← Back to Home</a>
 
 ```sql seasons
-select distinct season, season_name from superligaen.team_season_stats
+select distinct season from superligaen.team_season_stats
 order by season desc
 ```
 
-<Dropdown data={seasons} name=season value=season label=season_name>
-    <DropdownOption value=2025 valueLabel="2025/26"/>
+<Dropdown data={seasons} name=season value=season label=season>
+    <DropdownOption value="2025/26" valueLabel="2025/26"/>
 </Dropdown>
 
 ```sql standings
@@ -22,7 +22,7 @@ select
     gp, w, d, l, gf, ga, gd, pts,
     round_group
 from superligaen.team_season_stats
-where season = ${inputs.season.value}
+where season = '${inputs.season.value}'
 order by round_group, pts desc, gd desc, gf desc
 ```
 
@@ -43,7 +43,7 @@ select
     row_number() over (order by pts desc, gd desc, gf desc) as rank,
     team_name as team, gp, w, d, l, gf, ga, gd, pts
 from superligaen.team_regular_season_stats
-where season = ${inputs.season.value}
+where season = '${inputs.season.value}'
 ```
 
 ```sql all_teams

--- a/dashboards/pages/team-analytics.md
+++ b/dashboards/pages/team-analytics.md
@@ -7,7 +7,7 @@ title: Team Analytics
 <a href="/" class="inline-flex items-center gap-1 text-sm text-gray-500 hover:text-gray-800 no-underline mb-6 transition-colors">← Back to Home</a>
 
 ```sql seasons
-select distinct season, season_name from superligaen.team_analytics_kpis
+select distinct season from superligaen.team_analytics_kpis
 order by season desc
 ```
 
@@ -16,8 +16,8 @@ select distinct team_name as team from superligaen.team_analytics_kpis
 order by team_name
 ```
 
-<Dropdown data={seasons} name=season value=season label=season_name>
-    <DropdownOption value=2025 valueLabel="2025/26"/>
+<Dropdown data={seasons} name=season value=season label=season>
+    <DropdownOption value="2025/26" valueLabel="2025/26"/>
 </Dropdown>
 
 <Dropdown data={teams} name=team value=team label=team>
@@ -27,20 +27,20 @@ order by team_name
 ```sql kpis
 select * from superligaen.team_analytics_kpis
 where team_name = '${inputs.team.value}'
-  and season = ${inputs.season.value}
+  and season = '${inputs.season.value}'
 ```
 
 ```sql form
 select * from superligaen.team_analytics_form
 where team_name = '${inputs.team.value}'
-  and season = ${inputs.season.value}
+  and season = '${inputs.season.value}'
 order by match_date asc
 ```
 
 ```sql home_away
 select * from superligaen.team_analytics_home_away
 where team_name = '${inputs.team.value}'
-  and season = ${inputs.season.value}
+  and season = '${inputs.season.value}'
 order by side desc
 ```
 
@@ -78,7 +78,7 @@ order by side desc
 select match_date, round, match_round_number, cumulative_points, result, opponent, gf, ga
 from superligaen.team_analytics_form
 where team_name = '${inputs.team.value}'
-  and season = ${inputs.season.value}
+  and season = '${inputs.season.value}'
 order by match_date asc
 ```
 
@@ -103,7 +103,7 @@ select
     yellow_cards, red_cards
 from superligaen.team_analytics_form
 where team_name = '${inputs.team.value}'
-  and season = ${inputs.season.value}
+  and season = '${inputs.season.value}'
 order by match_date desc
 limit 10
 ```
@@ -158,11 +158,11 @@ limit 10
 ```sql shot_location
 select 'Inside Box' as location, shots_insidebox as shots
 from superligaen.team_analytics_kpis
-where team_name = '${inputs.team.value}' and season = ${inputs.season.value}
+where team_name = '${inputs.team.value}' and season = '${inputs.season.value}'
 union all
 select 'Outside Box', shots_outsidebox
 from superligaen.team_analytics_kpis
-where team_name = '${inputs.team.value}' and season = ${inputs.season.value}
+where team_name = '${inputs.team.value}' and season = '${inputs.season.value}'
 ```
 
 <BarChart
@@ -293,7 +293,7 @@ where team_name = '${inputs.team.value}' and season = ${inputs.season.value}
 ```sql home_away_chart
 select side, avg_shots_on_goal as "Shots on Goal", avg_xg as "xG", avg_possession / 10 as "Possession / 10", win_rate_pct / 10 as "Win Rate / 10"
 from superligaen.team_analytics_home_away
-where team_name = '${inputs.team.value}' and season = ${inputs.season.value}
+where team_name = '${inputs.team.value}' and season = '${inputs.season.value}'
 ```
 
 <BarChart

--- a/dashboards/pages/upcoming-matches.md
+++ b/dashboards/pages/upcoming-matches.md
@@ -52,7 +52,7 @@ limit 1
 
 ```sql h2h
 select
-    season_name             as season,
+    season,
     match_date,
     round,
     match_short_name    as match,

--- a/dashboards/sources/superligaen/kpis.sql
+++ b/dashboards/sources/superligaen/kpis.sql
@@ -5,8 +5,7 @@ select
         sum(f.total_shots)::decimal / nullif(count(distinct f.match_sk), 0),
         1
     )                                                                           as avg_shots_per_match,
-    max(m.season)                                                               as season,
-    max(m.season_name)                                                          as season_name
+    max(m.season)                                                               as season
 from superligaen.gold.fct_match_results f
 join superligaen.gold.dim_match        m on m.match_sk        = f.match_sk
 join superligaen.gold.dim_match_result r on r.match_result_sk = f.match_result_sk

--- a/dashboards/sources/superligaen/match_results_by_match.sql
+++ b/dashboards/sources/superligaen/match_results_by_match.sql
@@ -11,12 +11,11 @@ select
     sum(f.corner_kicks)                             as total_corners,
     round(sum(f.expected_goals::double), 2)         as total_xg,
     sum(f.goals_scored)                             as total_goals,
-    m.season,
-    m.season_name
+    m.season
 from superligaen.gold.fct_match_results f
 join superligaen.gold.dim_match        m on m.match_sk        = f.match_sk
 join superligaen.gold.dim_date         d on d.date_sk         = f.date_sk
 join superligaen.gold.dim_match_result r on r.match_result_sk = f.match_result_sk
 where r.match_result in ('Win', 'Draw', 'Loss')
-group by d.full_date, m.match_round_name, m.match_round_number, m.match_name, m.match_short_name, m.match_result, m.season, m.season_name
+group by d.full_date, m.match_round_name, m.match_round_number, m.match_name, m.match_short_name, m.match_result, m.season
 order by d.full_date desc

--- a/dashboards/sources/superligaen/team_analytics_form.sql
+++ b/dashboards/sources/superligaen/team_analytics_form.sql
@@ -27,8 +27,7 @@ select
         order by d.full_date
         rows between unbounded preceding and current row
     )                                                                       as cumulative_points,
-    m.season,
-    m.season_name
+    m.season
 from superligaen.gold.fct_match_results f
 join superligaen.gold.dim_team          t   on t.team_sk          = f.team_sk
 join superligaen.gold.dim_opponent_team ot  on ot.opponent_team_sk = f.opponent_team_sk

--- a/dashboards/sources/superligaen/team_analytics_home_away.sql
+++ b/dashboards/sources/superligaen/team_analytics_home_away.sql
@@ -2,7 +2,6 @@ select
     t.team_name,
     ts.team_side                                                                    as side,
     m.season,
-    m.season_name,
     count(*)                                                                        as matches,
     sum(f.points_earned)                                                            as points,
     count(*) filter (where r.match_result = 'Win')                                  as wins,
@@ -25,5 +24,5 @@ join superligaen.gold.dim_match         m   on m.match_sk         = f.match_sk
 join superligaen.gold.dim_match_result  r   on r.match_result_sk  = f.match_result_sk
 join superligaen.gold.dim_team_side     ts  on ts.team_side_sk    = f.team_side_sk
 where r.match_result in ('Win', 'Draw', 'Loss')
-group by t.team_name, ts.team_side, m.season, m.season_name
+group by t.team_name, ts.team_side, m.season
 order by t.team_name, m.season, ts.team_side

--- a/dashboards/sources/superligaen/team_analytics_kpis.sql
+++ b/dashboards/sources/superligaen/team_analytics_kpis.sql
@@ -1,7 +1,6 @@
 select
     t.team_name,
     m.season,
-    m.season_name,
     count(*)                                                                        as matches_played,
     sum(f.points_earned)                                                            as total_points,
     count(*) filter (where r.match_result = 'Win')                                  as wins,
@@ -40,5 +39,5 @@ join superligaen.gold.dim_team         t  on t.team_sk          = f.team_sk
 join superligaen.gold.dim_match        m  on m.match_sk         = f.match_sk
 join superligaen.gold.dim_match_result r  on r.match_result_sk  = f.match_result_sk
 where r.match_result in ('Win', 'Draw', 'Loss')
-group by t.team_name, m.season, m.season_name
+group by t.team_name, m.season
 order by m.season desc, total_points desc

--- a/dashboards/sources/superligaen/team_regular_season_stats.sql
+++ b/dashboards/sources/superligaen/team_regular_season_stats.sql
@@ -1,7 +1,6 @@
 select
     t.team_name,
     m.season,
-    m.season_name,
     count(*)                                                            as gp,
     sum(case when f.match_result_sk = 1 then 1 else 0 end)             as w,
     sum(case when f.match_result_sk = 2 then 1 else 0 end)             as d,
@@ -15,5 +14,5 @@ join superligaen.gold.dim_team t   on t.team_sk  = f.team_sk
 join superligaen.gold.dim_match m  on m.match_sk = f.match_sk
 where f.match_result_sk in (1, 2, 3)
   and m.match_round_name like 'Regular Season%'
-group by t.team_name, m.season, m.season_name
+group by t.team_name, m.season
 order by m.season desc, pts desc, gd desc, gf desc

--- a/dashboards/sources/superligaen/team_season_stats.sql
+++ b/dashboards/sources/superligaen/team_season_stats.sql
@@ -1,7 +1,6 @@
 select
     t.team_name,
     m.season,
-    m.season_name,
     count(*)                                                            as gp,
     sum(case when f.match_result_sk = 1 then 1 else 0 end)             as w,
     sum(case when f.match_result_sk = 2 then 1 else 0 end)             as d,
@@ -19,5 +18,5 @@ from superligaen.gold.fct_match_results f
 join superligaen.gold.dim_team t   on t.team_sk  = f.team_sk
 join superligaen.gold.dim_match m  on m.match_sk = f.match_sk
 where f.match_result_sk in (1, 2, 3)
-group by t.team_name, m.season, m.season_name
+group by t.team_name, m.season
 order by m.season desc, round_group, pts desc, gd desc, gf desc

--- a/dashboards/sources/superligaen/upcoming_matches.sql
+++ b/dashboards/sources/superligaen/upcoming_matches.sql
@@ -8,8 +8,7 @@ select
         || '|||'
         || MAX(CASE WHEN ts.team_side = 'Away' THEN t.team_name END)         as match_key,
     st.stadium_name                                                           as stadium,
-    m.season,
-    m.season_name
+    m.season
 from superligaen.gold.fct_match_results f
 join superligaen.gold.dim_match        m  on m.match_sk       = f.match_sk
 join superligaen.gold.dim_date         d  on d.date_sk        = f.date_sk
@@ -18,5 +17,5 @@ join superligaen.gold.dim_match_result r  on r.match_result_sk = f.match_result_
 join superligaen.gold.dim_team         t  on t.team_sk        = f.team_sk
 join superligaen.gold.dim_team_side    ts on ts.team_side_sk  = f.team_side_sk
 where r.match_result = 'Pending'
-group by d.full_date, m.match_round_name, m.match_name, st.stadium_name, m.season, m.season_name
+group by d.full_date, m.match_round_name, m.match_name, st.stadium_name, m.season
 order by d.full_date asc

--- a/dbt/models/gold/dims/dim_match.sql
+++ b/dbt/models/gold/dims/dim_match.sql
@@ -3,9 +3,9 @@
         materialized='incremental',
         incremental_strategy='merge',
         unique_key='match_id',
-        merge_update_columns=['season_name', 'match_round_type', 'match_round_number', 'match_status', 'match_name', 'match_short_name', 'match_result'],
+        merge_update_columns=['season', 'match_round_type', 'match_round_number', 'match_status', 'match_name', 'match_short_name', 'match_result'],
         post_hook=[
-            "INSERT INTO {{ this }} SELECT * FROM (VALUES (-1, NULL::INTEGER, NULL::INTEGER, NULL::VARCHAR, 'Unknown Match', 'Unknown', NULL::INTEGER, 'Unknown Match', 'Unknown Match', 'Unknown', NULL::VARCHAR), (-2, NULL::INTEGER, NULL::INTEGER, NULL::VARCHAR, 'Not Applicable Match', 'Not Applicable', NULL::INTEGER, 'Not Applicable Match', 'Not Applicable Match', 'Not Applicable', NULL::VARCHAR)) t(match_sk, match_id, season, season_name, match_round_name, match_round_type, match_round_number, match_status, match_name, match_short_name, match_result) WHERE t.match_sk NOT IN (SELECT match_sk FROM {{ this }})"
+            "INSERT INTO {{ this }} SELECT * FROM (VALUES (-1, NULL::INTEGER, NULL::VARCHAR, 'Unknown Match', 'Unknown', NULL::INTEGER, 'Unknown Match', 'Unknown Match', 'Unknown', NULL::VARCHAR), (-2, NULL::INTEGER, NULL::VARCHAR, 'Not Applicable Match', 'Not Applicable', NULL::INTEGER, 'Not Applicable Match', 'Not Applicable Match', 'Not Applicable', NULL::VARCHAR)) t(match_sk, match_id, season, match_round_name, match_round_type, match_round_number, match_status, match_name, match_short_name, match_result) WHERE t.match_sk NOT IN (SELECT match_sk FROM {{ this }})"
         ]
     )
 }}
@@ -26,8 +26,7 @@ team_round AS (
 src AS (
     SELECT
         f.fixture_id,
-        f.season,
-        f.season::VARCHAR || '/' || RIGHT((f.season + 1)::VARCHAR, 2)        AS season_name,
+        f.season::VARCHAR || '/' || RIGHT((f.season + 1)::VARCHAR, 2)        AS season,
         f.league_round                                                         AS match_round_name,
         CASE SPLIT_PART(f.league_round, ' - ', 1)
             WHEN 'Championship Group' THEN 'Championship'
@@ -69,7 +68,6 @@ SELECT
     {% endif %}
     src.fixture_id   AS match_id,
     src.season,
-    src.season_name,
     src.match_round_name,
     src.match_round_type,
     src.match_round_number,


### PR DESCRIPTION
## Summary
- Drops the raw integer `season` column (e.g. `2025`) from `dim_match`
- Renames `season_name` → `season` so the dim exposes a single human-readable attribute (e.g. `'2025/26'`)
- Updates `merge_update_columns` and sentinel `post_hook` values accordingly

## Deployment note
This is a breaking schema change — run `dbt run --select gold.dim_match --full-refresh` on prod after merge.
The fact table references `dim_match` only via `match_sk` so `fct_match_results` does not need a rebuild.

## Test plan
- [ ] CI dbt compile passes
- [ ] Verify `SELECT DISTINCT season FROM superligaen.gold.dim_match` returns `'2024/25'`, `'2025/26'` format only

Closes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)