### PR TITLE
fix: bump blog workflow to Ruby 3.2

### DIFF
--- a/.github/workflows/blog.yml
+++ b/.github/workflows/blog.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.1"
+          ruby-version: "3.2"
           bundler-cache: true
           working-directory: docs
 


### PR DESCRIPTION
## Summary
- Bumps Ruby from 3.1 → 3.2 in the blog workflow
- `sass-embedded 1.99.0` (pinned in `Gemfile.lock`) requires Ruby >= 3.2, causing the 3.1 build to fail
- `docs/_plugins/untaint_fix.rb` patches the Liquid 4.0.3 `taint` API removal on Ruby 3.2 — this works under GitHub Actions (plugins are not blocked, unlike the old legacy Pages build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)