### PR TITLE
fix: scroll to top on every page navigation

### DIFF
--- a/dashboards/pages/+layout.svelte
+++ b/dashboards/pages/+layout.svelte
@@ -9,7 +9,7 @@
   export let data;
 
   afterNavigate(() => {
-    window.scrollTo(0, 0);
+    setTimeout(() => window.scrollTo(0, 0), 0);
   });
 
   onMount(() => {

--- a/dashboards/pages/+layout.svelte
+++ b/dashboards/pages/+layout.svelte
@@ -3,9 +3,14 @@
   import '../app.css';
   import { EvidenceDefaultLayout } from '@evidence-dev/core-components';
   import { onMount } from 'svelte';
+  import { afterNavigate } from '$app/navigation';
   import { inject } from '@vercel/analytics';
 
   export let data;
+
+  afterNavigate(() => {
+    window.scrollTo(0, 0);
+  });
 
   onMount(() => {
     inject();


### PR DESCRIPTION
## Summary

- Uses SvelteKit's `afterNavigate` hook to call `window.scrollTo(0, 0)` on every page transition
- Fixes mobile UX where navigating to a new page would land mid-page from the previous scroll position

🤖 Generated with [Claude Code](https://claude.com/claude-code)