### PR TITLE
feat(#119): About This Project page

### DIFF
--- a/dashboards/pages/about.md
+++ b/dashboards/pages/about.md
@@ -1,0 +1,36 @@
+---
+title: About This Project
+---
+
+# About This Project
+
+## The Idea
+
+I am **Salih Ugur Kimilli**, a data engineer who loves turning raw data into useful insights. After moving to Denmark, I realised I knew very little about Danish football. I also wanted to build a real end-to-end data engineering project using only free, open-source tools — no vendor lock-in, no cloud bills.
+
+The two goals came together naturally: why not build an analytical product for **Superligaen**, the Danish Premier Football League? Something I could actually use myself, and that anyone curious about Danish football could benefit from too.
+
+That's how this project was born.
+
+## What Was Built
+
+A fully automated data pipeline that:
+
+- Ingests live match data from [api-football.com](https://www.api-football.com/) into a **MotherDuck** cloud data warehouse
+- Transforms raw JSON through **Bronze → Silver → Gold** layers using **dbt**
+- Serves analytics via this **Evidence.dev** dashboard, deployed on **Vercel**
+- Runs nightly via **GitHub Actions**
+
+## The Full Journey
+
+The complete story — every decision, every mistake, every fix — is documented in the blog:
+
+<a href="https://saugki1773.github.io/data-engineering-demo/" target="_blank" class="inline-flex items-center gap-2 mt-2 px-5 py-3 rounded-xl bg-gray-900 text-white font-semibold hover:bg-gray-700 transition-colors no-underline">
+  📖 Data Engineer's Diary
+</a>
+
+## Connect
+
+<a href="https://www.linkedin.com/in/salih-ugur-kimilli-since1773/" target="_blank" class="inline-flex items-center gap-2 mt-2 px-5 py-3 rounded-xl bg-blue-600 text-white font-semibold hover:bg-blue-700 transition-colors no-underline">
+  LinkedIn — Salih Ugur Kimilli
+</a>

--- a/dashboards/pages/index.md
+++ b/dashboards/pages/index.md
@@ -120,4 +120,14 @@ select * from superligaen.current_leader
   </div>
 </a>
 
+<a href="/about" class="block no-underline rounded-xl border border-gray-200 bg-white p-6 hover:border-blue-500 hover:shadow-lg transition-all duration-200 group shadow-sm">
+  <div class="flex items-start gap-4">
+    <div class="text-3xl">👤</div>
+    <div>
+      <div class="text-base font-bold text-gray-800 group-hover:text-blue-500 transition-colors">About This Project</div>
+      <div class="text-gray-400 text-sm mt-1">The story behind this project, the blog &amp; the author</div>
+    </div>
+  </div>
+</a>
+
 </div>


### PR DESCRIPTION
## Summary
- Adds `/about` page with a brief intro on the author and how the project was started, links to the Data Engineer's Diary blog and LinkedIn profile
- Adds About nav card to the homepage grid

Closes #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)