### PR TITLE
fix: set DBT_DATABASE so silver reads from correct bronze database

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -95,6 +95,7 @@ jobs:
         working-directory: dbt
         env:
           MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
+          DBT_DATABASE: ${{ github.event.inputs.target_db || 'superligaen' }}
         run: |
           TARGET=$([ "${{ github.event.inputs.target_db || 'superligaen' }}" = "superligaen" ] && echo "prod" || echo "dev")
           dbt run --select silver.* --target $TARGET --vars '{"lookback_days": ${{ github.event.inputs.lookback || '5' }}}'
@@ -104,6 +105,7 @@ jobs:
         working-directory: dbt
         env:
           MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
+          DBT_DATABASE: ${{ github.event.inputs.target_db || 'superligaen' }}
         run: |
           TARGET=$([ "${{ github.event.inputs.target_db || 'superligaen' }}" = "superligaen" ] && echo "prod" || echo "dev")
           if [ -n "${{ github.event.inputs.season }}" ]; then

--- a/.github/workflows/transform.yml
+++ b/.github/workflows/transform.yml
@@ -49,6 +49,7 @@ jobs:
         working-directory: dbt
         env:
           MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
+          DBT_DATABASE: ${{ github.event.inputs.target_db || 'superligaen' }}
         run: |
           TARGET=$([ "${{ github.event.inputs.target_db || 'superligaen' }}" = "superligaen" ] && echo "prod" || echo "dev")
           dbt run --select 'silver.*' --target $TARGET --vars '{"lookback_days": ${{ github.event.inputs.lookback || '5' }}}'
@@ -58,6 +59,7 @@ jobs:
         working-directory: dbt
         env:
           MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
+          DBT_DATABASE: ${{ github.event.inputs.target_db || 'superligaen' }}
         run: |
           TARGET=$([ "${{ github.event.inputs.target_db || 'superligaen' }}" = "superligaen" ] && echo "prod" || echo "dev")
           dbt run --select 'silver.*' --target $TARGET --vars '{"season": ${{ github.event.inputs.season }}}'
@@ -67,6 +69,7 @@ jobs:
         working-directory: dbt
         env:
           MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
+          DBT_DATABASE: ${{ github.event.inputs.target_db || 'superligaen' }}
         run: |
           TARGET=$([ "${{ github.event.inputs.target_db || 'superligaen' }}" = "superligaen" ] && echo "prod" || echo "dev")
           dbt run --select 'silver.*' --target $TARGET --full-refresh


### PR DESCRIPTION
## Root cause

`dbt/models/silver/_sources.yml` resolves the bronze database via:
```yaml
database: "{{ env_var('DBT_DATABASE', 'superligaen_dev') }}"
```

The `transform` steps in both `master.yml` and `transform.yml` only set `MOTHERDUCK_TOKEN` — `DBT_DATABASE` was never set. As a result, **every dbt silver run against prod was silently reading bronze from `superligaen_dev`** (dev database) instead of `superligaen` (prod). Bronze records ingested during the nightly pipeline were never visible to the silver transformation, so statuses like NS never updated to FT/2H.

## Fix

Added `DBT_DATABASE: ${{ github.event.inputs.target_db || 'superligaen' }}` to all silver dbt run steps in both workflows so the bronze source resolves to the same database being targeted.

## Immediate data fix

Manually corrected `superligaen.silver.fixtures` for fixture_id=1530572 via MotherDuck (was NS, now 2H matching bronze). The nightly pipeline at 23:00 UTC will update it to FT once the API returns the final result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)