### PR TITLE
feat: add last updated timestamp to home page footer

### DIFF
--- a/dashboards/pages/index.md
+++ b/dashboards/pages/index.md
@@ -8,6 +8,10 @@ title: " "
 select * from superligaen.league_info
 ```
 
+```sql last_updated
+select * from superligaen.last_updated
+```
+
 ```sql kpis
 select
     count(*)                                                              as total_matches,
@@ -131,3 +135,5 @@ select * from superligaen.current_leader
 </a>
 
 </div>
+
+<div class="mt-8 text-center text-xs text-gray-400">Data last updated: {last_updated[0]?.last_updated}</div>

--- a/dashboards/sources/superligaen/last_updated.sql
+++ b/dashboards/sources/superligaen/last_updated.sql
@@ -1,0 +1,2 @@
+select strftime(max(ingested_at), '%d %b %Y %H:%M UTC') as last_updated
+from superligaen.bronze.api_football__fixtures


### PR DESCRIPTION
## Summary
- New `last_updated.sql` source — queries `max(ingested_at)` from the fixtures bronze table, formatted as `20 Apr 2026 23:36 UTC`
- Displayed as a subtle small gray line at the very bottom of the home page

Closes #146

🤖 Generated with [Claude Code](https://claude.com/claude-code)