### PR TITLE
feat: add Cloudflare Web Analytics alongside Vercel Analytics

### DIFF
--- a/dashboards/pages/+layout.svelte
+++ b/dashboards/pages/+layout.svelte
@@ -7,7 +7,14 @@
 
   export let data;
 
-  onMount(() => inject());
+  onMount(() => {
+    inject();
+    const script = document.createElement('script');
+    script.defer = true;
+    script.src = 'https://static.cloudflareinsights.com/beacon.min.js';
+    script.dataset.cfBeacon = JSON.stringify({ token: '167db4d57c9742e1883b3e1ea858bccc' });
+    document.head.appendChild(script);
+  });
 </script>
 
 <EvidenceDefaultLayout {data}>


### PR DESCRIPTION
## Summary
Adds Cloudflare Web Analytics beacon alongside the existing Vercel Analytics inject, giving visibility in both dashboards.

Used a JS-based injection (`document.createElement`) instead of a `<svelte:head>` script tag to avoid Svelte parsing the `{}` characters in the `data-cf-beacon` attribute as template expressions.

## Test plan
- [ ] Layout looks normal after deploy
- [ ] Visits appear in Vercel → Analytics tab
- [ ] Visits appear in Cloudflare → Web Analytics tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)