### PR TITLE
fix: include Championship and Relegation rounds in points progression

### DIFF
--- a/dashboards/sources/superligaen/points_progression.sql
+++ b/dashboards/sources/superligaen/points_progression.sql
@@ -10,6 +10,5 @@ from superligaen.gold.fct_match_results f
 join superligaen.gold.dim_match        m on m.match_sk        = f.match_sk
 join superligaen.gold.dim_team         t on t.team_sk         = f.team_sk
 join superligaen.gold.dim_match_result r on r.match_result_sk = f.match_result_sk
-where m.match_round_type = 'Regular Season'
-  and r.match_result in ('Win', 'Draw', 'Loss')
+where r.match_result in ('Win', 'Draw', 'Loss')
 order by m.season, t.team_name, m.match_round_number


### PR DESCRIPTION
## Summary
- Removes the `match_round_type = 'Regular Season'` filter from `points_progression.sql`
- For completed seasons (e.g. 2024/25), the chart was silently stopping at round 22, missing the Championship Round (rounds 23–32) and Relegation Round (rounds 23–32) where the title and relegation are decided
- Cumulative points now run continuously across all 32 rounds

## Test plan
- [ ] Check 2024/25 points progression chart — should now show rounds up to 32 instead of stopping at 22
- [ ] Verify current season (in-progress) still renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)