### PR TITLE
feat: filter sync_dev_db by season

### DIFF
--- a/.github/workflows/sync-dev-db.yml
+++ b/.github/workflows/sync-dev-db.yml
@@ -2,6 +2,11 @@ name: Sync dev database from prod
 
 on:
   workflow_dispatch:
+    inputs:
+      season:
+        description: "Season year to copy into dev (e.g. 2024 for the 2024/25 season)"
+        required: true
+        default: "2024"
 
 jobs:
   sync:
@@ -24,4 +29,4 @@ jobs:
       - name: Copy superligaen → superligaen_dev
         env:
           MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
-        run: python scripts/sync_dev_db.py
+        run: python scripts/sync_dev_db.py --season ${{ github.event.inputs.season }}

--- a/scripts/sync_dev_db.py
+++ b/scripts/sync_dev_db.py
@@ -4,9 +4,13 @@ Syncs superligaen_dev from superligaen (prod).
 Steps:
   1. Discover all schemas and tables in prod
   2. Drop all existing tables in dev
-  3. Recreate each table in dev as a full copy from prod
+  3. Recreate each table in dev, filtering by season where the column exists
+
+Pass --season <year> (e.g. 2024) to copy only that season's data.
+Tables without a season column are always copied in full (e.g. venues).
 """
 
+import argparse
 import logging
 import os
 
@@ -26,7 +30,31 @@ def connect():
     return duckdb.connect(f"md:?motherduck_token={token}")
 
 
+def season_column_info(con, db):
+    """Returns {(schema, table): data_type} for every table that has a season column."""
+    rows = con.execute(f"""
+        SELECT schema_name, table_name, data_type
+        FROM duckdb_columns()
+        WHERE database_name = '{db}'
+          AND column_name = 'season'
+    """).fetchall()
+    return {(schema, table): dtype for schema, table, dtype in rows}
+
+
+def season_filter(dtype, season_int):
+    """Build a WHERE clause fragment matching the season column's type."""
+    season_str = f"{season_int}/{str(season_int + 1)[-2:]}"   # e.g. 2024/25
+    if "INT" in dtype.upper():
+        return f"WHERE season = {season_int}"
+    return f"WHERE season = '{season_str}'"
+
+
 def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--season", type=int, required=True,
+                        help="Season year to copy (e.g. 2024 for the 2024/25 season)")
+    args = parser.parse_args()
+
     con = connect()
 
     # Discover all base tables in prod
@@ -42,6 +70,10 @@ def main():
         raise SystemExit(1)
 
     log.info("Found %d tables in %s", len(prod_tables), PROD_DB)
+
+    # Determine which tables have a season column and their type
+    season_cols = season_column_info(con, PROD_DB)
+    log.info("Season-filterable tables: %d", len(season_cols))
 
     # Drop existing tables in dev
     dev_tables = con.execute(f"""
@@ -61,14 +93,25 @@ def main():
         con.execute(f"CREATE SCHEMA IF NOT EXISTS {DEV_DB}.{schema}")
 
     # Copy each table from prod to dev
+    copied = 0
     for schema, table in prod_tables:
-        log.info("Copying %s.%s -> %s.%s", PROD_DB, f"{schema}.{table}", DEV_DB, f"{schema}.{table}")
+        key = (schema, table)
+        if key in season_cols:
+            where = season_filter(season_cols[key], args.season)
+            log.info("Copying %s.%s (season=%s)", schema, table, args.season)
+        else:
+            where = ""
+            log.info("Copying %s.%s (full)", schema, table)
+
         con.execute(f"""
             CREATE OR REPLACE TABLE {DEV_DB}.{schema}.{table} AS
             SELECT * FROM {PROD_DB}.{schema}.{table}
+            {where}
         """)
+        copied += 1
 
-    log.info("Sync complete — %d tables copied from %s to %s", len(prod_tables), PROD_DB, DEV_DB)
+    log.info("Sync complete — %d tables copied from %s to %s (season filter: %s)",
+             copied, PROD_DB, DEV_DB, args.season)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- `sync_dev_db.py` now accepts `--season <year>` (e.g. `2024`)
- Tables with a `season` column are filtered to that season only — reduces dev DB size significantly
- Tables without a `season` column (e.g. `venues`, `teams`) are always copied in full
- Handles both INTEGER season format (bronze/silver) and VARCHAR `'2024/25'` format (gold) by inspecting the column type via `duckdb_columns()`
- GitHub Actions workflow exposes `season` as a required `workflow_dispatch` input (defaults to `2024`)

## Test plan
- [ ] Trigger workflow with `season=2024` and verify dev DB only contains 2024/25 data in filtered tables
- [ ] Verify lookup tables like `venues` are fully copied

🤖 Generated with [Claude Code](https://claude.com/claude-code)