### PR TITLE
fix: unify match_round_name and match_round_type in dim_match

### DIFF
--- a/dashboards/sources/superligaen/team_season_stats.sql
+++ b/dashboards/sources/superligaen/team_season_stats.sql
@@ -10,9 +10,10 @@ select
     sum(f.goals_scored) - sum(f.goals_conceded)                        as gd,
     sum(coalesce(f.points_earned, 0))                                   as pts,
     case
-        when max(case when m.match_round_type = 'Championship' then 1 else 0 end) = 1 then 'Championship Group'
-        when max(case when m.match_round_type = 'Relegation'   then 1 else 0 end) = 1 then 'Relegation Group'
-        else 'Regular Season'
+        when max(case when m.match_round_type = 'Championship Group' then 1 else 0 end) = 1 then 'Championship Group'
+        when max(case when m.match_round_type = 'Relegation Group'   then 1 else 0 end) = 1 then 'Relegation Group'
+        when max(case when m.match_round_type = 'Regular Season'     then 1 else 0 end) = 1 then 'Regular Season'
+        else max(m.match_round_type)
     end                                                                 as round_group
 from superligaen.gold.fct_match_results f
 join superligaen.gold.dim_team t   on t.team_sk  = f.team_sk

--- a/dbt/models/gold/dims/dim_match.sql
+++ b/dbt/models/gold/dims/dim_match.sql
@@ -27,12 +27,18 @@ src AS (
     SELECT
         f.fixture_id,
         f.season::VARCHAR || '/' || RIGHT((f.season + 1)::VARCHAR, 2)        AS season,
-        f.league_round                                                         AS match_round_name,
         CASE SPLIT_PART(f.league_round, ' - ', 1)
-            WHEN 'Championship Group' THEN 'Championship'
-            WHEN 'Championship Round' THEN 'Championship'
-            WHEN 'Relegation Group'   THEN 'Relegation'
-            WHEN 'Relegation Round'   THEN 'Relegation'
+            WHEN 'Championship Group' THEN 'Championship Group - ' || tr.round_number::VARCHAR
+            WHEN 'Championship Round' THEN 'Championship Group - ' || tr.round_number::VARCHAR
+            WHEN 'Relegation Group'   THEN 'Relegation Group - '   || tr.round_number::VARCHAR
+            WHEN 'Relegation Round'   THEN 'Relegation Group - '   || tr.round_number::VARCHAR
+            ELSE f.league_round
+        END                                                                   AS match_round_name,
+        CASE SPLIT_PART(f.league_round, ' - ', 1)
+            WHEN 'Championship Group' THEN 'Championship Group'
+            WHEN 'Championship Round' THEN 'Championship Group'
+            WHEN 'Relegation Group'   THEN 'Relegation Group'
+            WHEN 'Relegation Round'   THEN 'Relegation Group'
             ELSE SPLIT_PART(f.league_round, ' - ', 1)
         END                                                                   AS match_round_type,
         tr.round_number                                                       AS match_round_number,

--- a/docs/_posts/2026-04-16-building-the-dashboard.md
+++ b/docs/_posts/2026-04-16-building-the-dashboard.md
@@ -44,7 +44,7 @@ We built seven pages:
 
 **Home** — a hero banner with the league logo and flag, four KPI tiles (current leader, team count, matches played, goals scored this season), and a navigation grid linking to every other page.
 
-**Standings** — three separate tables covering the Championship Round, Relegation Round, and Regular Season standings, with a season selector to browse historical tables.
+**Standings** — three separate tables covering the Championship Group, Relegation Group, and Regular Season standings, with a season selector to browse historical tables.
 
 **Match Results** — a filterable table of all historical results with a Goals vs xG chart by round that shows which rounds were overperforming or underperforming expected goals.
 


### PR DESCRIPTION
## Summary
- Reconstructs `match_round_name` using the absolute `round_number` with a standardised prefix (`Championship Group` / `Relegation Group`) — fixing the inconsistency between older seasons (`Championship Round - 1`) and 2025/26 (`Championship Group - 23`)
- Changes `match_round_type` from `Championship`/`Relegation` to `Championship Group`/`Relegation Group`
- Updates `team_season_stats.sql` filter values to match, with a safe `else max(m.match_round_type)` fallback for future round types
- Updates dashboard docs copy to reflect the correct group names

Closes #150

## Test plan
- [ ] Run `dbt run --select dim_match` full-refresh against dev and verify `match_round_name` for 2020–2024 now shows `Championship Group - 23..32` instead of `Championship Round - 1..10`
- [ ] Verify `match_round_type` values are `Championship Group` / `Relegation Group` / `Regular Season`
- [ ] Check standings dashboard still correctly splits into Championship Group, Relegation Group, Regular Season tables
- [ ] Check `team_season_stats` query returns correct `round_group` values

🤖 Generated with [Claude Code](https://claude.com/claude-code)