### PR TITLE
feat: add suggestion issue template and feedback button

### DIFF
--- a/.github/ISSUE_TEMPLATE/suggestion.md
+++ b/.github/ISSUE_TEMPLATE/suggestion.md
@@ -1,0 +1,16 @@
+---
+name: Suggestion
+about: Share an idea or improvement for the dashboard
+title: "[Suggestion] "
+labels: enhancement
+assignees: ''
+---
+
+**What page or feature does this relate to?**
+<!-- e.g. League Analysis, Team Analytics, Home page, data pipeline... -->
+
+**What would you like to see?**
+<!-- Describe your idea as clearly as you can. -->
+
+**Why would this be useful?**
+<!-- How would it improve your experience? -->

--- a/dashboards/pages/about.md
+++ b/dashboards/pages/about.md
@@ -42,7 +42,7 @@ This dashboard is free to use and updated every day. If you find it useful, cons
 Have a suggestion for the dashboard? Open an issue on GitHub — no account needed beyond a free sign-up.
 
 <div class="-mt-3">
-<a href="https://github.com/SaUgKi1773/data-engineering-demo/issues/new?template=suggestion.md" target="_blank" class="inline-flex items-center gap-2 px-5 py-3 rounded-xl bg-violet-600 text-white font-semibold hover:bg-violet-700 transition-colors no-underline">
+<a href="https://github.com/SaUgKi1773/data-engineering-demo/issues/new?template=suggestion.md" target="_blank" class="inline-flex items-center gap-2 px-5 py-3 rounded-xl bg-teal-600 text-white font-semibold hover:bg-teal-700 transition-colors no-underline">
   Share a Suggestion
 </a>
 </div>

--- a/dashboards/pages/about.md
+++ b/dashboards/pages/about.md
@@ -37,6 +37,16 @@ This dashboard is free to use and updated every day. If you find it useful, cons
 </a>
 </div>
 
+## Share an Idea
+
+Have a suggestion for the dashboard? Open an issue on GitHub — no account needed beyond a free sign-up.
+
+<div class="-mt-3">
+<a href="https://github.com/SaUgKi1773/data-engineering-demo/issues/new?template=suggestion.md" target="_blank" class="inline-flex items-center gap-2 px-5 py-3 rounded-xl bg-violet-600 text-white font-semibold hover:bg-violet-700 transition-colors no-underline">
+  Share a Suggestion
+</a>
+</div>
+
 ## Connect
 
 <div class="mt-2">


### PR DESCRIPTION
## Summary

- Adds `.github/ISSUE_TEMPLATE/suggestion.md` — structured template with fields for page, idea, and why it's useful
- Adds a "Share a Suggestion" button on the About page linking directly to the pre-filled template
- Button sits between Support and Connect sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)