### PR TITLE
fix(#87): rename full_date→date and format quarter as Q1–Q4 in dim_date

### DIFF
--- a/dashboards/sources/superligaen/match_results.sql
+++ b/dashboards/sources/superligaen/match_results.sql
@@ -1,5 +1,5 @@
 select
-    d.full_date                  as match_date,
+    d.date                  as match_date,
     m.match_round_name           as round,
     m.season,
     t.team_name,
@@ -19,4 +19,4 @@ join superligaen.gold.dim_match_result  r   on r.match_result_sk    = f.match_re
 join superligaen.gold.dim_team_side     ts  on ts.team_side_sk      = f.team_side_sk
 join superligaen.gold.dim_stadium       st  on st.stadium_sk        = f.stadium_sk
 where r.match_result in ('Win', 'Draw', 'Loss')
-order by d.full_date desc
+order by d.date desc

--- a/dashboards/sources/superligaen/match_results_by_match.sql
+++ b/dashboards/sources/superligaen/match_results_by_match.sql
@@ -1,5 +1,5 @@
 select
-    d.full_date                                     as match_date,
+    d.date                                     as match_date,
     m.match_round_name                              as round,
     m.match_round_number,
     m.match_name,
@@ -17,5 +17,5 @@ join superligaen.gold.dim_match        m on m.match_sk        = f.match_sk
 join superligaen.gold.dim_date         d on d.date_sk         = f.date_sk
 join superligaen.gold.dim_match_result r on r.match_result_sk = f.match_result_sk
 where r.match_result in ('Win', 'Draw', 'Loss')
-group by d.full_date, m.match_round_name, m.match_round_number, m.match_name, m.match_short_name, m.match_result, m.season
-order by d.full_date desc
+group by d.date, m.match_round_name, m.match_round_number, m.match_name, m.match_short_name, m.match_result, m.season
+order by d.date desc

--- a/dashboards/sources/superligaen/team_analytics_form.sql
+++ b/dashboards/sources/superligaen/team_analytics_form.sql
@@ -1,6 +1,6 @@
 select
     t.team_name,
-    d.full_date                                                             as match_date,
+    d.date                                                             as match_date,
     m.match_round_name                                                      as round,
     m.match_round_number,
     ot.opponent_team_name                                                   as opponent,
@@ -24,7 +24,7 @@ select
     round(f.passes_accurate::double / nullif(f.total_passes, 0) * 100, 1)  as pass_accuracy,
     sum(f.points_earned) over (
         partition by t.team_name, m.season
-        order by d.full_date
+        order by d.date
         rows between unbounded preceding and current row
     )                                                                       as cumulative_points,
     m.season
@@ -36,4 +36,4 @@ join superligaen.gold.dim_match         m   on m.match_sk         = f.match_sk
 join superligaen.gold.dim_match_result  r   on r.match_result_sk  = f.match_result_sk
 join superligaen.gold.dim_team_side     ts  on ts.team_side_sk    = f.team_side_sk
 where r.match_result in ('Win', 'Draw', 'Loss')
-order by t.team_name, m.season, d.full_date
+order by t.team_name, m.season, d.date

--- a/dashboards/sources/superligaen/upcoming_matches.sql
+++ b/dashboards/sources/superligaen/upcoming_matches.sql
@@ -1,5 +1,5 @@
 select
-    d.full_date                                                               as match_date,
+    d.date                                                               as match_date,
     m.match_round_name                                                        as round,
     m.match_name,
     MAX(CASE WHEN ts.team_side = 'Home' THEN t.team_name END)                as home_team,
@@ -17,5 +17,5 @@ join superligaen.gold.dim_match_result r  on r.match_result_sk = f.match_result_
 join superligaen.gold.dim_team         t  on t.team_sk        = f.team_sk
 join superligaen.gold.dim_team_side    ts on ts.team_side_sk  = f.team_side_sk
 where r.match_result = 'Pending'
-group by d.full_date, m.match_round_name, m.match_name, st.stadium_name, m.season
-order by d.full_date asc
+group by d.date, m.match_round_name, m.match_name, st.stadium_name, m.season
+order by d.date asc

--- a/dbt/models/gold/dims/dim_date.sql
+++ b/dbt/models/gold/dims/dim_date.sql
@@ -7,9 +7,9 @@
 
 SELECT
     strftime('%Y%m%d', d)::INTEGER           AS date_sk,
-    d::DATE                                  AS full_date,
+    d::DATE                                  AS date,
     EXTRACT(year    FROM d)::INTEGER         AS year,
-    EXTRACT(quarter FROM d)::INTEGER         AS quarter,
+    'Q' || EXTRACT(quarter FROM d)::INTEGER  AS quarter,
     EXTRACT(month   FROM d)::INTEGER         AS month,
     monthname(d)                             AS month_name,
     weekofyear(d)::INTEGER                   AS week_number,

--- a/dbt/models/gold/fct_match_results.sql
+++ b/dbt/models/gold/fct_match_results.sql
@@ -93,7 +93,7 @@ joined AS (
         s.goalkeeper_saves,
         s.expected_goals
     FROM fixture_teams ft
-    JOIN      {{ ref('dim_date')    }} d   ON d.full_date      = ft.match_date
+    JOIN      {{ ref('dim_date')    }} d   ON d.date           = ft.match_date
     LEFT JOIN {{ ref('dim_time')    }} t   ON t.time_sk        = ft.kick_off_hour
     LEFT JOIN {{ ref('dim_team')    }} tm  ON tm.team_id       = ft.team_id
     LEFT JOIN {{ ref('dim_team')    }} opp ON opp.team_id      = ft.opponent_id


### PR DESCRIPTION
## Summary
- Renames `full_date` → `date` in `dim_date` for cleaner report column names
- Formats `quarter` as `'Q1'`/`'Q2'`/`'Q3'`/`'Q4'` instead of raw integers
- Updates the `JOIN` in `fct_match_results` from `d.full_date` to `d.date`

## Deployment note
`dim_date` is `materialized='table'` so it rebuilds automatically on the next run — no full-refresh needed.
`fct_match_results` is incremental; run it after `dim_date` rebuilds (normal pipeline order handles this).

## Test plan
- [ ] CI dbt compile passes
- [ ] Verify `SELECT date, quarter FROM superligaen.gold.dim_date LIMIT 5` shows a DATE column and `'Q1'` format

Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)