### PR TITLE
fix: require TARGET_DB in ingestion — no silent dev default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
 MOTHERDUCK_TOKEN=
 API_FOOTBALL_KEY=
-# TARGET_DB defaults to superligaen_dev — set to superligaen for prod
-TARGET_DB=superligaen_dev
+# TARGET_DB is required — set to superligaen (prod) or superligaen_dev (dev)
+TARGET_DB=

--- a/ingestion/db.py
+++ b/ingestion/db.py
@@ -49,7 +49,9 @@ ALL_BRONZE_TABLES = (
 def connect(target_db: str | None = None) -> duckdb.DuckDBPyConnection:
     token = os.environ["MOTHERDUCK_TOKEN"]
     if target_db is None:
-        target_db = os.environ.get("TARGET_DB", "superligaen_dev")
+        target_db = os.environ.get("TARGET_DB")
+    if not target_db:
+        raise RuntimeError("TARGET_DB env var is required — set it to 'superligaen' or 'superligaen_dev'")
     conn = duckdb.connect(f"md:{target_db}?motherduck_token={token}")
     log.info("Connected to MotherDuck: %s", target_db)
     return conn


### PR DESCRIPTION
## Problem

`ingestion/db.py` defaulted to `superligaen_dev` when `TARGET_DB` was unset — same silent-failure pattern that caused prod silver to read from dev bronze.

## Fix

Raise a `RuntimeError` if `TARGET_DB` is not set, forcing the caller to be explicit. Updated `.env.example` accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)