### PR TITLE
fix: coalesce round_number to prevent null match_round_name on future fixtures

### DIFF
--- a/dbt/models/gold/dims/dim_match.sql
+++ b/dbt/models/gold/dims/dim_match.sql
@@ -28,10 +28,10 @@ src AS (
         f.fixture_id,
         f.season::VARCHAR || '/' || RIGHT((f.season + 1)::VARCHAR, 2)        AS season,
         CASE SPLIT_PART(f.league_round, ' - ', 1)
-            WHEN 'Championship Group' THEN 'Championship Group - ' || tr.round_number::VARCHAR
-            WHEN 'Championship Round' THEN 'Championship Group - ' || tr.round_number::VARCHAR
-            WHEN 'Relegation Group'   THEN 'Relegation Group - '   || tr.round_number::VARCHAR
-            WHEN 'Relegation Round'   THEN 'Relegation Group - '   || tr.round_number::VARCHAR
+            WHEN 'Championship Group' THEN 'Championship Group - ' || COALESCE(tr.round_number::VARCHAR, SPLIT_PART(f.league_round, ' - ', 2))
+            WHEN 'Championship Round' THEN 'Championship Group - ' || COALESCE(tr.round_number::VARCHAR, SPLIT_PART(f.league_round, ' - ', 2))
+            WHEN 'Relegation Group'   THEN 'Relegation Group - '   || COALESCE(tr.round_number::VARCHAR, SPLIT_PART(f.league_round, ' - ', 2))
+            WHEN 'Relegation Round'   THEN 'Relegation Group - '   || COALESCE(tr.round_number::VARCHAR, SPLIT_PART(f.league_round, ' - ', 2))
             ELSE f.league_round
         END                                                                   AS match_round_name,
         CASE SPLIT_PART(f.league_round, ' - ', 1)


### PR DESCRIPTION
## Summary
- Future "Not Started" fixtures have no `fixture_statistics` rows yet, so `round_number` is `NULL`
- String concatenation with `NULL` produced a `NULL` `match_round_name` for all unplayed Championship/Relegation Group rounds
- Fix: `COALESCE(tr.round_number::VARCHAR, SPLIT_PART(f.league_round, ' - ', 2))` — falls back to the number already in the source `league_round`, which for 2025/26 is already the absolute round number

## Test plan
- [ ] Verify `SELECT * FROM dim_match WHERE match_round_name IS NULL` returns 0 rows (excluding sentinel rows)
- [ ] Confirm future Championship/Relegation Group fixtures show correct round names (e.g. `Championship Group - 28`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)