### PR TITLE
fix: sort upcoming fixtures by date+kickoff; move Upcoming Fixtures before Team Analysis (#104 #105)

### DIFF
--- a/dashboards/pages/index.md
+++ b/dashboards/pages/index.md
@@ -70,22 +70,22 @@ select * from superligaen.current_leader
   </div>
 </a>
 
-<a href="/team-analytics" class="block no-underline rounded-xl border border-gray-200 bg-white p-6 hover:border-blue-500 hover:shadow-lg transition-all duration-200 group shadow-sm">
-  <div class="flex items-start gap-4">
-    <div class="text-3xl">📊</div>
-    <div>
-      <div class="text-base font-bold text-gray-800 group-hover:text-blue-500 transition-colors">Team Analysis</div>
-      <div class="text-gray-400 text-sm mt-1">Deep-dive KPIs, form, shooting accuracy &amp; discipline</div>
-    </div>
-  </div>
-</a>
-
 <a href="/upcoming-matches" class="block no-underline rounded-xl border border-gray-200 bg-white p-6 hover:border-blue-500 hover:shadow-lg transition-all duration-200 group shadow-sm">
   <div class="flex items-start gap-4">
     <div class="text-3xl">📅</div>
     <div>
       <div class="text-base font-bold text-gray-800 group-hover:text-blue-500 transition-colors">Upcoming Fixtures</div>
       <div class="text-gray-400 text-sm mt-1">Head-to-head history &amp; form guide for upcoming matches</div>
+    </div>
+  </div>
+</a>
+
+<a href="/team-analytics" class="block no-underline rounded-xl border border-gray-200 bg-white p-6 hover:border-blue-500 hover:shadow-lg transition-all duration-200 group shadow-sm">
+  <div class="flex items-start gap-4">
+    <div class="text-3xl">📊</div>
+    <div>
+      <div class="text-base font-bold text-gray-800 group-hover:text-blue-500 transition-colors">Team Analysis</div>
+      <div class="text-gray-400 text-sm mt-1">Deep-dive KPIs, form, shooting accuracy &amp; discipline</div>
     </div>
   </div>
 </a>

--- a/dashboards/pages/index.md
+++ b/dashboards/pages/index.md
@@ -80,22 +80,22 @@ select * from superligaen.current_leader
   </div>
 </a>
 
-<a href="/team-analytics" class="block no-underline rounded-xl border border-gray-200 bg-white p-6 hover:border-blue-500 hover:shadow-lg transition-all duration-200 group shadow-sm">
-  <div class="flex items-start gap-4">
-    <div class="text-3xl">📊</div>
-    <div>
-      <div class="text-base font-bold text-gray-800 group-hover:text-blue-500 transition-colors">Team Analysis</div>
-      <div class="text-gray-400 text-sm mt-1">Deep-dive KPIs, form, shooting accuracy &amp; discipline</div>
-    </div>
-  </div>
-</a>
-
 <a href="/league-analytics" class="block no-underline rounded-xl border border-gray-200 bg-white p-6 hover:border-blue-500 hover:shadow-lg transition-all duration-200 group shadow-sm">
   <div class="flex items-start gap-4">
     <div class="text-3xl">🌍</div>
     <div>
       <div class="text-base font-bold text-gray-800 group-hover:text-blue-500 transition-colors">League Analysis</div>
       <div class="text-gray-400 text-sm mt-1">Cross-team benchmarks, rankings and league-wide trends</div>
+    </div>
+  </div>
+</a>
+
+<a href="/team-analytics" class="block no-underline rounded-xl border border-gray-200 bg-white p-6 hover:border-blue-500 hover:shadow-lg transition-all duration-200 group shadow-sm">
+  <div class="flex items-start gap-4">
+    <div class="text-3xl">📊</div>
+    <div>
+      <div class="text-base font-bold text-gray-800 group-hover:text-blue-500 transition-colors">Team Analysis</div>
+      <div class="text-gray-400 text-sm mt-1">Deep-dive KPIs, form, shooting accuracy &amp; discipline</div>
     </div>
   </div>
 </a>

--- a/dashboards/pages/upcoming-matches.md
+++ b/dashboards/pages/upcoming-matches.md
@@ -20,7 +20,7 @@ select
          THEN 'TBD' ELSE stadium END                                               as stadium,
     season
 from superligaen.upcoming_matches
-order by match_date asc
+order by match_date asc, kick_off_time asc
 ```
 
 ## Upcoming Fixtures


### PR DESCRIPTION
## Summary
- **#104**: Added `kick_off_time asc` to the `ORDER BY` in the Upcoming Fixtures query so matches with the same date are sorted by kick-off time
- **#105**: Swapped the Upcoming Fixtures and Team Analysis cards on the home page so Upcoming Fixtures appears first

## Test plan
- [ ] Upcoming Fixtures table shows matches ordered by date then kick-off time (earliest first)
- [ ] Home page grid shows Upcoming Fixtures card before Team Analysis card

🤖 Generated with [Claude Code](https://claude.com/claude-code)