### PR TITLE
fix(#88): descriptive sentinel values for Unknown/Not Applicable rows in all dims

### DIFF
--- a/dbt/models/gold/dims/dim_league.sql
+++ b/dbt/models/gold/dims/dim_league.sql
@@ -5,7 +5,7 @@
         unique_key='league_id',
         merge_update_columns=['league_name', 'league_type', 'league_logo', 'league_country', 'league_country_code', 'league_country_flag'],
         post_hook=[
-            "INSERT INTO {{ this }} SELECT * FROM (VALUES (-1, NULL::INTEGER, 'Unknown League', 'Unknown League', NULL::VARCHAR, 'Unknown League', 'Unknown League', NULL::VARCHAR), (-2, NULL::INTEGER, 'Not Applicable League', 'Not Applicable League', NULL::VARCHAR, 'Not Applicable League', 'Not Applicable League', NULL::VARCHAR)) t(league_sk, league_id, league_name, league_type, league_logo, league_country, league_country_code, league_country_flag) WHERE t.league_sk NOT IN (SELECT league_sk FROM {{ this }})"
+            "INSERT INTO {{ this }} SELECT * FROM (VALUES (-1, NULL::INTEGER, 'Unknown League Name', 'Unknown League Type', NULL::VARCHAR, 'Unknown League Country', 'Unknown League Country Code', NULL::VARCHAR), (-2, NULL::INTEGER, 'Not Applicable League Name', 'Not Applicable League Type', NULL::VARCHAR, 'Not Applicable League Country', 'Not Applicable League Country Code', NULL::VARCHAR)) t(league_sk, league_id, league_name, league_type, league_logo, league_country, league_country_code, league_country_flag) WHERE t.league_sk NOT IN (SELECT league_sk FROM {{ this }})"
         ]
     )
 }}

--- a/dbt/models/gold/dims/dim_match.sql
+++ b/dbt/models/gold/dims/dim_match.sql
@@ -5,7 +5,7 @@
         unique_key='match_id',
         merge_update_columns=['season_name', 'match_round_type', 'match_round_number', 'match_status', 'match_name', 'match_short_name', 'match_result'],
         post_hook=[
-            "INSERT INTO {{ this }} SELECT * FROM (VALUES (-1, NULL::INTEGER, NULL::INTEGER, NULL::VARCHAR, 'Unknown Match', 'Unknown', NULL::INTEGER, 'Unknown Match', 'Unknown Match', 'Unknown', NULL::VARCHAR), (-2, NULL::INTEGER, NULL::INTEGER, NULL::VARCHAR, 'Not Applicable Match', 'Not Applicable', NULL::INTEGER, 'Not Applicable Match', 'Not Applicable Match', 'Not Applicable', NULL::VARCHAR)) t(match_sk, match_id, season, season_name, match_round_name, match_round_type, match_round_number, match_status, match_name, match_short_name, match_result) WHERE t.match_sk NOT IN (SELECT match_sk FROM {{ this }})"
+            "INSERT INTO {{ this }} SELECT * FROM (VALUES (-1, NULL::INTEGER, NULL::INTEGER, NULL::VARCHAR, 'Unknown Match Round Name', 'Unknown Match Round Type', NULL::INTEGER, 'Unknown Match Status', 'Unknown Match Name', 'Unknown Match Short Name', NULL::VARCHAR), (-2, NULL::INTEGER, NULL::INTEGER, NULL::VARCHAR, 'Not Applicable Match Round Name', 'Not Applicable Match Round Type', NULL::INTEGER, 'Not Applicable Match Status', 'Not Applicable Match Name', 'Not Applicable Match Short Name', NULL::VARCHAR)) t(match_sk, match_id, season, season_name, match_round_name, match_round_type, match_round_number, match_status, match_name, match_short_name, match_result) WHERE t.match_sk NOT IN (SELECT match_sk FROM {{ this }})"
         ]
     )
 }}

