### PR TITLE
feat: upcoming fixtures, match results, referee & season analytics (#99 #100 #101 #102)

### DIFF
--- a/dashboards/pages/index.md
+++ b/dashboards/pages/index.md
@@ -90,4 +90,24 @@ select * from superligaen.current_leader
   </div>
 </a>
 
+<a href="/season-analytics" class="block no-underline rounded-xl border border-gray-200 bg-white p-6 hover:border-blue-500 hover:shadow-lg transition-all duration-200 group shadow-sm">
+  <div class="flex items-start gap-4">
+    <div class="text-3xl">🌍</div>
+    <div>
+      <div class="text-base font-bold text-gray-800 group-hover:text-blue-500 transition-colors">Season Analytics</div>
+      <div class="text-gray-400 text-sm mt-1">Cross-team benchmarks, rankings and league-wide trends</div>
+    </div>
+  </div>
+</a>
+
+<a href="/referee-analytics" class="block no-underline rounded-xl border border-gray-200 bg-white p-6 hover:border-blue-500 hover:shadow-lg transition-all duration-200 group shadow-sm">
+  <div class="flex items-start gap-4">
+    <div class="text-3xl">🟨</div>
+    <div>
+      <div class="text-base font-bold text-gray-800 group-hover:text-blue-500 transition-colors">Referee Analytics</div>
+      <div class="text-gray-400 text-sm mt-1">Cards, fouls, team exposure and match logs by referee</div>
+    </div>
+  </div>
+</a>
+
 </div>

--- a/dashboards/pages/index.md
+++ b/dashboards/pages/index.md
@@ -74,7 +74,7 @@ select * from superligaen.current_leader
   <div class="flex items-start gap-4">
     <div class="text-3xl">📊</div>
     <div>
-      <div class="text-base font-bold text-gray-800 group-hover:text-blue-500 transition-colors">Team Analytics</div>
+      <div class="text-base font-bold text-gray-800 group-hover:text-blue-500 transition-colors">Team Analysis</div>
       <div class="text-gray-400 text-sm mt-1">Deep-dive KPIs, form, shooting accuracy &amp; discipline</div>
     </div>
   </div>
@@ -90,11 +90,11 @@ select * from superligaen.current_leader
   </div>
 </a>
 
-<a href="/season-analytics" class="block no-underline rounded-xl border border-gray-200 bg-white p-6 hover:border-blue-500 hover:shadow-lg transition-all duration-200 group shadow-sm">
+<a href="/league-analytics" class="block no-underline rounded-xl border border-gray-200 bg-white p-6 hover:border-blue-500 hover:shadow-lg transition-all duration-200 group shadow-sm">
   <div class="flex items-start gap-4">
     <div class="text-3xl">🌍</div>
     <div>
-      <div class="text-base font-bold text-gray-800 group-hover:text-blue-500 transition-colors">Season Analytics</div>
+      <div class="text-base font-bold text-gray-800 group-hover:text-blue-500 transition-colors">League Analysis</div>
       <div class="text-gray-400 text-sm mt-1">Cross-team benchmarks, rankings and league-wide trends</div>
     </div>
   </div>
@@ -104,7 +104,7 @@ select * from superligaen.current_leader
   <div class="flex items-start gap-4">
     <div class="text-3xl">🟨</div>
     <div>
-      <div class="text-base font-bold text-gray-800 group-hover:text-blue-500 transition-colors">Referee Analytics</div>
+      <div class="text-base font-bold text-gray-800 group-hover:text-blue-500 transition-colors">Referee Analysis</div>
       <div class="text-gray-400 text-sm mt-1">Cards, fouls, team exposure and match logs by referee</div>
     </div>
   </div>

--- a/dashboards/pages/league-analytics.md
+++ b/dashboards/pages/league-analytics.md
@@ -1,7 +1,7 @@
 ---
 sidebar: never
 hide_toc: true
-title: Season Analytics
+title: League Analysis
 ---
 
 <a href="/" class="inline-flex items-center gap-1 text-sm text-gray-500 hover:text-gray-800 no-underline mb-6 transition-colors">← Back to Home</a>
@@ -11,7 +11,7 @@ select distinct season from superligaen.team_analytics_kpis
 order by season desc
 ```
 
-<Dropdown data={seasons} name=season value=season label=season>
+<Dropdown data={seasons} name=season value=season label=season order="season desc">
     <DropdownOption value="2025/26" valueLabel="2025/26"/>
 </Dropdown>
 
@@ -37,15 +37,11 @@ order by pos
 
 ```sql league_kpis
 select
-    sum(goals_for)                              as total_goals,
-    round(avg(avg_goals_scored + avg_goals_conceded) / 2, 2) as avg_goals_per_match,
-    max(goals_for)                              as most_goals_scored,
-    min(goals_against)                          as fewest_conceded,
-    round(avg(avg_possession), 1)               as avg_possession,
-    round(avg(shot_conversion_pct), 1)          as avg_shot_conversion,
-    round(sum(total_xg), 2)                     as total_xg,
-    sum(yellow_cards)                           as total_yellow_cards,
-    sum(red_cards)                              as total_red_cards
+    sum(goals_for)                                                          as total_goals,
+    round(sum(goals_for)::double / (sum(matches_played) / 2), 2)           as avg_goals_per_match,
+    round(avg(shot_conversion_pct), 1)                                     as avg_shot_conversion,
+    sum(yellow_cards)                                                       as total_yellow_cards,
+    sum(red_cards)                                                          as total_red_cards
 from superligaen.team_analytics_kpis
 where season = '${inputs.season.value}'
 ```
@@ -68,11 +64,12 @@ order by goals_for desc
 select
     team_name,
     goals_against,
+    clean_sheets,
     avg_saves,
     avg_goals_conceded
 from superligaen.team_analytics_kpis
 where season = '${inputs.season.value}'
-order by goals_against asc
+order by clean_sheets desc
 ```
 
 ```sql possession_rankings
@@ -110,23 +107,14 @@ where season = '${inputs.season.value}'
 order by goals_for desc
 ```
 
-```sql points_vs_xg
-select
-    team_name,
-    total_points,
-    round(total_xg, 2) as total_xg
-from superligaen.team_analytics_kpis
-where season = '${inputs.season.value}'
-order by total_points desc
-```
+## {inputs.season.value} — League Analysis
 
-## {inputs.season.value} — League Overview
-
-<div class="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
-  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4 text-center"><BigValue data={league_kpis} value=total_goals          title="Goals Scored"       /></div>
-  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4 text-center"><BigValue data={league_kpis} value=total_xg             title="Total xG"           /></div>
-  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4 text-center"><BigValue data={league_kpis} value=total_yellow_cards   title="Yellow Cards"       /></div>
-  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4 text-center"><BigValue data={league_kpis} value=total_red_cards      title="Red Cards"          /></div>
+<div class="grid grid-cols-2 md:grid-cols-5 gap-4 mb-6">
+  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4 text-center"><BigValue data={league_kpis} value=total_goals           title="Goals Scored"       /></div>
+  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4 text-center"><BigValue data={league_kpis} value=avg_goals_per_match   title="Avg Goals / Match"  /></div>
+  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4 text-center"><BigValue data={league_kpis} value=avg_shot_conversion   title="Shot Conversion %"  /></div>
+  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4 text-center"><BigValue data={league_kpis} value=total_yellow_cards    title="Yellow Cards"       /></div>
+  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4 text-center"><BigValue data={league_kpis} value=total_red_cards       title="Red Cards"          /></div>
 </div>
 
 ---
@@ -211,11 +199,11 @@ order by total_points desc
 <BarChart
     data={defence_rankings}
     x=team_name
-    y=goals_against
-    title="Goals Conceded"
+    y=clean_sheets
+    title="Clean Sheets"
     xAxisTitle="Team"
-    yAxisTitle="Goals Conceded"
-    colorPalette={['#ef4444']}
+    yAxisTitle="Clean Sheets"
+    colorPalette={['#14b8a6']}
     swapXY=true
 />
 
@@ -226,11 +214,11 @@ order by total_points desc
 <BarChart
     data={defence_rankings}
     x=team_name
-    y=avg_saves
-    title="Avg Saves per Match"
+    y=goals_against
+    title="Goals Conceded"
     xAxisTitle="Team"
-    yAxisTitle="Saves"
-    colorPalette={['#14b8a6']}
+    yAxisTitle="Goals Conceded"
+    colorPalette={['#ef4444']}
     swapXY=true
 />
 
@@ -278,7 +266,7 @@ order by total_points desc
 
 ---
 
-## Discipline Index
+## Discipline
 
 <BarChart
     data={discipline_rankings}
@@ -324,19 +312,3 @@ order by total_points desc
 </div>
 
 </div>
-
----
-
-## Full Team Benchmark
-
-<DataTable data={league_table} rows=20>
-    <Column id=pos                  title="#"             align=center />
-    <Column id=team_name            title="Team"          />
-    <Column id=pts                  title="Pts"           contentType=colorscale colorPalette={['white','#3b82f6']} align=center />
-    <Column id=gf                   title="GF"            align=center />
-    <Column id=ga                   title="GA"            align=center />
-    <Column id=gd                   title="GD"            contentType=delta align=center />
-    <Column id=total_xg             title="xG"            contentType=colorscale colorPalette={['white','#6366f1']} />
-    <Column id=xg_overperformance   title="xG OP"         contentType=delta />
-    <Column id=win_rate_pct         title="Win %"         contentType=colorscale colorPalette={['white','#22c55e']} fmt='0.0"%"' />
-</DataTable>

--- a/dashboards/pages/match-results.md
+++ b/dashboards/pages/match-results.md
@@ -11,21 +11,20 @@ select distinct season from superligaen.match_results_by_match
 order by season desc
 ```
 
-<Dropdown data={seasons} name=season value=season label=season>
+<Dropdown data={seasons} name=season value=season label=season order="season desc">
     <DropdownOption value="2025/26" valueLabel="2025/26"/>
 </Dropdown>
 
 ```sql rounds
-select
-    round,
-    max(match_date) as last_date
+select distinct CAST(match_round_number AS INTEGER) as round_number
 from superligaen.match_results_by_match
-where season = '${inputs.season.value}'
-group by round
-order by last_date desc
+where season = (select max(season) from superligaen.match_results_by_match)
+order by 1 desc
 ```
 
-<Dropdown data={rounds} name=round value=round label=round multiple=true defaultValue={rounds[0].round} />
+{#key rounds[0]?.round_number}
+<Dropdown data={rounds} name=round value=round_number label=round_number multiple=true defaultValue={[rounds[0]?.round_number]} order="round_number desc" />
+{/key}
 
 ```sql results
 select
@@ -34,7 +33,7 @@ select
     total_yellow_cards, total_red_cards, total_corners
 from superligaen.match_results_by_match
 where season = '${inputs.season.value}'
-  and round in ${inputs.round.value}
+  and CAST(match_round_number AS INTEGER) in ${inputs.round.value}
 order by match_date desc
 ```
 
@@ -46,10 +45,10 @@ select
     round(sum(total_xg::double), 2)     as total_xg
 from superligaen.match_results_by_match
 where season = '${inputs.season.value}'
-  and round in ${inputs.round.value}
+  and CAST(match_round_number AS INTEGER) in ${inputs.round.value}
 ```
 
-## Match Results — {inputs.season.value} — {inputs.round.label}
+## Match Results — {inputs.season.value}
 
 <div class="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
   <div class="rounded-xl border border-gray-300 bg-gray-100 p-4 text-center"><BigValue data={round_kpis} value=total_goals         title="Goals Scored"       /></div>

--- a/dashboards/pages/match-results.md
+++ b/dashboards/pages/match-results.md
@@ -15,6 +15,18 @@ order by season desc
     <DropdownOption value="2025/26" valueLabel="2025/26"/>
 </Dropdown>
 
+```sql rounds
+select
+    round,
+    max(match_date) as last_date
+from superligaen.match_results_by_match
+where season = '${inputs.season.value}'
+group by round
+order by last_date desc
+```
+
+<Dropdown data={rounds} name=round value=round label=round multiple=true defaultValue={rounds[0].round} />
+
 ```sql results
 select
     match_date, round, match_name, score,
@@ -22,66 +34,31 @@ select
     total_yellow_cards, total_red_cards, total_corners
 from superligaen.match_results_by_match
 where season = '${inputs.season.value}'
+  and round in ${inputs.round.value}
 order by match_date desc
 ```
 
-```sql season_kpis
+```sql round_kpis
 select
-    count(*)                            as total_matches,
     sum(total_goals)                    as total_goals,
     round(avg(total_goals), 2)          as avg_goals_per_match,
-    round(avg(total_xg), 2)             as avg_xg_per_match,
-    sum(total_yellow_cards)             as total_yellow_cards,
-    sum(total_red_cards)                as total_red_cards,
-    round(avg(total_shots_on_goal), 1)  as avg_shots_on_goal
+    round(avg(total_shots_on_goal), 1)  as avg_shots_on_goal,
+    round(sum(total_xg::double), 2)     as total_xg
 from superligaen.match_results_by_match
 where season = '${inputs.season.value}'
+  and round in ${inputs.round.value}
 ```
 
-```sql goals_over_time
-select
-    match_round_number,
-    sum(total_goals) as goals,
-    round(sum(total_xg::double), 2) as xg
-from superligaen.match_results_by_match
-where season = '${inputs.season.value}'
-group by match_round_number
-order by match_round_number asc
-```
+## Match Results — {inputs.season.value} — {inputs.round.label}
 
----
-
-## Season {inputs.season.label} at a Glance
-
-<div class="grid grid-cols-2 md:grid-cols-4 gap-4 mb-4">
-  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4 text-center"><BigValue data={season_kpis} value=total_matches       title="Matches Played"    /></div>
-  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4 text-center"><BigValue data={season_kpis} value=total_goals          title="Goals Scored"      /></div>
-  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4 text-center"><BigValue data={season_kpis} value=avg_goals_per_match  title="Avg Goals / Match" /></div>
-  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4 text-center"><BigValue data={season_kpis} value=avg_xg_per_match     title="Avg xG / Match"    /></div>
-  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4 text-center"><BigValue data={season_kpis} value=avg_shots_on_goal    title="Avg Shots on Goal" /></div>
-  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4 text-center"><BigValue data={season_kpis} value=total_yellow_cards   title="Yellow Cards"      /></div>
-  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4 text-center"><BigValue data={season_kpis} value=total_red_cards      title="Red Cards"         /></div>
+<div class="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
+  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4 text-center"><BigValue data={round_kpis} value=total_goals         title="Goals Scored"       /></div>
+  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4 text-center"><BigValue data={round_kpis} value=avg_goals_per_match  title="Avg Goals / Match"  /></div>
+  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4 text-center"><BigValue data={round_kpis} value=avg_shots_on_goal    title="Avg Shots on Goal"  /></div>
+  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4 text-center"><BigValue data={round_kpis} value=total_xg             title="Total xG"           /></div>
 </div>
 
----
-
-## Goals & xG Over the Season
-
-<LineChart
-    data={goals_over_time}
-    x=match_round_number
-    y={['goals','xg']}
-    title="Goals vs xG — {inputs.season.label}"
-    xAxisTitle="Round"
-    yAxisTitle="Goals"
-    colorPalette={['#22c55e','#3b82f6']}
-/>
-
----
-
-## Match Results — {inputs.season.label}
-
-<DataTable data={results} rows=20 search=true>
+<DataTable data={results} rows=20>
     <Column id=match_date          title="Date"           />
     <Column id=round               title="Round"          />
     <Column id=match_name          title="Match"          wrap=true />
@@ -93,4 +70,3 @@ order by match_round_number asc
     <Column id=total_red_cards     title="RC"             contentType=colorscale colorPalette={['white','#ef4444']} align=center />
     <Column id=total_corners       title="Corners"        contentType=colorscale colorPalette={['white','#a855f7']} align=center />
 </DataTable>
-

--- a/dashboards/pages/referee-analytics.md
+++ b/dashboards/pages/referee-analytics.md
@@ -1,7 +1,7 @@
 ---
 sidebar: never
 hide_toc: true
-title: Referee Analytics
+title: Referee Analysis
 ---
 
 <a href="/" class="inline-flex items-center gap-1 text-sm text-gray-500 hover:text-gray-800 no-underline mb-6 transition-colors">← Back to Home</a>
@@ -11,7 +11,7 @@ select distinct season from superligaen.referee_analytics
 order by season desc
 ```
 
-<Dropdown data={seasons} name=season value=season label=season>
+<Dropdown data={seasons} name=season value=season label=season order="season desc">
     <DropdownOption value="2025/26" valueLabel="2025/26"/>
 </Dropdown>
 
@@ -32,7 +32,7 @@ from superligaen.referee_analytics
 where season = '${inputs.season.value}'
 ```
 
-## Referee Analytics — {inputs.season.value}
+## Referee Analysis — {inputs.season.value}
 
 <div class="grid grid-cols-2 md:grid-cols-5 gap-4 mb-6">
   <div class="rounded-xl border border-gray-300 bg-gray-100 p-4 text-center"><BigValue data={season_totals} value=total_referees      title="Referees Active"    /></div>
@@ -94,40 +94,19 @@ where season = '${inputs.season.value}'
 <Dropdown data={season_stats} name=referee value=referee_name label=referee_name />
 
 ```sql referee_team_exposure
-select
-    t.team_name,
-    count(distinct m.match_sk)  as matches
-from superligaen.gold.fct_match_results f
-join superligaen.gold.dim_referee      ref on ref.referee_sk     = f.referee_sk
-join superligaen.gold.dim_match        m   on m.match_sk         = f.match_sk
-join superligaen.gold.dim_match_result r   on r.match_result_sk = f.match_result_sk
-join superligaen.gold.dim_team         t   on t.team_sk          = f.team_sk
-where r.match_result in ('Win', 'Draw', 'Loss')
-  and ref.referee_name = '${inputs.referee.value}'
-  and m.season = '${inputs.season.value}'
-group by t.team_name
+select team_name, matches
+from superligaen.referee_team_exposure
+where referee_name = '${inputs.referee.value}'
+  and season = '${inputs.season.value}'
 order by matches desc
 ```
 
 ```sql referee_match_log
-select
-    strftime(d.date, '%Y-%m-%d')   as match_date,
-    m.match_round_name              as round,
-    m.match_name,
-    m.match_result                  as score,
-    sum(f.yellow_cards)             as yellow_cards,
-    sum(f.red_cards)                as red_cards,
-    sum(f.fouls)                    as total_fouls
-from superligaen.gold.fct_match_results f
-join superligaen.gold.dim_referee      ref on ref.referee_sk     = f.referee_sk
-join superligaen.gold.dim_match        m   on m.match_sk         = f.match_sk
-join superligaen.gold.dim_match_result r   on r.match_result_sk = f.match_result_sk
-join superligaen.gold.dim_date         d   on d.date_sk          = f.date_sk
-where r.match_result in ('Win', 'Draw', 'Loss')
-  and ref.referee_name = '${inputs.referee.value}'
-  and m.season = '${inputs.season.value}'
-group by d.date, m.match_round_name, m.match_name, m.match_result
-order by d.date desc
+select match_date, round, match_name, score, yellow_cards, red_cards, total_fouls
+from superligaen.referee_match_log
+where referee_name = '${inputs.referee.value}'
+  and season = '${inputs.season.value}'
+order by match_date desc
 ```
 
 ```sql referee_kpis

--- a/dashboards/pages/referee-analytics.md
+++ b/dashboards/pages/referee-analytics.md
@@ -1,0 +1,181 @@
+---
+sidebar: never
+hide_toc: true
+title: Referee Analytics
+---
+
+<a href="/" class="inline-flex items-center gap-1 text-sm text-gray-500 hover:text-gray-800 no-underline mb-6 transition-colors">← Back to Home</a>
+
+```sql seasons
+select distinct season from superligaen.referee_analytics
+order by season desc
+```
+
+<Dropdown data={seasons} name=season value=season label=season>
+    <DropdownOption value="2025/26" valueLabel="2025/26"/>
+</Dropdown>
+
+```sql season_stats
+select * from superligaen.referee_analytics
+where season = '${inputs.season.value}'
+order by matches_managed desc
+```
+
+```sql season_totals
+select
+    count(distinct referee_name)                        as total_referees,
+    sum(matches_managed)                                as total_match_slots,
+    round(avg(avg_yellows_per_match), 2)                as league_avg_yellows,
+    round(avg(avg_reds_per_match), 3)                   as league_avg_reds,
+    round(avg(avg_fouls_per_match), 1)                  as league_avg_fouls
+from superligaen.referee_analytics
+where season = '${inputs.season.value}'
+```
+
+## Referee Analytics — {inputs.season.value}
+
+<div class="grid grid-cols-2 md:grid-cols-5 gap-4 mb-6">
+  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4 text-center"><BigValue data={season_totals} value=total_referees      title="Referees Active"    /></div>
+  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4 text-center"><BigValue data={season_totals} value=league_avg_yellows  title="Avg YC / Match"     /></div>
+  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4 text-center"><BigValue data={season_totals} value=league_avg_reds     title="Avg RC / Match"     /></div>
+  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4 text-center"><BigValue data={season_totals} value=league_avg_fouls    title="Avg Fouls / Match"  /></div>
+</div>
+
+---
+
+## Season Leaderboard
+
+<DataTable data={season_stats} rows=20>
+    <Column id=referee_name         title="Referee"             />
+    <Column id=matches_managed      title="Games"               contentType=colorscale colorPalette={['white','#3b82f6']} align=center />
+    <Column id=total_yellow_cards   title="Yellow Cards"        contentType=colorscale colorPalette={['white','#eab308']} align=center />
+    <Column id=total_red_cards      title="Red Cards"           contentType=colorscale colorPalette={['white','#ef4444']} align=center />
+    <Column id=total_fouls          title="Total Fouls"         contentType=colorscale colorPalette={['white','#f97316']} align=center />
+    <Column id=avg_yellows_per_match title="Avg YC / Match"     contentType=colorscale colorPalette={['white','#eab308']} />
+    <Column id=avg_reds_per_match    title="Avg RC / Match"     contentType=colorscale colorPalette={['white','#ef4444']} />
+    <Column id=avg_fouls_per_match   title="Avg Fouls / Match"  contentType=bar        colorPalette={['#f97316']} />
+    <Column id=card_severity_index   title="Card Severity"      contentType=colorscale colorPalette={['white','#dc2626']} />
+</DataTable>
+
+---
+
+## Cards per Match — All Referees
+
+<BarChart
+    data={season_stats}
+    x=referee_name
+    y={['avg_yellows_per_match', 'avg_reds_per_match']}
+    title="Average Cards per Match — {inputs.season.value}"
+    xAxisTitle="Referee"
+    yAxisTitle="Cards per Match"
+    colorPalette={['#eab308','#ef4444']}
+    swapXY=true
+/>
+
+---
+
+## Fouls Called per Match
+
+<BarChart
+    data={season_stats}
+    x=referee_name
+    y=avg_fouls_per_match
+    title="Average Fouls per Match — {inputs.season.value}"
+    xAxisTitle="Referee"
+    yAxisTitle="Fouls per Match"
+    colorPalette={['#f97316']}
+    swapXY=true
+/>
+
+---
+
+## Referee Deep Dive
+
+<Dropdown data={season_stats} name=referee value=referee_name label=referee_name />
+
+```sql referee_team_exposure
+select
+    t.team_name,
+    count(distinct m.match_sk)  as matches
+from superligaen.gold.fct_match_results f
+join superligaen.gold.dim_referee      ref on ref.referee_sk     = f.referee_sk
+join superligaen.gold.dim_match        m   on m.match_sk         = f.match_sk
+join superligaen.gold.dim_match_result r   on r.match_result_sk = f.match_result_sk
+join superligaen.gold.dim_team         t   on t.team_sk          = f.team_sk
+where r.match_result in ('Win', 'Draw', 'Loss')
+  and ref.referee_name = '${inputs.referee.value}'
+  and m.season = '${inputs.season.value}'
+group by t.team_name
+order by matches desc
+```
+
+```sql referee_match_log
+select
+    strftime(d.date, '%Y-%m-%d')   as match_date,
+    m.match_round_name              as round,
+    m.match_name,
+    m.match_result                  as score,
+    sum(f.yellow_cards)             as yellow_cards,
+    sum(f.red_cards)                as red_cards,
+    sum(f.fouls)                    as total_fouls
+from superligaen.gold.fct_match_results f
+join superligaen.gold.dim_referee      ref on ref.referee_sk     = f.referee_sk
+join superligaen.gold.dim_match        m   on m.match_sk         = f.match_sk
+join superligaen.gold.dim_match_result r   on r.match_result_sk = f.match_result_sk
+join superligaen.gold.dim_date         d   on d.date_sk          = f.date_sk
+where r.match_result in ('Win', 'Draw', 'Loss')
+  and ref.referee_name = '${inputs.referee.value}'
+  and m.season = '${inputs.season.value}'
+group by d.date, m.match_round_name, m.match_name, m.match_result
+order by d.date desc
+```
+
+```sql referee_kpis
+select * from superligaen.referee_analytics
+where referee_name = '${inputs.referee.value}'
+  and season = '${inputs.season.value}'
+```
+
+<div class="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6 mt-4">
+  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4 text-center"><BigValue data={referee_kpis} value=matches_managed       title="Games"              /></div>
+  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4 text-center"><BigValue data={referee_kpis} value=total_yellow_cards    title="Yellow Cards"       /></div>
+  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4 text-center"><BigValue data={referee_kpis} value=total_red_cards       title="Red Cards"          /></div>
+  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4 text-center"><BigValue data={referee_kpis} value=avg_fouls_per_match   title="Avg Fouls / Match"  /></div>
+</div>
+
+<div class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-6">
+
+<div>
+
+### Team Exposure
+
+<BarChart
+    data={referee_team_exposure}
+    x=team_name
+    y=matches
+    title="Matches per Team — {inputs.referee.value}"
+    xAxisTitle="Team"
+    yAxisTitle="Matches"
+    colorPalette={['#6366f1']}
+    swapXY=true
+/>
+
+</div>
+
+<div>
+
+### Match Log
+
+<DataTable data={referee_match_log} rows=10>
+    <Column id=match_date    title="Date"   />
+    <Column id=round         title="Round"  />
+    <Column id=match_name    title="Match"  wrap=true />
+    <Column id=score         title="Score"  align=center />
+    <Column id=yellow_cards  title="YC"     contentType=colorscale colorPalette={['white','#eab308']} align=center />
+    <Column id=red_cards     title="RC"     contentType=colorscale colorPalette={['white','#ef4444']} align=center />
+    <Column id=total_fouls   title="Fouls"  contentType=bar colorPalette={['#f97316']} />
+</DataTable>
+
+</div>
+
+</div>

--- a/dashboards/pages/season-analytics.md
+++ b/dashboards/pages/season-analytics.md
@@ -1,0 +1,342 @@
+---
+sidebar: never
+hide_toc: true
+title: Season Analytics
+---
+
+<a href="/" class="inline-flex items-center gap-1 text-sm text-gray-500 hover:text-gray-800 no-underline mb-6 transition-colors">← Back to Home</a>
+
+```sql seasons
+select distinct season from superligaen.team_analytics_kpis
+order by season desc
+```
+
+<Dropdown data={seasons} name=season value=season label=season>
+    <DropdownOption value="2025/26" valueLabel="2025/26"/>
+</Dropdown>
+
+```sql league_table
+select
+    row_number() over (order by total_points desc, goal_difference desc, goals_for desc) as pos,
+    team_name,
+    matches_played  as mp,
+    wins            as w,
+    draws           as d,
+    losses          as l,
+    goals_for       as gf,
+    goals_against   as ga,
+    goal_difference as gd,
+    total_points    as pts,
+    win_rate_pct,
+    total_xg,
+    xg_overperformance
+from superligaen.team_analytics_kpis
+where season = '${inputs.season.value}'
+order by pos
+```
+
+```sql league_kpis
+select
+    sum(goals_for)                              as total_goals,
+    round(avg(avg_goals_scored + avg_goals_conceded) / 2, 2) as avg_goals_per_match,
+    max(goals_for)                              as most_goals_scored,
+    min(goals_against)                          as fewest_conceded,
+    round(avg(avg_possession), 1)               as avg_possession,
+    round(avg(shot_conversion_pct), 1)          as avg_shot_conversion,
+    round(sum(total_xg), 2)                     as total_xg,
+    sum(yellow_cards)                           as total_yellow_cards,
+    sum(red_cards)                              as total_red_cards
+from superligaen.team_analytics_kpis
+where season = '${inputs.season.value}'
+```
+
+```sql attack_rankings
+select
+    team_name,
+    goals_for,
+    total_xg,
+    xg_overperformance,
+    avg_shots_on_goal,
+    shot_conversion_pct,
+    on_target_conversion_pct
+from superligaen.team_analytics_kpis
+where season = '${inputs.season.value}'
+order by goals_for desc
+```
+
+```sql defence_rankings
+select
+    team_name,
+    goals_against,
+    avg_saves,
+    avg_goals_conceded
+from superligaen.team_analytics_kpis
+where season = '${inputs.season.value}'
+order by goals_against asc
+```
+
+```sql possession_rankings
+select
+    team_name,
+    avg_possession,
+    avg_pass_accuracy,
+    avg_corners,
+    avg_offsides
+from superligaen.team_analytics_kpis
+where season = '${inputs.season.value}'
+order by avg_possession desc
+```
+
+```sql discipline_rankings
+select
+    team_name,
+    yellow_cards,
+    red_cards,
+    avg_fouls,
+    aggression_index
+from superligaen.team_analytics_kpis
+where season = '${inputs.season.value}'
+order by aggression_index desc
+```
+
+```sql xg_vs_goals
+select
+    team_name,
+    goals_for,
+    round(total_xg, 2) as expected_goals,
+    xg_overperformance
+from superligaen.team_analytics_kpis
+where season = '${inputs.season.value}'
+order by goals_for desc
+```
+
+```sql points_vs_xg
+select
+    team_name,
+    total_points,
+    round(total_xg, 2) as total_xg
+from superligaen.team_analytics_kpis
+where season = '${inputs.season.value}'
+order by total_points desc
+```
+
+## {inputs.season.value} — League Overview
+
+<div class="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
+  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4 text-center"><BigValue data={league_kpis} value=total_goals          title="Goals Scored"       /></div>
+  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4 text-center"><BigValue data={league_kpis} value=total_xg             title="Total xG"           /></div>
+  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4 text-center"><BigValue data={league_kpis} value=total_yellow_cards   title="Yellow Cards"       /></div>
+  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4 text-center"><BigValue data={league_kpis} value=total_red_cards      title="Red Cards"          /></div>
+</div>
+
+---
+
+## League Table
+
+<DataTable data={league_table} rows=20>
+    <Column id=pos              title="#"            align=center />
+    <Column id=team_name        title="Team"         />
+    <Column id=mp               title="MP"           align=center />
+    <Column id=w                title="W"            align=center />
+    <Column id=d                title="D"            align=center />
+    <Column id=l                title="L"            align=center />
+    <Column id=gf               title="GF"           align=center />
+    <Column id=ga               title="GA"           align=center />
+    <Column id=gd               title="GD"           contentType=delta align=center />
+    <Column id=pts              title="Pts"          contentType=colorscale colorPalette={['white','#3b82f6']} align=center />
+    <Column id=win_rate_pct     title="Win %"        contentType=colorscale colorPalette={['white','#22c55e']} fmt='0.0"%"' />
+    <Column id=total_xg         title="xG"           contentType=colorscale colorPalette={['white','#6366f1']} />
+    <Column id=xg_overperformance title="xG OP"      contentType=delta />
+</DataTable>
+
+---
+
+## Attack — Who's Scoring?
+
+<div class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-6">
+
+<div>
+
+<BarChart
+    data={attack_rankings}
+    x=team_name
+    y=goals_for
+    title="Goals Scored"
+    xAxisTitle="Team"
+    yAxisTitle="Goals"
+    colorPalette={['#22c55e']}
+    swapXY=true
+/>
+
+</div>
+
+<div>
+
+<BarChart
+    data={attack_rankings}
+    x=team_name
+    y=shot_conversion_pct
+    title="Shot Conversion %"
+    xAxisTitle="Team"
+    yAxisTitle="Conversion %"
+    colorPalette={['#f59e0b']}
+    swapXY=true
+/>
+
+</div>
+
+</div>
+
+### Goals vs Expected Goals
+
+<BarChart
+    data={xg_vs_goals}
+    x=team_name
+    y={['goals_for', 'expected_goals']}
+    title="Goals Scored vs xG — Overperformers & Underperformers"
+    xAxisTitle="Team"
+    yAxisTitle="Goals / xG"
+    colorPalette={['#22c55e','#6366f1']}
+    swapXY=true
+/>
+
+---
+
+## Defence — Who's Keeping Clean Sheets?
+
+<div class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-6">
+
+<div>
+
+<BarChart
+    data={defence_rankings}
+    x=team_name
+    y=goals_against
+    title="Goals Conceded"
+    xAxisTitle="Team"
+    yAxisTitle="Goals Conceded"
+    colorPalette={['#ef4444']}
+    swapXY=true
+/>
+
+</div>
+
+<div>
+
+<BarChart
+    data={defence_rankings}
+    x=team_name
+    y=avg_saves
+    title="Avg Saves per Match"
+    xAxisTitle="Team"
+    yAxisTitle="Saves"
+    colorPalette={['#14b8a6']}
+    swapXY=true
+/>
+
+</div>
+
+</div>
+
+---
+
+## Possession & Passing
+
+<div class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-6">
+
+<div>
+
+<BarChart
+    data={possession_rankings}
+    x=team_name
+    y=avg_possession
+    title="Average Possession %"
+    xAxisTitle="Team"
+    yAxisTitle="Possession %"
+    colorPalette={['#8b5cf6']}
+    swapXY=true
+/>
+
+</div>
+
+<div>
+
+<BarChart
+    data={possession_rankings}
+    x=team_name
+    y=avg_pass_accuracy
+    title="Average Pass Accuracy %"
+    xAxisTitle="Team"
+    yAxisTitle="Pass Accuracy %"
+    colorPalette={['#0ea5e9']}
+    swapXY=true
+/>
+
+</div>
+
+</div>
+
+---
+
+## Discipline Index
+
+<BarChart
+    data={discipline_rankings}
+    x=team_name
+    y=aggression_index
+    title="Aggression Index — Fouls + Cards Weighted"
+    xAxisTitle="Team"
+    yAxisTitle="Aggression Index"
+    colorPalette={['#f97316']}
+    swapXY=true
+/>
+
+<div class="grid grid-cols-1 md:grid-cols-2 gap-6 mt-6">
+
+<div>
+
+<BarChart
+    data={discipline_rankings}
+    x=team_name
+    y=yellow_cards
+    title="Yellow Cards"
+    xAxisTitle="Team"
+    yAxisTitle="Yellow Cards"
+    colorPalette={['#eab308']}
+    swapXY=true
+/>
+
+</div>
+
+<div>
+
+<BarChart
+    data={discipline_rankings}
+    x=team_name
+    y=red_cards
+    title="Red Cards"
+    xAxisTitle="Team"
+    yAxisTitle="Red Cards"
+    colorPalette={['#dc2626']}
+    swapXY=true
+/>
+
+</div>
+
+</div>
+
+---
+
+## Full Team Benchmark
+
+<DataTable data={league_table} rows=20>
+    <Column id=pos                  title="#"             align=center />
+    <Column id=team_name            title="Team"          />
+    <Column id=pts                  title="Pts"           contentType=colorscale colorPalette={['white','#3b82f6']} align=center />
+    <Column id=gf                   title="GF"            align=center />
+    <Column id=ga                   title="GA"            align=center />
+    <Column id=gd                   title="GD"            contentType=delta align=center />
+    <Column id=total_xg             title="xG"            contentType=colorscale colorPalette={['white','#6366f1']} />
+    <Column id=xg_overperformance   title="xG OP"         contentType=delta />
+    <Column id=win_rate_pct         title="Win %"         contentType=colorscale colorPalette={['white','#22c55e']} fmt='0.0"%"' />
+</DataTable>

--- a/dashboards/pages/standings.md
+++ b/dashboards/pages/standings.md
@@ -11,7 +11,7 @@ select distinct season from superligaen.team_season_stats
 order by season desc
 ```
 
-<Dropdown data={seasons} name=season value=season label=season>
+<Dropdown data={seasons} name=season value=season label=season order="season desc">
     <DropdownOption value="2025/26" valueLabel="2025/26"/>
 </Dropdown>
 

--- a/dashboards/pages/team-analytics.md
+++ b/dashboards/pages/team-analytics.md
@@ -1,7 +1,7 @@
 ---
 sidebar: never
 hide_toc: true
-title: Team Analytics
+title: Team Analysis
 ---
 
 <a href="/" class="inline-flex items-center gap-1 text-sm text-gray-500 hover:text-gray-800 no-underline mb-6 transition-colors">← Back to Home</a>
@@ -16,7 +16,7 @@ select distinct team_name as team from superligaen.team_analytics_kpis
 order by team_name
 ```
 
-<Dropdown data={seasons} name=season value=season label=season>
+<Dropdown data={seasons} name=season value=season label=season order="season desc">
     <DropdownOption value="2025/26" valueLabel="2025/26"/>
 </Dropdown>
 

--- a/dashboards/pages/upcoming-matches.md
+++ b/dashboards/pages/upcoming-matches.md
@@ -14,6 +14,7 @@ select
     home_team,
     away_team,
     match_key,
+    kick_off_time,
     CASE WHEN stadium LIKE '%Unknown%' OR stadium LIKE '%Applicable%'
          THEN 'TBD' ELSE stadium END                                               as stadium,
     season
@@ -24,11 +25,11 @@ order by match_date asc
 ## Upcoming Fixtures
 
 <DataTable data={upcoming} rows=10>
-    <Column id=match_date  title="Date"    />
-    <Column id=round       title="Round"   />
-    <Column id=home_team   title="Home"    />
-    <Column id=away_team   title="Away"    />
-    <Column id=stadium     title="Stadium" />
+    <Column id=match_date    title="Date"    />
+    <Column id=kick_off_time title="KO"      />
+    <Column id=round         title="Round"   />
+    <Column id=match_name    title="Match"   wrap=true />
+    <Column id=stadium       title="Stadium" />
 </DataTable>
 
 ---
@@ -43,6 +44,7 @@ select
     away_team,
     strftime(match_date, '%d %b %Y')                          as match_date,
     round,
+    kick_off_time,
     CASE WHEN stadium LIKE '%Unknown%' OR stadium LIKE '%Applicable%'
          THEN 'TBD' ELSE stadium END                          as stadium
 from superligaen.upcoming_matches
@@ -84,30 +86,32 @@ where side = 'Home'
 
 ```sql home_form
 select
-    strftime(match_date, '%Y-%m-%d') as match_date,
-    match_name                       as match,
-    score
-from superligaen.match_results_by_match
-where match_name LIKE SPLIT_PART('${inputs.match.value}', '|||', 1) || ' - %'
-   or match_name LIKE '% - ' || SPLIT_PART('${inputs.match.value}', '|||', 1)
+    strftime(match_date, '%d %b') as match_date,
+    opponent,
+    gf,
+    ga,
+    result
+from superligaen.team_analytics_form
+where team_name = SPLIT_PART('${inputs.match.value}', '|||', 1)
 order by match_date desc
 limit 5
 ```
 
 ```sql away_form
 select
-    strftime(match_date, '%Y-%m-%d') as match_date,
-    match_name                       as match,
-    score
-from superligaen.match_results_by_match
-where match_name LIKE SPLIT_PART('${inputs.match.value}', '|||', 2) || ' - %'
-   or match_name LIKE '% - ' || SPLIT_PART('${inputs.match.value}', '|||', 2)
+    strftime(match_date, '%d %b') as match_date,
+    opponent,
+    gf,
+    ga,
+    result
+from superligaen.team_analytics_form
+where team_name = SPLIT_PART('${inputs.match.value}', '|||', 2)
 order by match_date desc
 limit 5
 ```
 
 <div class="rounded-2xl border border-gray-200 bg-gray-50 p-4 md:p-6 mb-6 text-center">
-  <div class="text-xs text-gray-400 uppercase tracking-widest mb-3">{match_info[0].round} &middot; {match_info[0].match_date} &middot; {match_info[0].stadium}</div>
+  <div class="text-xs text-gray-400 uppercase tracking-widest mb-3">{match_info[0].round} &middot; {match_info[0].match_date} &middot; {match_info[0].kick_off_time} &middot; {match_info[0].stadium}</div>
   <div class="flex items-center justify-center gap-4 md:gap-6">
     <div class="flex-1 min-w-0">
       <div class="text-base md:text-xl font-bold text-gray-800 truncate">{match_info[0].home_team}</div>
@@ -159,20 +163,46 @@ limit 5
 
 <div class="rounded-xl border border-gray-200 bg-gray-50 p-4">
   <div class="text-base font-bold text-gray-700 mb-3">{match_info[0].home_team}</div>
-  <DataTable data={home_form} rows=5>
-      <Column id=match_date  title="Date"  />
-      <Column id=match       title="Match" />
-      <Column id=score       title="Score" align=center />
-  </DataTable>
+  <div class="flex flex-col gap-2">
+    {#each home_form as m}
+      <div class="flex items-center justify-between rounded-lg bg-white border border-gray-100 px-3 py-2">
+        <div class="text-xs text-gray-400 w-14 shrink-0">{m.match_date}</div>
+        <div class="text-xs text-gray-600 flex-1 px-2 truncate">vs {m.opponent}</div>
+        <div class="text-sm font-bold text-gray-700 w-10 text-center shrink-0">{m.gf}–{m.ga}</div>
+        <div class="ml-2 shrink-0">
+          {#if m.result === 'Win'}
+            <span class="inline-block text-xs font-bold px-2 py-0.5 rounded bg-green-500 text-white">W</span>
+          {:else if m.result === 'Draw'}
+            <span class="inline-block text-xs font-bold px-2 py-0.5 rounded bg-yellow-400 text-white">D</span>
+          {:else}
+            <span class="inline-block text-xs font-bold px-2 py-0.5 rounded bg-red-500 text-white">L</span>
+          {/if}
+        </div>
+      </div>
+    {/each}
+  </div>
 </div>
 
 <div class="rounded-xl border border-gray-200 bg-gray-50 p-4">
   <div class="text-base font-bold text-gray-700 mb-3">{match_info[0].away_team}</div>
-  <DataTable data={away_form} rows=5>
-      <Column id=match_date  title="Date"  />
-      <Column id=match       title="Match" />
-      <Column id=score       title="Score" align=center />
-  </DataTable>
+  <div class="flex flex-col gap-2">
+    {#each away_form as m}
+      <div class="flex items-center justify-between rounded-lg bg-white border border-gray-100 px-3 py-2">
+        <div class="text-xs text-gray-400 w-14 shrink-0">{m.match_date}</div>
+        <div class="text-xs text-gray-600 flex-1 px-2 truncate">vs {m.opponent}</div>
+        <div class="text-sm font-bold text-gray-700 w-10 text-center shrink-0">{m.gf}–{m.ga}</div>
+        <div class="ml-2 shrink-0">
+          {#if m.result === 'Win'}
+            <span class="inline-block text-xs font-bold px-2 py-0.5 rounded bg-green-500 text-white">W</span>
+          {:else if m.result === 'Draw'}
+            <span class="inline-block text-xs font-bold px-2 py-0.5 rounded bg-yellow-400 text-white">D</span>
+          {:else}
+            <span class="inline-block text-xs font-bold px-2 py-0.5 rounded bg-red-500 text-white">L</span>
+          {/if}
+        </div>
+      </div>
+    {/each}
+  </div>
 </div>
 
 </div>

--- a/dashboards/pages/upcoming-matches.md
+++ b/dashboards/pages/upcoming-matches.md
@@ -10,6 +10,7 @@ title: Upcoming Fixtures
 select
     strftime(match_date, '%Y-%m-%d')                                              as match_date,
     round,
+    match_round_number,
     match_name,
     home_team,
     away_team,
@@ -25,18 +26,18 @@ order by match_date asc
 ## Upcoming Fixtures
 
 <DataTable data={upcoming} rows=10>
-    <Column id=match_date    title="Date"    />
-    <Column id=kick_off_time title="KO"      />
-    <Column id=round         title="Round"   />
-    <Column id=match_name    title="Match"   wrap=true />
-    <Column id=stadium       title="Stadium" />
+    <Column id=match_date    title="Date"        />
+    <Column id=round         title="Round"       />
+    <Column id=match_name    title="Match"       wrap=true />
+    <Column id=stadium       title="Stadium"     />
+    <Column id=kick_off_time title="Kick-Off Time" />
 </DataTable>
 
 ---
 
 ## Match Analysis
 
-<Dropdown data={upcoming} name=match value=match_key label=match_name />
+<Dropdown data={upcoming} name=match value=match_key label=match_name order="match_round_number desc, match_date asc" />
 
 ```sql match_info
 select
@@ -93,7 +94,7 @@ select
     result
 from superligaen.team_analytics_form
 where team_name = SPLIT_PART('${inputs.match.value}', '|||', 1)
-order by match_date desc
+order by epoch(match_date) desc
 limit 5
 ```
 
@@ -106,7 +107,7 @@ select
     result
 from superligaen.team_analytics_form
 where team_name = SPLIT_PART('${inputs.match.value}', '|||', 2)
-order by match_date desc
+order by epoch(match_date) desc
 limit 5
 ```
 
@@ -168,14 +169,14 @@ limit 5
       <div class="flex items-center justify-between rounded-lg bg-white border border-gray-100 px-3 py-2">
         <div class="text-xs text-gray-400 w-14 shrink-0">{m.match_date}</div>
         <div class="text-xs text-gray-600 flex-1 px-2 truncate">vs {m.opponent}</div>
-        <div class="text-sm font-bold text-gray-700 w-10 text-center shrink-0">{m.gf}–{m.ga}</div>
-        <div class="ml-2 shrink-0">
+        <div class="text-sm font-bold text-gray-700 w-12 text-center shrink-0">{m.gf}–{m.ga}</div>
+        <div class="w-8 text-center shrink-0">
           {#if m.result === 'Win'}
-            <span class="inline-block text-xs font-bold px-2 py-0.5 rounded bg-green-500 text-white">W</span>
+            <span class="inline-flex items-center justify-center w-6 h-5 text-xs font-bold rounded bg-green-500 text-white">W</span>
           {:else if m.result === 'Draw'}
-            <span class="inline-block text-xs font-bold px-2 py-0.5 rounded bg-yellow-400 text-white">D</span>
+            <span class="inline-flex items-center justify-center w-6 h-5 text-xs font-bold rounded bg-yellow-400 text-white">D</span>
           {:else}
-            <span class="inline-block text-xs font-bold px-2 py-0.5 rounded bg-red-500 text-white">L</span>
+            <span class="inline-flex items-center justify-center w-6 h-5 text-xs font-bold rounded bg-red-500 text-white">L</span>
           {/if}
         </div>
       </div>
@@ -190,14 +191,14 @@ limit 5
       <div class="flex items-center justify-between rounded-lg bg-white border border-gray-100 px-3 py-2">
         <div class="text-xs text-gray-400 w-14 shrink-0">{m.match_date}</div>
         <div class="text-xs text-gray-600 flex-1 px-2 truncate">vs {m.opponent}</div>
-        <div class="text-sm font-bold text-gray-700 w-10 text-center shrink-0">{m.gf}–{m.ga}</div>
-        <div class="ml-2 shrink-0">
+        <div class="text-sm font-bold text-gray-700 w-12 text-center shrink-0">{m.gf}–{m.ga}</div>
+        <div class="w-8 text-center shrink-0">
           {#if m.result === 'Win'}
-            <span class="inline-block text-xs font-bold px-2 py-0.5 rounded bg-green-500 text-white">W</span>
+            <span class="inline-flex items-center justify-center w-6 h-5 text-xs font-bold rounded bg-green-500 text-white">W</span>
           {:else if m.result === 'Draw'}
-            <span class="inline-block text-xs font-bold px-2 py-0.5 rounded bg-yellow-400 text-white">D</span>
+            <span class="inline-flex items-center justify-center w-6 h-5 text-xs font-bold rounded bg-yellow-400 text-white">D</span>
           {:else}
-            <span class="inline-block text-xs font-bold px-2 py-0.5 rounded bg-red-500 text-white">L</span>
+            <span class="inline-flex items-center justify-center w-6 h-5 text-xs font-bold rounded bg-red-500 text-white">L</span>
           {/if}
         </div>
       </div>

--- a/dashboards/sources/superligaen/referee_analytics.sql
+++ b/dashboards/sources/superligaen/referee_analytics.sql
@@ -1,0 +1,20 @@
+select
+    ref.referee_name,
+    m.season,
+    count(distinct m.match_sk)                                                              as matches_managed,
+    sum(f.yellow_cards)                                                                     as total_yellow_cards,
+    sum(f.red_cards)                                                                        as total_red_cards,
+    sum(f.fouls)                                                                            as total_fouls,
+    round(sum(f.yellow_cards)::double / count(distinct m.match_sk), 2)                     as avg_yellows_per_match,
+    round(sum(f.red_cards)::double / count(distinct m.match_sk), 2)                        as avg_reds_per_match,
+    round(sum(f.fouls)::double / count(distinct m.match_sk), 2)                            as avg_fouls_per_match,
+    round(sum(f.yellow_cards + f.red_cards * 3)::double / count(distinct m.match_sk), 2)  as card_severity_index
+from superligaen.gold.fct_match_results f
+join superligaen.gold.dim_referee      ref on ref.referee_sk      = f.referee_sk
+join superligaen.gold.dim_match        m   on m.match_sk          = f.match_sk
+join superligaen.gold.dim_match_result r   on r.match_result_sk  = f.match_result_sk
+where r.match_result in ('Win', 'Draw', 'Loss')
+  and ref.referee_name not like '%Unknown%'
+  and ref.referee_name not like '%Applicable%'
+group by ref.referee_name, m.season
+order by m.season desc, matches_managed desc

--- a/dashboards/sources/superligaen/referee_match_log.sql
+++ b/dashboards/sources/superligaen/referee_match_log.sql
@@ -1,0 +1,20 @@
+select
+    ref.referee_name,
+    m.season,
+    strftime(d.date, '%Y-%m-%d')   as match_date,
+    m.match_round_name              as round,
+    m.match_name,
+    m.match_result                  as score,
+    sum(f.yellow_cards)             as yellow_cards,
+    sum(f.red_cards)                as red_cards,
+    sum(f.fouls)                    as total_fouls
+from superligaen.gold.fct_match_results f
+join superligaen.gold.dim_referee      ref on ref.referee_sk     = f.referee_sk
+join superligaen.gold.dim_match        m   on m.match_sk         = f.match_sk
+join superligaen.gold.dim_match_result r   on r.match_result_sk = f.match_result_sk
+join superligaen.gold.dim_date         d   on d.date_sk          = f.date_sk
+where r.match_result in ('Win', 'Draw', 'Loss')
+  and ref.referee_name not like '%Unknown%'
+  and ref.referee_name not like '%Applicable%'
+group by ref.referee_name, m.season, d.date, m.match_round_name, m.match_name, m.match_result
+order by ref.referee_name, m.season desc, d.date desc

--- a/dashboards/sources/superligaen/referee_team_exposure.sql
+++ b/dashboards/sources/superligaen/referee_team_exposure.sql
@@ -1,0 +1,15 @@
+select
+    ref.referee_name,
+    m.season,
+    t.team_name,
+    count(distinct m.match_sk)  as matches
+from superligaen.gold.fct_match_results f
+join superligaen.gold.dim_referee      ref on ref.referee_sk     = f.referee_sk
+join superligaen.gold.dim_match        m   on m.match_sk         = f.match_sk
+join superligaen.gold.dim_match_result r   on r.match_result_sk = f.match_result_sk
+join superligaen.gold.dim_team         t   on t.team_sk          = f.team_sk
+where r.match_result in ('Win', 'Draw', 'Loss')
+  and ref.referee_name not like '%Unknown%'
+  and ref.referee_name not like '%Applicable%'
+group by ref.referee_name, m.season, t.team_name
+order by ref.referee_name, m.season desc, matches desc

--- a/dashboards/sources/superligaen/team_analytics_kpis.sql
+++ b/dashboards/sources/superligaen/team_analytics_kpis.sql
@@ -33,7 +33,8 @@ select
     round(
         (sum(f.fouls) + sum(f.yellow_cards) * 5 + sum(f.red_cards) * 15)
         ::double / count(*), 1
-    )                                                                               as aggression_index
+    )                                                                               as aggression_index,
+    count(*) filter (where f.goals_conceded = 0)                                    as clean_sheets
 from superligaen.gold.fct_match_results f
 join superligaen.gold.dim_team         t  on t.team_sk          = f.team_sk
 join superligaen.gold.dim_match        m  on m.match_sk         = f.match_sk

--- a/dashboards/sources/superligaen/upcoming_matches.sql
+++ b/dashboards/sources/superligaen/upcoming_matches.sql
@@ -1,6 +1,7 @@
 select
     d.date                                                               as match_date,
     m.match_round_name                                                        as round,
+    m.match_round_number,
     m.match_name,
     MAX(CASE WHEN ts.team_side = 'Home' THEN t.team_name END)                as home_team,
     MAX(CASE WHEN ts.team_side = 'Away' THEN t.team_name END)                as away_team,
@@ -18,5 +19,5 @@ join superligaen.gold.dim_match_result r  on r.match_result_sk = f.match_result_
 join superligaen.gold.dim_team         t  on t.team_sk        = f.team_sk
 join superligaen.gold.dim_team_side    ts on ts.team_side_sk  = f.team_side_sk
 where r.match_result = 'Pending'
-group by d.date, m.match_round_name, m.match_name, st.stadium_name, m.kick_off_time, m.season
+group by d.date, m.match_round_name, m.match_round_number, m.match_name, st.stadium_name, m.kick_off_time, m.season
 order by d.date asc

--- a/dashboards/sources/superligaen/upcoming_matches.sql
+++ b/dashboards/sources/superligaen/upcoming_matches.sql
@@ -8,6 +8,7 @@ select
         || '|||'
         || MAX(CASE WHEN ts.team_side = 'Away' THEN t.team_name END)         as match_key,
     st.stadium_name                                                           as stadium,
+    m.kick_off_time,
     m.season
 from superligaen.gold.fct_match_results f
 join superligaen.gold.dim_match        m  on m.match_sk       = f.match_sk
@@ -17,5 +18,5 @@ join superligaen.gold.dim_match_result r  on r.match_result_sk = f.match_result_
 join superligaen.gold.dim_team         t  on t.team_sk        = f.team_sk
 join superligaen.gold.dim_team_side    ts on ts.team_side_sk  = f.team_side_sk
 where r.match_result = 'Pending'
-group by d.date, m.match_round_name, m.match_name, st.stadium_name, m.season
+group by d.date, m.match_round_name, m.match_name, st.stadium_name, m.kick_off_time, m.season
 order by d.date asc

--- a/dbt/models/gold/dims/dim_match.sql
+++ b/dbt/models/gold/dims/dim_match.sql
@@ -3,9 +3,9 @@
         materialized='incremental',
         incremental_strategy='merge',
         unique_key='match_id',
-        merge_update_columns=['season', 'match_round_type', 'match_round_number', 'match_status', 'match_name', 'match_short_name', 'match_result'],
+        merge_update_columns=['season', 'match_round_type', 'match_round_number', 'match_status', 'match_name', 'match_short_name', 'match_result', 'kick_off_time'],
         post_hook=[
-            "INSERT INTO {{ this }} SELECT * FROM (VALUES (-1, NULL::INTEGER, NULL::VARCHAR, 'Unknown Match Round Name', 'Unknown Match Round Type', NULL::INTEGER, 'Unknown Match Status', 'Unknown Match Name', 'Unknown Match Short Name', NULL::VARCHAR), (-2, NULL::INTEGER, NULL::VARCHAR, 'Not Applicable Match Round Name', 'Not Applicable Match Round Type', NULL::INTEGER, 'Not Applicable Match Status', 'Not Applicable Match Name', 'Not Applicable Match Short Name', NULL::VARCHAR)) t(match_sk, match_id, season, match_round_name, match_round_type, match_round_number, match_status, match_name, match_short_name, match_result) WHERE t.match_sk NOT IN (SELECT match_sk FROM {{ this }})"
+            "INSERT INTO {{ this }} SELECT * FROM (VALUES (-1, NULL::INTEGER, NULL::VARCHAR, 'Unknown Match Round Name', 'Unknown Match Round Type', NULL::INTEGER, 'Unknown Match Status', 'Unknown Match Name', 'Unknown Match Short Name', NULL::VARCHAR, NULL::VARCHAR), (-2, NULL::INTEGER, NULL::VARCHAR, 'Not Applicable Match Round Name', 'Not Applicable Match Round Type', NULL::INTEGER, 'Not Applicable Match Status', 'Not Applicable Match Name', 'Not Applicable Match Short Name', NULL::VARCHAR, NULL::VARCHAR)) t(match_sk, match_id, season, match_round_name, match_round_type, match_round_number, match_status, match_name, match_short_name, match_result, kick_off_time) WHERE t.match_sk NOT IN (SELECT match_sk FROM {{ this }})"
         ]
     )
 }}
@@ -42,7 +42,8 @@ src AS (
         CASE
             WHEN f.status_short IN ('FT', 'AET', 'PEN')
             THEN f.goals_home::VARCHAR || ' - ' || f.goals_away::VARCHAR
-        END                                                                   AS match_result
+        END                                                                   AS match_result,
+        strftime(timezone('Europe/Copenhagen', f.kick_off), '%H:%M')         AS kick_off_time
     FROM {{ ref('fixtures') }} f
     LEFT JOIN team_round tr ON tr.fixture_id = f.fixture_id
     LEFT JOIN (
@@ -74,5 +75,6 @@ SELECT
     src.match_status,
     src.match_name,
     src.match_short_name,
-    src.match_result
+    src.match_result,
+    src.kick_off_time
 FROM src


### PR DESCRIPTION
## Summary

- **#99 — Upcoming Fixtures improvements**: added `kick_off_time` to `dim_match` (converted from UTC to Europe/Copenhagen), updated table to show match name instead of separate home/away columns + KO time column, added KO time to match banner, replaced form guide DataTables with inline W/D/L coloured cards using `team_analytics_form`
- **#100 — Match Results simplification**: round multi-select filter defaulting to most recent finished round, section title reflects season + round, 4 KPI cards only (Goals, Avg Goals/Match, Avg SoG, Total xG), clean results table without search or heading
- **#101 — Referee Analytics**: new page with season leaderboard, cards/fouls bar charts, team exposure per referee, per-match log; backed by new `referee_analytics.sql` source
- **#102 — Season Analytics**: new page with league table, attack/defence/possession/discipline rankings and cross-team benchmark charts; uses existing `team_analytics_kpis` source; both new pages added to homepage

## Test plan

- [ ] Run `dbt run --select gold.dim_match --target dev` to confirm `kick_off_time` column populates with valid HH:MM times
- [ ] Verify upcoming fixtures table shows KO time and match_name correctly
- [ ] Verify form guide W/D/L cards render with correct colours
- [ ] Verify match results round filter defaults to most recent round and multi-select works
- [ ] Open `/referee-analytics` and confirm leaderboard, charts and deep dive all load
- [ ] Open `/season-analytics` and confirm league table and all benchmark charts load

🤖 Generated with [Claude Code](https://claude.com/claude-code)