### PR TITLE
fix: derive bronze source database from dbt target

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -95,7 +95,6 @@ jobs:
         working-directory: dbt
         env:
           MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
-          DBT_DATABASE: ${{ github.event.inputs.target_db || 'superligaen' }}
         run: |
           TARGET=$([ "${{ github.event.inputs.target_db || 'superligaen' }}" = "superligaen" ] && echo "prod" || echo "dev")
           dbt run --select silver.* --target $TARGET --vars '{"lookback_days": ${{ github.event.inputs.lookback || '5' }}}'
@@ -105,7 +104,6 @@ jobs:
         working-directory: dbt
         env:
           MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
-          DBT_DATABASE: ${{ github.event.inputs.target_db || 'superligaen' }}
         run: |
           TARGET=$([ "${{ github.event.inputs.target_db || 'superligaen' }}" = "superligaen" ] && echo "prod" || echo "dev")
           if [ -n "${{ github.event.inputs.season }}" ]; then

--- a/.github/workflows/transform.yml
+++ b/.github/workflows/transform.yml
@@ -49,7 +49,6 @@ jobs:
         working-directory: dbt
         env:
           MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
-          DBT_DATABASE: ${{ github.event.inputs.target_db || 'superligaen' }}
         run: |
           TARGET=$([ "${{ github.event.inputs.target_db || 'superligaen' }}" = "superligaen" ] && echo "prod" || echo "dev")
           dbt run --select 'silver.*' --target $TARGET --vars '{"lookback_days": ${{ github.event.inputs.lookback || '5' }}}'
@@ -59,7 +58,6 @@ jobs:
         working-directory: dbt
         env:
           MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
-          DBT_DATABASE: ${{ github.event.inputs.target_db || 'superligaen' }}
         run: |
           TARGET=$([ "${{ github.event.inputs.target_db || 'superligaen' }}" = "superligaen" ] && echo "prod" || echo "dev")
           dbt run --select 'silver.*' --target $TARGET --vars '{"season": ${{ github.event.inputs.season }}}'
@@ -69,7 +67,6 @@ jobs:
         working-directory: dbt
         env:
           MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
-          DBT_DATABASE: ${{ github.event.inputs.target_db || 'superligaen' }}
         run: |
           TARGET=$([ "${{ github.event.inputs.target_db || 'superligaen' }}" = "superligaen" ] && echo "prod" || echo "dev")
           dbt run --select 'silver.*' --target $TARGET --full-refresh

--- a/dbt/models/silver/_sources.yml
+++ b/dbt/models/silver/_sources.yml
@@ -2,7 +2,7 @@ version: 2
 
 sources:
   - name: bronze
-    database: "{{ env_var('DBT_DATABASE', 'superligaen_dev') }}"
+    database: "{{ 'superligaen' if target.name == 'prod' else 'superligaen_dev' }}"
     schema: bronze
     tables:
       - name: api_football__fixtures


### PR DESCRIPTION
## Problem

PR #115 fixed the symptoms (missing `DBT_DATABASE` in workflows) but not the root cause. `_sources.yml` was relying on an env var with a hardcoded dev default — a config that could silently break any time someone runs dbt without setting it.

## Fix

```yaml
# before
database: "{{ env_var('DBT_DATABASE', 'superligaen_dev') }}"

# after
database: "{{ 'superligaen' if target.name == 'prod' else 'superligaen_dev' }}"
```

The bronze source database now derives from the dbt target, which is already the authoritative signal for which environment is being used. Also reverts the `DBT_DATABASE` env var additions to the workflows from PR #115 since they're no longer needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)