### PR TITLE
fix: supplement dim_stadium with venue data from fixtures

### DIFF
--- a/dbt/models/gold/dims/dim_stadium.sql
+++ b/dbt/models/gold/dims/dim_stadium.sql
@@ -10,19 +10,49 @@
     )
 }}
 
+WITH venues_from_api AS (
+    SELECT
+        venue_id,
+        venue_name,
+        address,
+        city,
+        country,
+        capacity,
+        surface
+    FROM {{ ref('venues') }}
+    WHERE venue_id IS NOT NULL
+),
+venues_from_fixtures AS (
+    SELECT DISTINCT
+        f.venue_id,
+        f.venue_name,
+        f.venue_city      AS city,
+        NULL::VARCHAR     AS address,
+        NULL::VARCHAR     AS country,
+        NULL::INTEGER     AS capacity,
+        NULL::VARCHAR     AS surface
+    FROM {{ ref('fixtures') }} f
+    LEFT JOIN venues_from_api v ON v.venue_id = f.venue_id
+    WHERE f.venue_id IS NOT NULL
+      AND v.venue_id IS NULL
+),
+combined AS (
+    SELECT * FROM venues_from_api
+    UNION ALL
+    SELECT * FROM venues_from_fixtures
+)
 SELECT
     {% if is_incremental() %}
     (SELECT COALESCE(MAX(stadium_sk), 0) FROM {{ this }} WHERE stadium_sk > 0)
-        + ROW_NUMBER() OVER (ORDER BY src.venue_id) AS stadium_sk,
+        + ROW_NUMBER() OVER (ORDER BY venue_id) AS stadium_sk,
     {% else %}
-    ROW_NUMBER() OVER (ORDER BY src.venue_id) AS stadium_sk,
+    ROW_NUMBER() OVER (ORDER BY venue_id) AS stadium_sk,
     {% endif %}
-    src.venue_id    AS stadium_id,
-    src.venue_name  AS stadium_name,
-    src.address     AS stadium_address,
-    src.city        AS stadium_city,
-    src.country     AS stadium_country,
-    src.capacity    AS stadium_capacity,
-    src.surface     AS stadium_surface
-FROM {{ ref('venues') }} src
-WHERE src.venue_id IS NOT NULL
+    venue_id    AS stadium_id,
+    venue_name  AS stadium_name,
+    address     AS stadium_address,
+    city        AS stadium_city,
+    country     AS stadium_country,
+    capacity    AS stadium_capacity,
+    surface     AS stadium_surface
+FROM combined

--- a/dbt/models/gold/dims/dim_stadium.sql
+++ b/dbt/models/gold/dims/dim_stadium.sql
@@ -26,11 +26,11 @@ venues_from_fixtures AS (
     SELECT DISTINCT
         f.venue_id,
         f.venue_name,
-        f.venue_city      AS city,
-        NULL::VARCHAR     AS address,
-        NULL::VARCHAR     AS country,
-        NULL::INTEGER     AS capacity,
-        NULL::VARCHAR     AS surface
+        f.venue_city                     AS city,
+        'Unknown Stadium Address'        AS address,
+        'Unknown Stadium Country'        AS country,
+        NULL::INTEGER                    AS capacity,
+        'Unknown Stadium Surface'        AS surface
     FROM {{ ref('fixtures') }} f
     LEFT JOIN venues_from_api v ON v.venue_id = f.venue_id
     WHERE f.venue_id IS NOT NULL


### PR DESCRIPTION
## Summary
- `dim_stadium` was sourced exclusively from `silver.venues` (the venues API), which only contains currently active venues
- When a stadium is renamed and re-ID'd by the API, the old ID disappears — any historical fixtures referencing it resolve to `stadium_sk = -1`
- This caused 40 unknown stadiums in `fct_match_results` (CASA Arena Horsens → Nordstern Arena Horsens, Telia Parken → Parken)
- `dim_stadium` now unions `silver.venues` (primary, full data) with `silver.fixtures` (fallback — any venue_id not in the API gets a row with name + city from the fixture)
- Since fixture bronze data is never deleted, this is resilient to future venue renames and safe on full refreshes

## Test plan
- [ ] Run `dbt run --select gold.dim_stadium --full-refresh` against dev
- [ ] Confirm venue IDs 450 and 439 now appear in `dim_stadium`
- [ ] Run `dbt run --select gold.fct_match_results --full-refresh` against dev
- [ ] Re-run the unknown dimensions query — `unknown_stadium` should drop to 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)