### PR TITLE
fix: null out points_earned for non-league round types

### DIFF
--- a/dbt/models/gold/fct_match_results.sql
+++ b/dbt/models/gold/fct_match_results.sql
@@ -64,11 +64,14 @@ joined AS (
             ELSE -1
         END                          AS match_result_sk,
         CASE
-            WHEN ft.status_short IN ('FT', 'AET', 'PEN')
+            WHEN m.match_round_type IN ('Regular Season', 'Championship', 'Relegation')
+                 AND ft.status_short IN ('FT', 'AET', 'PEN')
                  AND ft.goals_scored  > ft.goals_conceded THEN 3
-            WHEN ft.status_short IN ('FT', 'AET', 'PEN')
+            WHEN m.match_round_type IN ('Regular Season', 'Championship', 'Relegation')
+                 AND ft.status_short IN ('FT', 'AET', 'PEN')
                  AND ft.goals_scored  = ft.goals_conceded THEN 1
-            WHEN ft.status_short IN ('FT', 'AET', 'PEN')
+            WHEN m.match_round_type IN ('Regular Season', 'Championship', 'Relegation')
+                 AND ft.status_short IN ('FT', 'AET', 'PEN')
                  AND ft.goals_scored  < ft.goals_conceded THEN 0
             ELSE NULL
         END                          AS points_earned,


### PR DESCRIPTION
## Summary
- `points_earned` in `fct_match_results` is now built around an inclusion list: only `Regular Season`, `Championship`, and `Relegation` round types receive 3/1/0 points
- Conference League Play-offs, sentinel rows, and any future non-league round types all produce `NULL`

Closes #137

🤖 Generated with [Claude Code](https://claude.com/claude-code)