### PR TITLE
feat: add match analysis section to match results page

### DIFF
--- a/dashboards/evidence.config.yaml
+++ b/dashboards/evidence.config.yaml
@@ -1,6 +1,6 @@
 appearance:
-  default: system
-  switcher: true
+  default: light
+  switcher: false
 
 theme:
   colorPalettes:

--- a/dashboards/pages/+layout.svelte
+++ b/dashboards/pages/+layout.svelte
@@ -22,6 +22,6 @@
   });
 </script>
 
-<EvidenceDefaultLayout {data} hideBreadcrumbs={true} neverShowQueries={true}>
+<EvidenceDefaultLayout {data} hideBreadcrumbs={true} neverShowQueries={true} hideMenu={true}>
   <slot slot="content" />
 </EvidenceDefaultLayout>

--- a/dashboards/pages/match-results.md
+++ b/dashboards/pages/match-results.md
@@ -69,3 +69,199 @@ where season = '${inputs.season.value}'
     <Column id=total_red_cards     title="RC"             contentType=colorscale colorPalette={['white','#ef4444']} align=center />
     <Column id=total_corners       title="Corners"        contentType=colorscale colorPalette={['white','#a855f7']} align=center />
 </DataTable>
+
+---
+
+## Match Analysis
+
+```sql match_options
+select
+    match_name || '|' || cast(match_date as varchar) as match_key,
+    match_name || '  (' || score || ')'              as match_label,
+    match_date
+from superligaen.match_results_by_match
+where season = '${inputs.season.value}'
+  and cast(match_round_number as integer) in ${inputs.round.value}
+order by match_date desc
+```
+
+{#key match_options[0]?.match_key}
+<Dropdown data={match_options} name=match value=match_key label=match_label defaultValue={match_options[0]?.match_key} />
+{/key}
+
+```sql mc
+select
+    max(case when side = 'Home' then team_name end)                              as home_team,
+    max(case when side = 'Away' then team_name end)                              as away_team,
+    max(score)                                                                   as score,
+    max(case when side = 'Home' then goals end)                                  as home_goals,
+    max(case when side = 'Away' then goals end)                                  as away_goals,
+    round(max(case when side = 'Home' then xg end)::double, 2)                   as home_xg,
+    round(max(case when side = 'Away' then xg end)::double, 2)                   as away_xg,
+    max(case when side = 'Home' then shots_on_goal end)                          as home_sog,
+    max(case when side = 'Away' then shots_on_goal end)                          as away_sog,
+    max(case when side = 'Home' then total_shots end)                            as home_shots,
+    max(case when side = 'Away' then total_shots end)                            as away_shots,
+    max(case when side = 'Home' then possession end)                             as home_possession,
+    max(case when side = 'Away' then possession end)                             as away_possession,
+    max(case when side = 'Home' then pass_accuracy end)                          as home_pass_accuracy,
+    max(case when side = 'Away' then pass_accuracy end)                          as away_pass_accuracy,
+    max(case when side = 'Home' then corners end)                                as home_corners,
+    max(case when side = 'Away' then corners end)                                as away_corners,
+    max(case when side = 'Home' then fouls end)                                  as home_fouls,
+    max(case when side = 'Away' then fouls end)                                  as away_fouls,
+    max(case when side = 'Home' then offsides end)                               as home_offsides,
+    max(case when side = 'Away' then offsides end)                               as away_offsides,
+    max(case when side = 'Home' then yellow_cards end)                           as home_yc,
+    max(case when side = 'Away' then yellow_cards end)                           as away_yc,
+    max(case when side = 'Home' then red_cards end)                              as home_rc,
+    max(case when side = 'Away' then red_cards end)                              as away_rc,
+    max(case when side = 'Home' then saves end)                                  as home_saves,
+    max(case when side = 'Away' then saves end)                                  as away_saves
+from superligaen.match_analysis
+where match_name            = split_part('${inputs.match.value}', '|', 1)
+  and cast(match_date as varchar) = split_part('${inputs.match.value}', '|', 2)
+  and season                = '${inputs.season.value}'
+```
+
+<div class="rounded-xl border border-gray-200 bg-white p-6 mt-2">
+
+  <div class="grid grid-cols-3 text-center border-b border-gray-200 pb-4 mb-2">
+    <div class="text-left font-bold text-lg text-blue-600">{mc[0]?.home_team}<div class="text-xs font-normal text-gray-400">Home</div></div>
+    <div class="text-center text-2xl font-bold text-gray-700">{mc[0]?.score}</div>
+    <div class="text-right font-bold text-lg text-orange-500">{mc[0]?.away_team}<div class="text-xs font-normal text-gray-400">Away</div></div>
+  </div>
+
+  <div class="py-2 border-b border-gray-100">
+    <div class="grid grid-cols-3 items-center text-center mb-1.5">
+      <div class="font-semibold text-lg text-blue-600">{mc[0]?.home_goals}</div>
+      <div class="text-gray-400 text-xs uppercase tracking-wide">Goals</div>
+      <div class="font-semibold text-lg text-orange-500">{mc[0]?.away_goals}</div>
+    </div>
+    <div class="flex h-1 rounded-full overflow-hidden bg-orange-400">
+      <div class="bg-blue-500" style="width:{(mc[0]?.home_goals ?? 0) / ((mc[0]?.home_goals ?? 0) + (mc[0]?.away_goals ?? 0)) * 100 || 50}%"></div>
+    </div>
+  </div>
+
+  <div class="py-2 border-b border-gray-100">
+    <div class="grid grid-cols-3 items-center text-center mb-1.5">
+      <div class="font-semibold text-lg text-blue-600">{mc[0]?.home_xg}</div>
+      <div class="text-gray-400 text-xs uppercase tracking-wide">xG</div>
+      <div class="font-semibold text-lg text-orange-500">{mc[0]?.away_xg}</div>
+    </div>
+    <div class="flex h-1 rounded-full overflow-hidden bg-orange-400">
+      <div class="bg-blue-500" style="width:{(mc[0]?.home_xg ?? 0) / ((mc[0]?.home_xg ?? 0) + (mc[0]?.away_xg ?? 0)) * 100 || 50}%"></div>
+    </div>
+  </div>
+
+  <div class="py-2 border-b border-gray-100">
+    <div class="grid grid-cols-3 items-center text-center mb-1.5">
+      <div class="font-semibold text-lg text-blue-600">{mc[0]?.home_sog}</div>
+      <div class="text-gray-400 text-xs uppercase tracking-wide">Shots on Goal</div>
+      <div class="font-semibold text-lg text-orange-500">{mc[0]?.away_sog}</div>
+    </div>
+    <div class="flex h-1 rounded-full overflow-hidden bg-orange-400">
+      <div class="bg-blue-500" style="width:{(mc[0]?.home_sog ?? 0) / ((mc[0]?.home_sog ?? 0) + (mc[0]?.away_sog ?? 0)) * 100 || 50}%"></div>
+    </div>
+  </div>
+
+  <div class="py-2 border-b border-gray-100">
+    <div class="grid grid-cols-3 items-center text-center mb-1.5">
+      <div class="font-semibold text-lg text-blue-600">{mc[0]?.home_shots}</div>
+      <div class="text-gray-400 text-xs uppercase tracking-wide">Total Shots</div>
+      <div class="font-semibold text-lg text-orange-500">{mc[0]?.away_shots}</div>
+    </div>
+    <div class="flex h-1 rounded-full overflow-hidden bg-orange-400">
+      <div class="bg-blue-500" style="width:{(mc[0]?.home_shots ?? 0) / ((mc[0]?.home_shots ?? 0) + (mc[0]?.away_shots ?? 0)) * 100 || 50}%"></div>
+    </div>
+  </div>
+
+  <div class="py-2 border-b border-gray-100">
+    <div class="grid grid-cols-3 items-center text-center mb-1.5">
+      <div class="font-semibold text-lg text-blue-600">{mc[0]?.home_possession}%</div>
+      <div class="text-gray-400 text-xs uppercase tracking-wide">Possession</div>
+      <div class="font-semibold text-lg text-orange-500">{mc[0]?.away_possession}%</div>
+    </div>
+    <div class="flex h-1 rounded-full overflow-hidden bg-orange-400">
+      <div class="bg-blue-500" style="width:{mc[0]?.home_possession || 50}%"></div>
+    </div>
+  </div>
+
+  <div class="py-2 border-b border-gray-100">
+    <div class="grid grid-cols-3 items-center text-center mb-1.5">
+      <div class="font-semibold text-lg text-blue-600">{mc[0]?.home_pass_accuracy}%</div>
+      <div class="text-gray-400 text-xs uppercase tracking-wide">Pass Accuracy</div>
+      <div class="font-semibold text-lg text-orange-500">{mc[0]?.away_pass_accuracy}%</div>
+    </div>
+    <div class="flex h-1 rounded-full overflow-hidden bg-orange-400">
+      <div class="bg-blue-500" style="width:{mc[0]?.home_pass_accuracy || 50}%"></div>
+    </div>
+  </div>
+
+  <div class="py-2 border-b border-gray-100">
+    <div class="grid grid-cols-3 items-center text-center mb-1.5">
+      <div class="font-semibold text-lg text-blue-600">{mc[0]?.home_corners}</div>
+      <div class="text-gray-400 text-xs uppercase tracking-wide">Corners</div>
+      <div class="font-semibold text-lg text-orange-500">{mc[0]?.away_corners}</div>
+    </div>
+    <div class="flex h-1 rounded-full overflow-hidden bg-orange-400">
+      <div class="bg-blue-500" style="width:{(mc[0]?.home_corners ?? 0) / ((mc[0]?.home_corners ?? 0) + (mc[0]?.away_corners ?? 0)) * 100 || 50}%"></div>
+    </div>
+  </div>
+
+  <div class="py-2 border-b border-gray-100">
+    <div class="grid grid-cols-3 items-center text-center mb-1.5">
+      <div class="font-semibold text-lg text-blue-600">{mc[0]?.home_fouls}</div>
+      <div class="text-gray-400 text-xs uppercase tracking-wide">Fouls</div>
+      <div class="font-semibold text-lg text-orange-500">{mc[0]?.away_fouls}</div>
+    </div>
+    <div class="flex h-1 rounded-full overflow-hidden bg-orange-400">
+      <div class="bg-blue-500" style="width:{(mc[0]?.home_fouls ?? 0) / ((mc[0]?.home_fouls ?? 0) + (mc[0]?.away_fouls ?? 0)) * 100 || 50}%"></div>
+    </div>
+  </div>
+
+  <div class="py-2 border-b border-gray-100">
+    <div class="grid grid-cols-3 items-center text-center mb-1.5">
+      <div class="font-semibold text-lg text-blue-600">{mc[0]?.home_offsides}</div>
+      <div class="text-gray-400 text-xs uppercase tracking-wide">Offsides</div>
+      <div class="font-semibold text-lg text-orange-500">{mc[0]?.away_offsides}</div>
+    </div>
+    <div class="flex h-1 rounded-full overflow-hidden bg-orange-400">
+      <div class="bg-blue-500" style="width:{(mc[0]?.home_offsides ?? 0) / ((mc[0]?.home_offsides ?? 0) + (mc[0]?.away_offsides ?? 0)) * 100 || 50}%"></div>
+    </div>
+  </div>
+
+  <div class="py-2 border-b border-gray-100">
+    <div class="grid grid-cols-3 items-center text-center mb-1.5">
+      <div class="font-semibold text-lg text-blue-600">{mc[0]?.home_yc}</div>
+      <div class="text-gray-400 text-xs uppercase tracking-wide">Yellow Cards</div>
+      <div class="font-semibold text-lg text-orange-500">{mc[0]?.away_yc}</div>
+    </div>
+    <div class="flex h-1 rounded-full overflow-hidden bg-orange-400">
+      <div class="bg-blue-500" style="width:{(mc[0]?.home_yc ?? 0) / ((mc[0]?.home_yc ?? 0) + (mc[0]?.away_yc ?? 0)) * 100 || 50}%"></div>
+    </div>
+  </div>
+
+  <div class="py-2 border-b border-gray-100">
+    <div class="grid grid-cols-3 items-center text-center mb-1.5">
+      <div class="font-semibold text-lg text-blue-600">{mc[0]?.home_rc}</div>
+      <div class="text-gray-400 text-xs uppercase tracking-wide">Red Cards</div>
+      <div class="font-semibold text-lg text-orange-500">{mc[0]?.away_rc}</div>
+    </div>
+    <div class="flex h-1 rounded-full overflow-hidden bg-orange-400">
+      <div class="bg-blue-500" style="width:{(mc[0]?.home_rc ?? 0) / ((mc[0]?.home_rc ?? 0) + (mc[0]?.away_rc ?? 0)) * 100 || 50}%"></div>
+    </div>
+  </div>
+
+  <div class="py-2">
+    <div class="grid grid-cols-3 items-center text-center mb-1.5">
+      <div class="font-semibold text-lg text-blue-600">{mc[0]?.home_saves}</div>
+      <div class="text-gray-400 text-xs uppercase tracking-wide">Saves</div>
+      <div class="font-semibold text-lg text-orange-500">{mc[0]?.away_saves}</div>
+    </div>
+    <div class="flex h-1 rounded-full overflow-hidden bg-orange-400">
+      <div class="bg-blue-500" style="width:{(mc[0]?.home_saves ?? 0) / ((mc[0]?.home_saves ?? 0) + (mc[0]?.away_saves ?? 0)) * 100 || 50}%"></div>
+    </div>
+  </div>
+
+</div>

--- a/dashboards/sources/superligaen/match_analysis.sql
+++ b/dashboards/sources/superligaen/match_analysis.sql
@@ -1,0 +1,29 @@
+select
+    d.date                                                                      as match_date,
+    m.match_name,
+    m.match_result                                                              as score,
+    m.season,
+    t.team_name,
+    ts.team_side                                                                as side,
+    f.goals_scored                                                              as goals,
+    round(f.expected_goals::double, 2)                                          as xg,
+    f.shots_on_goal,
+    f.total_shots,
+    f.shots_insidebox,
+    f.shots_outsidebox,
+    round(f.ball_possession_pct::double, 1)                                     as possession,
+    f.corner_kicks                                                              as corners,
+    f.fouls,
+    f.offsides,
+    f.yellow_cards,
+    f.red_cards,
+    f.goalkeeper_saves                                                          as saves,
+    round(f.passes_accurate::double / nullif(f.total_passes, 0) * 100, 1)      as pass_accuracy
+from superligaen.gold.fct_match_results f
+join superligaen.gold.dim_match        m  on m.match_sk        = f.match_sk
+join superligaen.gold.dim_date         d  on d.date_sk         = f.date_sk
+join superligaen.gold.dim_team         t  on t.team_sk         = f.team_sk
+join superligaen.gold.dim_match_result r  on r.match_result_sk = f.match_result_sk
+join superligaen.gold.dim_team_side    ts on ts.team_side_sk   = f.team_side_sk
+where r.match_result in ('Win', 'Draw', 'Loss')
+order by d.date desc, m.match_name, ts.team_side


### PR DESCRIPTION
## Summary
- New `match_analysis.sql` source — per-team stats for every completed match (goals, xG, shots, possession, pass accuracy, corners, fouls, offsides, cards, saves)
- Match Analysis section added below the results table with a match dropdown that defaults to the most recent match in the current season/round filter
- BBC Sport-style comparison layout: home team in blue, away team in orange, thin split bar under each stat showing the relative proportion
- Dashboard locked to light mode (`appearance: default: light`) and three-dot menu removed (`hideMenu={true}`, `switcher: false`)

Closes #139

🤖 Generated with [Claude Code](https://claude.com/claude-code)