### PR TITLE
feat: add Vercel Analytics (correct implementation)

### DIFF
--- a/dashboards/package-lock.json
+++ b/dashboards/package-lock.json
@@ -21,7 +21,8 @@
         "@evidence-dev/snowflake": "^1.2.4",
         "@evidence-dev/source-javascript": "^0.0.3",
         "@evidence-dev/sqlite": "^2.0.9",
-        "@evidence-dev/trino": "^1.0.11"
+        "@evidence-dev/trino": "^1.0.11",
+        "@vercel/analytics": "^2.0.1"
       },
       "engines": {
         "node": ">=18.0.0",
@@ -6410,6 +6411,48 @@
       "resolved": "https://registry.npmjs.org/@uwdata/mosaic-sql/-/mosaic-sql-0.3.5.tgz",
       "integrity": "sha512-/xdasEcxBzBG1O9WyhnsFnbf/GXjKSbl4lcpg3Cawrl3m6EuA9mKm0WStxAlEBRj1CscJbOHi355e1g7bv/zGg==",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/@vercel/analytics": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-2.0.1.tgz",
+      "integrity": "sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@remix-run/react": "^2",
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "nuxt": ">= 3",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@remix-run/react": {
+          "optional": true
+        },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "nuxt": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@vitest/coverage-v8": {
       "version": "3.0.5",

--- a/dashboards/package.json
+++ b/dashboards/package.json
@@ -29,7 +29,8 @@
     "@evidence-dev/snowflake": "^1.2.4",
     "@evidence-dev/source-javascript": "^0.0.3",
     "@evidence-dev/sqlite": "^2.0.9",
-    "@evidence-dev/trino": "^1.0.11"
+    "@evidence-dev/trino": "^1.0.11",
+    "@vercel/analytics": "^2.0.1"
   },
   "overrides": {
     "jsonwebtoken": "9.0.0",

--- a/dashboards/pages/+layout.svelte
+++ b/dashboards/pages/+layout.svelte
@@ -1,0 +1,15 @@
+<script>
+  import '@evidence-dev/tailwind/fonts.css';
+  import '../app.css';
+  import { EvidenceDefaultLayout } from '@evidence-dev/core-components';
+  import { onMount } from 'svelte';
+  import { inject } from '@vercel/analytics';
+
+  export let data;
+
+  onMount(() => inject());
+</script>
+
+<EvidenceDefaultLayout {data}>
+  <slot slot="content" />
+</EvidenceDefaultLayout>


### PR DESCRIPTION
## Summary
Properly integrates Vercel Analytics by extending Evidence.dev's own layout rather than replacing it.

The previous attempt (`pages/+layout.svelte` with just `<slot />`) overwrote Evidence's built-in layout and stripped all navigation/UI chrome. This version copies Evidence's exact layout and adds the `inject()` call alongside it.

## Test plan
- [ ] Site layout and navigation look normal after deploy
- [ ] Visits appear in Vercel → Analytics tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)