--- a/dbt/models/gold/dims/dim_stadium.sql
+++ b/dbt/models/gold/dims/dim_stadium.sql
@@ -5,7 +5,7 @@
         unique_key='stadium_id',
         merge_update_columns=['stadium_name', 'stadium_address', 'stadium_city', 'stadium_country', 'stadium_capacity', 'stadium_surface'],
         post_hook=[
-            "INSERT INTO {{ this }} SELECT * FROM (VALUES (-1, NULL::INTEGER, 'Unknown Stadium', 'Unknown Stadium', 'Unknown Stadium', 'Unknown Stadium', NULL::INTEGER, 'Unknown Stadium'), (-2, NULL::INTEGER, 'Not Applicable Stadium', 'Not Applicable Stadium', 'Not Applicable Stadium', 'Not Applicable Stadium', NULL::INTEGER, 'Not Applicable Stadium')) t(stadium_sk, stadium_id, stadium_name, stadium_address, stadium_city, stadium_country, stadium_capacity, stadium_surface) WHERE t.stadium_sk NOT IN (SELECT stadium_sk FROM {{ this }})"
+            "INSERT INTO {{ this }} SELECT * FROM (VALUES (-1, NULL::INTEGER, 'Unknown Stadium Name', 'Unknown Stadium Address', 'Unknown Stadium City', 'Unknown Stadium Country', NULL::INTEGER, 'Unknown Stadium Surface'), (-2, NULL::INTEGER, 'Not Applicable Stadium Name', 'Not Applicable Stadium Address', 'Not Applicable Stadium City', 'Not Applicable Stadium Country', NULL::INTEGER, 'Not Applicable Stadium Surface')) t(stadium_sk, stadium_id, stadium_name, stadium_address, stadium_city, stadium_country, stadium_capacity, stadium_surface) WHERE t.stadium_sk NOT IN (SELECT stadium_sk FROM {{ this }})"
         ]
     )
 }}

--- a/dbt/models/gold/dims/dim_team.sql
+++ b/dbt/models/gold/dims/dim_team.sql
@@ -5,7 +5,7 @@
         unique_key='team_id',
         merge_update_columns=['team_name', 'team_code', 'team_country', 'team_founded_year', 'team_logo'],
         post_hook=[
-            "INSERT INTO {{ this }} SELECT * FROM (VALUES (-1, NULL::INTEGER, 'Unknown Team', 'Unknown Team', 'Unknown Team', NULL::INTEGER, NULL::VARCHAR), (-2, NULL::INTEGER, 'Not Applicable Team', 'Not Applicable Team', 'Not Applicable Team', NULL::INTEGER, NULL::VARCHAR)) t(team_sk, team_id, team_name, team_code, team_country, team_founded_year, team_logo) WHERE t.team_sk NOT IN (SELECT team_sk FROM {{ this }})"
+            "INSERT INTO {{ this }} SELECT * FROM (VALUES (-1, NULL::INTEGER, 'Unknown Team Name', 'Unknown Team Code', 'Unknown Team Country', NULL::INTEGER, NULL::VARCHAR), (-2, NULL::INTEGER, 'Not Applicable Team Name', 'Not Applicable Team Code', 'Not Applicable Team Country', NULL::INTEGER, NULL::VARCHAR)) t(team_sk, team_id, team_name, team_code, team_country, team_founded_year, team_logo) WHERE t.team_sk NOT IN (SELECT team_sk FROM {{ this }})"
         ]
     )
 }}

--- a/dbt/models/gold/dims/dim_time.sql
+++ b/dbt/models/gold/dims/dim_time.sql
@@ -15,6 +15,6 @@ SELECT hour::INTEGER AS time_sk,
        END           AS period_of_day
 FROM generate_series(0, 23) t(hour)
 UNION ALL
-SELECT -1, NULL, 'Unknown Time'
+SELECT -1, NULL, 'Unknown Period Of Day'
 UNION ALL
-SELECT -2, NULL, 'Not Applicable Time'
+SELECT -2, NULL, 'Not Applicable Period Of Day'


### PR DESCRIPTION
## Summary
Each `Unknown` and `Not Applicable` sentinel row now labels every string attribute with its own name rather than repeating the dimension name:

| Dim | Before | After (example) |
|-----|--------|-----------------|
| dim_league | `league_type = 'Unknown League'` | `league_type = 'Unknown League Type'` |
| dim_team | `team_code = 'Unknown Team'` | `team_code = 'Unknown Team Code'` |
| dim_stadium | `stadium_address = 'Unknown Stadium'` | `stadium_address = 'Unknown Stadium Address'` |
| dim_match | `match_round_type = 'Unknown'` | `match_round_type = 'Unknown Match Round Type'` |
| dim_time | `period_of_day = 'Unknown Time'` | `period_of_day = 'Unknown Period Of Day'` |

Integer and URL/image columns remain `NULL`.
`dim_match_result`, `dim_team_side`, and `dim_referee` were already correctly labelled and are unchanged.

## Deployment note
- `dim_time`, `dim_match_result`, `dim_team_side` are `materialized='table'` — they rebuild on the next run automatically.
- All other dims use `post_hook` INSERT with `WHERE sk NOT IN (SELECT sk FROM this)`, so existing sentinels are **not** updated automatically. Run `DELETE FROM superligaen.gold.<dim> WHERE <sk> IN (-1, -2)` then re-run the model (or use `--full-refresh`) to apply the new labels.

## Test plan
- [ ] CI dbt compile passes
- [ ] Verify sentinel rows in each dim show the new labels

Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)