### PR TITLE
fix(#89): standardise workflow names, job names, and parameters

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   validate:
+    name: Validate
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: Deploy to prod
+name: Gold full refresh (prod)
 
 on:
   workflow_dispatch:
@@ -10,9 +10,11 @@ jobs:
     timeout-minutes: 30
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v5
+      - name: Set up Python
+        uses: actions/setup-python@v5
         with:
           python-version: "3.12"
 

--- a/.github/workflows/gold.yml
+++ b/.github/workflows/gold.yml
@@ -12,9 +12,9 @@ on:
         required: false
         default: ""
       lookback:
-        description: "Days to look back for incremental window (default: 2)"
+        description: "Days to look back for incremental window (default: 5)"
         required: false
-        default: "2"
+        default: "5"
       target_db:
         description: "Target MotherDuck database (superligaen or superligaen_dev). Default: superligaen."
         required: false
@@ -22,13 +22,16 @@ on:
 
 jobs:
   gold:
+    name: Gold transformation
     runs-on: ubuntu-latest
     timeout-minutes: 30
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v5
+      - name: Set up Python
+        uses: actions/setup-python@v5
         with:
           python-version: "3.12"
 
@@ -48,7 +51,7 @@ jobs:
           MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
         run: |
           TARGET=$([ "${{ github.event.inputs.target_db || 'superligaen' }}" = "superligaen" ] && echo "prod" || echo "dev")
-          dbt run --select 'gold.*' --target $TARGET --vars '{"lookback_days": ${{ github.event.inputs.lookback || '2' }}}'
+          dbt run --select 'gold.*' --target $TARGET --vars '{"lookback_days": ${{ github.event.inputs.lookback || '5' }}}'
 
       - name: Build gold (seasonal load)
         if: ${{ github.event.inputs.full_load == 'true' && github.event.inputs.season != '' }}

--- a/.github/workflows/ingest.yml
+++ b/.github/workflows/ingest.yml
@@ -1,4 +1,4 @@
-name: Daily ingestion
+name: Ingestion
 
 on:
   workflow_dispatch:
@@ -15,6 +15,10 @@ on:
         description: "Season year for full load (e.g. 2025). Leave empty to load all seasons."
         required: false
         default: ""
+      lookback:
+        description: "Days to look back for incremental run (default: 5)"
+        required: false
+        default: "5"
       target_db:
         description: "Target MotherDuck database (e.g. superligaen). Leave empty to use default (superligaen)."
         required: false
@@ -22,6 +26,7 @@ on:
 
 jobs:
   ingest:
+    name: Bronze ingestion
     runs-on: ubuntu-latest
     timeout-minutes: 360  # 6h max — covers one full season load
 
@@ -37,13 +42,13 @@ jobs:
       - name: Install dependencies
         run: pip install -r requirements.txt
 
-      - name: Run ingestion (daily incremental)
+      - name: Run ingestion (incremental)
         if: ${{ github.event.inputs.full_load != 'true' }}
         env:
           MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
           API_FOOTBALL_KEY: ${{ secrets.API_FOOTBALL_KEY }}
           TARGET_DB: ${{ github.event.inputs.target_db || 'superligaen' }}
-        run: python ingestion/run.py --lookback 2
+        run: python ingestion/run.py --lookback ${{ github.event.inputs.lookback || '5' }}
 
       - name: Run ingestion (full load)
         if: ${{ github.event.inputs.full_load == 'true' }}

--- a/.github/workflows/sync-dev-db.yml
+++ b/.github/workflows/sync-dev-db.yml
@@ -5,6 +5,7 @@ on:
 
 jobs:
   sync:
+    name: Sync dev DB from prod
     runs-on: ubuntu-latest
     timeout-minutes: 30
 

--- a/.github/workflows/transform.yml
+++ b/.github/workflows/transform.yml
@@ -12,9 +12,9 @@ on:
         required: false
         default: ""
       lookback:
-        description: "Days to look back for incremental window (default: 2)"
+        description: "Days to look back for incremental window (default: 5)"
         required: false
-        default: "2"
+        default: "5"
       target_db:
         description: "Target MotherDuck database (superligaen or superligaen_dev). Default: superligaen."
         required: false
@@ -22,13 +22,16 @@ on:
 
 jobs:
   transform:
+    name: Silver transformation
     runs-on: ubuntu-latest
     timeout-minutes: 60
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v5
+      - name: Set up Python
+        uses: actions/setup-python@v5
         with:
           python-version: "3.12"
 
@@ -48,7 +51,7 @@ jobs:
           MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
         run: |
           TARGET=$([ "${{ github.event.inputs.target_db || 'superligaen' }}" = "superligaen" ] && echo "prod" || echo "dev")
-          dbt run --select 'silver.*' --target $TARGET --vars '{"lookback_days": ${{ github.event.inputs.lookback || '2' }}}'
+          dbt run --select 'silver.*' --target $TARGET --vars '{"lookback_days": ${{ github.event.inputs.lookback || '5' }}}'
 
       - name: Run silver (seasonal load)
         if: ${{ github.event.inputs.full_load == 'true' && github.event.inputs.season != '' }}

--- a/.github/workflows/vercel.yml
+++ b/.github/workflows/vercel.yml
@@ -1,16 +1,18 @@
-name: Deploy to Vercel
+name: Publish to Vercel
 
 on:
   workflow_dispatch:
 
 jobs:
   deploy:
+    name: Publish to Vercel
     runs-on: ubuntu-latest
     permissions:
       contents: write
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- **Workflow names** (`name:` at the top): `'Deploy to prod'` → `'Gold full refresh (prod)'`, `'Daily ingestion'` → `'Ingestion'`, `'Deploy to Vercel'` → `'Publish to Vercel'`
- **Job names** (`name:` on each job): added to every workflow that was missing it — now all jobs have a human-readable label in the GitHub Actions UI
- **Step names**: added explicit `name: Checkout` and `name: Set up Python` to all workflows that used the bare `uses:` shorthand
- **Lookback default**: standardised to `5` across `gold.yml` and `transform.yml` (was `2`, `master.yml` uses `5`)
- **`ingest.yml` parameter**: added `lookback` input so incremental runs are parameterizable; previously the value was hardcoded to `2`

## Test plan
- [ ] Trigger each manual workflow and verify the correct name appears in the GitHub Actions UI
- [ ] Verify `ingest.yml` respects the new `lookback` input

Closes #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)