### PR TITLE
fix: update About page intro text and remove duplicate heading

### DIFF
--- a/dashboards/pages/about.md
+++ b/dashboards/pages/about.md
@@ -2,13 +2,11 @@
 title: About This Project
 ---
 
-# About This Project
-
 ## The Idea
 
-I am **Salih Ugur Kimilli**, a data engineer who loves turning raw data into useful insights. After moving to Denmark, I realised I knew very little about Danish football. I also wanted to build a real end-to-end data engineering project using only free, open-source tools — no vendor lock-in, no cloud bills.
+I am **Salih Ugur Kimilli**, a data engineer who loves turning raw data into useful insights. I wanted to build a real end-to-end data engineering project using only free, open-source tools — no vendor lock-in, no cloud bills. Around the same time, I had recently moved to Denmark and realised I knew very little about Danish football.
 
-The two goals came together naturally: why not build an analytical product for **Superligaen**, the Danish Premier Football League? Something I could actually use myself, and that anyone curious about Danish football could benefit from too.
+The two things clicked together: why not build an analytical product for **Superligaen**, the Danish Premier Football League? Something I could actually use myself, and that anyone curious about Danish football could benefit from too.
 
 That's how this project was born.
 

--- a/dashboards/pages/about.md
+++ b/dashboards/pages/about.md
@@ -4,7 +4,7 @@ title: About This Project
 
 ## The Idea
 
-I am **Salih Ugur Kimilli**, a data engineer who loves turning raw data into useful insights. I wanted to build a real end-to-end data engineering project using only free, open-source tools — no vendor lock-in, no cloud bills. Around the same time, I had recently moved to Denmark and realised I knew very little about Danish football.
+I am **Salih Ugur Kimilli**, a data engineer who loves turning raw data into insights. I wanted to build a real end-to-end data engineering project using only free, open-source tools — no vendor lock-in, no cloud bills. Around the same time, I had recently moved to Denmark and realised I knew very little about Danish football.
 
 The two things clicked together: why not build an analytical product for **Superligaen**, the Danish Premier Football League? Something I could actually use myself, and that anyone curious about Danish football could benefit from too.
 


### PR DESCRIPTION
## Summary
- Rewrites The Idea intro: data engineering goal first, then Denmark/football
- Removes duplicate `# About This Project` h1 (page title from frontmatter already renders it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)