### PR TITLE
fix: replace silver ref with bronze source in fixtures model

### DIFF
--- a/dbt/models/silver/fixtures.sql
+++ b/dbt/models/silver/fixtures.sql
@@ -16,9 +16,12 @@ WITH venue_lookup AS (
     GROUP BY (elem->>'$.name')::VARCHAR
 ),
 home_team_venue AS (
-    SELECT DISTINCT ON (team_id) team_id, venue_id
-    FROM {{ ref('teams') }}
-    WHERE venue_id IS NOT NULL
+    SELECT DISTINCT ON (team_id)
+        (elem->>'$.team.id')::INTEGER  AS team_id,
+        (elem->>'$.venue.id')::INTEGER AS venue_id
+    FROM {{ source('bronze', 'api_football__teams') }},
+    UNNEST(raw_json::JSON[]) AS t(elem)
+    WHERE (elem->>'$.venue.id') IS NOT NULL
     ORDER BY team_id, season DESC
 ),
 src AS (


### PR DESCRIPTION
## Summary
- `home_team_venue` CTE in `silver/fixtures.sql` was referencing `{{ ref('teams') }}` (another silver model)
- Replaced with an inline extraction from `{{ source('bronze', 'api_football__teams') }}` — same logic, same data, no inter-silver dependency
- Confirmed no other silver models reference other silver models

Closes #140

🤖 Generated with [Claude Code](https://claude.com/claude-code)