### PR TITLE
feat: move season attribute from dim_match to dim_date

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ erDiagram
         int day_of_week
         varchar day_name
         varchar is_weekend
+        varchar season
     }
 
     dim_time {
@@ -121,7 +122,6 @@ erDiagram
     dim_match {
         int match_sk PK
         int match_id
-        int season
         varchar match_round_name
         varchar match_round_type
         int match_round_number

--- a/dashboards/sources/superligaen/current_leader.sql
+++ b/dashboards/sources/superligaen/current_leader.sql
@@ -2,10 +2,11 @@ select
     t.team_name,
     sum(f.points_earned)::integer as pts
 from superligaen.gold.fct_match_results f
-join superligaen.gold.dim_team         t on t.team_sk        = f.team_sk
-join superligaen.gold.dim_match        m on m.match_sk       = f.match_sk
+join superligaen.gold.dim_team         t on t.team_sk         = f.team_sk
+join superligaen.gold.dim_match        m on m.match_sk        = f.match_sk
+join superligaen.gold.dim_date         d on d.date_sk         = f.date_sk
 join superligaen.gold.dim_match_result r on r.match_result_sk = f.match_result_sk
-where m.season = (select max(season) from superligaen.gold.dim_match where season is not null)
+where d.season = (select max(d2.season) from superligaen.gold.fct_match_results f2 join superligaen.gold.dim_date d2 on d2.date_sk = f2.date_sk)
   and r.match_result in ('Win', 'Draw', 'Loss')
 group by t.team_name
 order by pts desc

--- a/dashboards/sources/superligaen/kpis.sql
+++ b/dashboards/sources/superligaen/kpis.sql
@@ -5,10 +5,11 @@ select
         sum(f.total_shots)::decimal / nullif(count(distinct f.match_sk), 0),
         1
     )                                                                           as avg_shots_per_match,
-    max(m.season)                                                               as season
+    max(d.season)                                                               as season
 from superligaen.gold.fct_match_results f
 join superligaen.gold.dim_match        m on m.match_sk        = f.match_sk
+join superligaen.gold.dim_date         d on d.date_sk         = f.date_sk
 join superligaen.gold.dim_match_result r on r.match_result_sk = f.match_result_sk
-where m.season = (select max(season) from superligaen.gold.dim_match where season is not null)
+where d.season = (select max(d2.season) from superligaen.gold.fct_match_results f2 join superligaen.gold.dim_date d2 on d2.date_sk = f2.date_sk)
   and r.match_result in ('Win', 'Draw', 'Loss')
   and f.total_shots is not null

--- a/dashboards/sources/superligaen/match_analysis.sql
+++ b/dashboards/sources/superligaen/match_analysis.sql
@@ -2,7 +2,7 @@ select
     d.date                                                                      as match_date,
     m.match_name,
     m.match_result                                                              as score,
-    m.season,
+    d.season,
     t.team_name,
     ts.team_side                                                                as side,
     f.goals_scored                                                              as goals,

--- a/dashboards/sources/superligaen/match_results.sql
+++ b/dashboards/sources/superligaen/match_results.sql
@@ -1,7 +1,7 @@
 select
     d.date                  as match_date,
     m.match_round_name           as round,
-    m.season,
+    d.season,
     t.team_name,
     ot.opponent_team_name        as opponent,
     ts.team_side                 as side,

--- a/dashboards/sources/superligaen/match_results_by_match.sql
+++ b/dashboards/sources/superligaen/match_results_by_match.sql
@@ -11,11 +11,11 @@ select
     sum(f.corner_kicks)                             as total_corners,
     round(sum(f.expected_goals::double), 2)         as total_xg,
     sum(f.goals_scored)                             as total_goals,
-    m.season
+    d.season
 from superligaen.gold.fct_match_results f
 join superligaen.gold.dim_match        m on m.match_sk        = f.match_sk
 join superligaen.gold.dim_date         d on d.date_sk         = f.date_sk
 join superligaen.gold.dim_match_result r on r.match_result_sk = f.match_result_sk
 where r.match_result in ('Win', 'Draw', 'Loss')
-group by d.date, m.match_round_name, m.match_round_number, m.match_name, m.match_short_name, m.match_result, m.season
+group by d.date, m.match_round_name, m.match_round_number, m.match_name, m.match_short_name, m.match_result, d.season
 order by d.date desc

--- a/dashboards/sources/superligaen/points_progression.sql
+++ b/dashboards/sources/superligaen/points_progression.sql
@@ -1,14 +1,15 @@
 select
-    m.season,
+    d.season,
     m.match_round_number          as round,
     t.team_name,
     sum(f.points_earned) over (
-        partition by f.team_sk, m.season
+        partition by f.team_sk, d.season
         order by m.match_round_number
     )                             as cumulative_points
 from superligaen.gold.fct_match_results f
 join superligaen.gold.dim_match        m on m.match_sk        = f.match_sk
+join superligaen.gold.dim_date         d on d.date_sk         = f.date_sk
 join superligaen.gold.dim_team         t on t.team_sk         = f.team_sk
 join superligaen.gold.dim_match_result r on r.match_result_sk = f.match_result_sk
 where r.match_result in ('Win', 'Draw', 'Loss')
-order by m.season, t.team_name, m.match_round_number
+order by d.season, t.team_name, m.match_round_number

--- a/dashboards/sources/superligaen/referee_analytics.sql
+++ b/dashboards/sources/superligaen/referee_analytics.sql
@@ -1,6 +1,6 @@
 select
     ref.referee_name,
-    m.season,
+    d.season,
     count(distinct m.match_sk)                                                              as matches_managed,
     sum(f.yellow_cards)                                                                     as total_yellow_cards,
     sum(f.red_cards)                                                                        as total_red_cards,
@@ -12,9 +12,10 @@ select
 from superligaen.gold.fct_match_results f
 join superligaen.gold.dim_referee      ref on ref.referee_sk      = f.referee_sk
 join superligaen.gold.dim_match        m   on m.match_sk          = f.match_sk
+join superligaen.gold.dim_date         d   on d.date_sk           = f.date_sk
 join superligaen.gold.dim_match_result r   on r.match_result_sk  = f.match_result_sk
 where r.match_result in ('Win', 'Draw', 'Loss')
   and ref.referee_name not like '%Unknown%'
   and ref.referee_name not like '%Applicable%'
-group by ref.referee_name, m.season
-order by m.season desc, matches_managed desc
+group by ref.referee_name, d.season
+order by d.season desc, matches_managed desc

--- a/dashboards/sources/superligaen/referee_match_log.sql
+++ b/dashboards/sources/superligaen/referee_match_log.sql
@@ -1,6 +1,6 @@
 select
     ref.referee_name,
-    m.season,
+    d.season,
     strftime(d.date, '%Y-%m-%d')   as match_date,
     m.match_round_name              as round,
     m.match_name,
@@ -16,5 +16,5 @@ join superligaen.gold.dim_date         d   on d.date_sk          = f.date_sk
 where r.match_result in ('Win', 'Draw', 'Loss')
   and ref.referee_name not like '%Unknown%'
   and ref.referee_name not like '%Applicable%'
-group by ref.referee_name, m.season, d.date, m.match_round_name, m.match_name, m.match_result
-order by ref.referee_name, m.season desc, d.date desc
+group by ref.referee_name, d.season, d.date, m.match_round_name, m.match_name, m.match_result
+order by ref.referee_name, d.season desc, d.date desc

--- a/dashboards/sources/superligaen/referee_team_exposure.sql
+++ b/dashboards/sources/superligaen/referee_team_exposure.sql
@@ -1,15 +1,16 @@
 select
     ref.referee_name,
-    m.season,
+    d.season,
     t.team_name,
     count(distinct m.match_sk)  as matches
 from superligaen.gold.fct_match_results f
 join superligaen.gold.dim_referee      ref on ref.referee_sk     = f.referee_sk
 join superligaen.gold.dim_match        m   on m.match_sk         = f.match_sk
+join superligaen.gold.dim_date         d   on d.date_sk          = f.date_sk
 join superligaen.gold.dim_match_result r   on r.match_result_sk = f.match_result_sk
 join superligaen.gold.dim_team         t   on t.team_sk          = f.team_sk
 where r.match_result in ('Win', 'Draw', 'Loss')
   and ref.referee_name not like '%Unknown%'
   and ref.referee_name not like '%Applicable%'
-group by ref.referee_name, m.season, t.team_name
-order by ref.referee_name, m.season desc, matches desc
+group by ref.referee_name, d.season, t.team_name
+order by ref.referee_name, d.season desc, matches desc

--- a/dashboards/sources/superligaen/team_analytics_form.sql
+++ b/dashboards/sources/superligaen/team_analytics_form.sql
@@ -23,11 +23,11 @@ select
     f.goalkeeper_saves                                                      as saves,
     round(f.passes_accurate::double / nullif(f.total_passes, 0) * 100, 1)  as pass_accuracy,
     sum(f.points_earned) over (
-        partition by t.team_name, m.season
+        partition by t.team_name, d.season
         order by d.date
         rows between unbounded preceding and current row
     )                                                                       as cumulative_points,
-    m.season
+    d.season
 from superligaen.gold.fct_match_results f
 join superligaen.gold.dim_team          t   on t.team_sk          = f.team_sk
 join superligaen.gold.dim_opponent_team ot  on ot.opponent_team_sk = f.opponent_team_sk
@@ -36,4 +36,4 @@ join superligaen.gold.dim_match         m   on m.match_sk         = f.match_sk
 join superligaen.gold.dim_match_result  r   on r.match_result_sk  = f.match_result_sk
 join superligaen.gold.dim_team_side     ts  on ts.team_side_sk    = f.team_side_sk
 where r.match_result in ('Win', 'Draw', 'Loss')
-order by t.team_name, m.season, d.date
+order by t.team_name, d.season, d.date

--- a/dashboards/sources/superligaen/team_analytics_home_away.sql
+++ b/dashboards/sources/superligaen/team_analytics_home_away.sql
@@ -1,7 +1,7 @@
 select
     t.team_name,
     ts.team_side                                                                    as side,
-    m.season,
+    d.season,
     count(*)                                                                        as matches,
     sum(f.points_earned)                                                            as points,
     count(*) filter (where r.match_result = 'Win')                                  as wins,
@@ -21,8 +21,9 @@ select
 from superligaen.gold.fct_match_results f
 join superligaen.gold.dim_team          t   on t.team_sk          = f.team_sk
 join superligaen.gold.dim_match         m   on m.match_sk         = f.match_sk
+join superligaen.gold.dim_date          d   on d.date_sk          = f.date_sk
 join superligaen.gold.dim_match_result  r   on r.match_result_sk  = f.match_result_sk
 join superligaen.gold.dim_team_side     ts  on ts.team_side_sk    = f.team_side_sk
 where r.match_result in ('Win', 'Draw', 'Loss')
-group by t.team_name, ts.team_side, m.season
-order by t.team_name, m.season, ts.team_side
+group by t.team_name, ts.team_side, d.season
+order by t.team_name, d.season, ts.team_side

--- a/dashboards/sources/superligaen/team_analytics_kpis.sql
+++ b/dashboards/sources/superligaen/team_analytics_kpis.sql
@@ -1,6 +1,6 @@
 select
     t.team_name,
-    m.season,
+    d.season,
     count(*)                                                                        as matches_played,
     sum(f.points_earned)                                                            as total_points,
     count(*) filter (where r.match_result = 'Win')                                  as wins,
@@ -38,7 +38,8 @@ select
 from superligaen.gold.fct_match_results f
 join superligaen.gold.dim_team         t  on t.team_sk          = f.team_sk
 join superligaen.gold.dim_match        m  on m.match_sk         = f.match_sk
+join superligaen.gold.dim_date         d  on d.date_sk          = f.date_sk
 join superligaen.gold.dim_match_result r  on r.match_result_sk  = f.match_result_sk
 where r.match_result in ('Win', 'Draw', 'Loss')
-group by t.team_name, m.season
-order by m.season desc, total_points desc
+group by t.team_name, d.season
+order by d.season desc, total_points desc

--- a/dashboards/sources/superligaen/team_regular_season_stats.sql
+++ b/dashboards/sources/superligaen/team_regular_season_stats.sql
@@ -1,6 +1,6 @@
 select
     t.team_name,
-    m.season,
+    d.season,
     count(*)                                                            as gp,
     sum(case when f.match_result_sk = 1 then 1 else 0 end)             as w,
     sum(case when f.match_result_sk = 2 then 1 else 0 end)             as d,
@@ -10,9 +10,10 @@ select
     sum(f.goals_scored) - sum(f.goals_conceded)                        as gd,
     sum(coalesce(f.points_earned, 0))                                   as pts
 from superligaen.gold.fct_match_results f
-join superligaen.gold.dim_team t   on t.team_sk  = f.team_sk
+join superligaen.gold.dim_team  t  on t.team_sk  = f.team_sk
 join superligaen.gold.dim_match m  on m.match_sk = f.match_sk
+join superligaen.gold.dim_date  d  on d.date_sk  = f.date_sk
 where f.match_result_sk in (1, 2, 3)
   and m.match_round_name like 'Regular Season%'
-group by t.team_name, m.season
-order by m.season desc, pts desc, gd desc, gf desc
+group by t.team_name, d.season
+order by d.season desc, pts desc, gd desc, gf desc

--- a/dashboards/sources/superligaen/team_season_stats.sql
+++ b/dashboards/sources/superligaen/team_season_stats.sql
@@ -1,6 +1,6 @@
 select
     t.team_name,
-    m.season,
+    d.season,
     count(*)                                                            as gp,
     sum(case when f.match_result_sk = 1 then 1 else 0 end)             as w,
     sum(case when f.match_result_sk = 2 then 1 else 0 end)             as d,
@@ -16,8 +16,9 @@ select
         else max(m.match_round_type)
     end                                                                 as round_group
 from superligaen.gold.fct_match_results f
-join superligaen.gold.dim_team t   on t.team_sk  = f.team_sk
+join superligaen.gold.dim_team  t  on t.team_sk  = f.team_sk
 join superligaen.gold.dim_match m  on m.match_sk = f.match_sk
+join superligaen.gold.dim_date  d  on d.date_sk  = f.date_sk
 where f.match_result_sk in (1, 2, 3)
-group by t.team_name, m.season
-order by m.season desc, round_group, pts desc, gd desc, gf desc
+group by t.team_name, d.season
+order by d.season desc, round_group, pts desc, gd desc, gf desc

--- a/dashboards/sources/superligaen/upcoming_matches.sql
+++ b/dashboards/sources/superligaen/upcoming_matches.sql
@@ -10,7 +10,7 @@ select
         || MAX(CASE WHEN ts.team_side = 'Away' THEN t.team_name END)         as match_key,
     st.stadium_name                                                           as stadium,
     m.kick_off_time,
-    m.season
+    d.season
 from superligaen.gold.fct_match_results f
 join superligaen.gold.dim_match        m  on m.match_sk       = f.match_sk
 join superligaen.gold.dim_date         d  on d.date_sk        = f.date_sk
@@ -19,5 +19,5 @@ join superligaen.gold.dim_match_result r  on r.match_result_sk = f.match_result_
 join superligaen.gold.dim_team         t  on t.team_sk        = f.team_sk
 join superligaen.gold.dim_team_side    ts on ts.team_side_sk  = f.team_side_sk
 where r.match_result = 'Pending'
-group by d.date, m.match_round_name, m.match_round_number, m.match_name, st.stadium_name, m.kick_off_time, m.season
+group by d.date, m.match_round_name, m.match_round_number, m.match_name, st.stadium_name, m.kick_off_time, d.season
 order by d.date asc

--- a/dbt/models/gold/dims/dim_date.sql
+++ b/dbt/models/gold/dims/dim_date.sql
@@ -5,6 +5,36 @@
     )
 }}
 
+WITH seasons_raw AS (
+    SELECT
+        (s->>'year')::INTEGER AS season_year,
+        (s->>'start')::DATE   AS season_start,
+        (s->>'end')::DATE     AS season_end
+    FROM {{ ref('leagues') }},
+         UNNEST(seasons::JSON[]) AS t(s)
+    WHERE league_id = 119
+),
+season_ranges AS (
+    SELECT
+        season_year::VARCHAR || '/' || RIGHT((season_year + 1)::VARCHAR, 2) AS season,
+        -- boundary_start: one day after the midpoint of the gap with the previous season;
+        -- first season uses its own start (no prior gap to split)
+        COALESCE(
+            (LAG(season_end) OVER (ORDER BY season_year)
+             + ((season_start - LAG(season_end) OVER (ORDER BY season_year)) / 2
+                * INTERVAL '1 day') + INTERVAL '1 day')::DATE,
+            season_start
+        ) AS boundary_start,
+        -- boundary_end: midpoint of the gap with the next season (inclusive);
+        -- last season uses its own end (no following gap to split yet)
+        COALESCE(
+            (season_end
+             + ((LEAD(season_start) OVER (ORDER BY season_year) - season_end) / 2
+                * INTERVAL '1 day'))::DATE,
+            season_end
+        ) AS boundary_end
+    FROM seasons_raw
+)
 SELECT
     strftime('%Y%m%d', d)::INTEGER           AS date_sk,
     d::DATE                                  AS date,
@@ -15,5 +45,7 @@ SELECT
     weekofyear(d)::INTEGER                   AS week_number,
     isodow(d)::INTEGER                       AS day_of_week,
     dayname(d)                               AS day_name,
-    CASE WHEN isodow(d) IN (6, 7) THEN 'Yes' ELSE 'No' END AS is_weekend
+    CASE WHEN isodow(d) IN (6, 7) THEN 'Yes' ELSE 'No' END AS is_weekend,
+    sr.season
 FROM generate_series(DATE '2020-01-01', DATE '2030-12-31', INTERVAL '1 day') t(d)
+LEFT JOIN season_ranges sr ON d::DATE BETWEEN sr.boundary_start AND sr.boundary_end

--- a/dbt/models/gold/dims/dim_match.sql
+++ b/dbt/models/gold/dims/dim_match.sql
@@ -3,9 +3,9 @@
         materialized='incremental',
         incremental_strategy='merge',
         unique_key='match_id',
-        merge_update_columns=['season', 'match_round_type', 'match_round_number', 'match_status', 'match_name', 'match_short_name', 'match_result', 'kick_off_time'],
+        merge_update_columns=['match_round_type', 'match_round_number', 'match_status', 'match_name', 'match_short_name', 'match_result', 'kick_off_time'],
         post_hook=[
-            "INSERT INTO {{ this }} SELECT * FROM (VALUES (-1, NULL::INTEGER, NULL::VARCHAR, 'Unknown Match Round Name', 'Unknown Match Round Type', NULL::INTEGER, 'Unknown Match Status', 'Unknown Match Name', 'Unknown Match Short Name', NULL::VARCHAR, NULL::VARCHAR), (-2, NULL::INTEGER, NULL::VARCHAR, 'Not Applicable Match Round Name', 'Not Applicable Match Round Type', NULL::INTEGER, 'Not Applicable Match Status', 'Not Applicable Match Name', 'Not Applicable Match Short Name', NULL::VARCHAR, NULL::VARCHAR)) t(match_sk, match_id, season, match_round_name, match_round_type, match_round_number, match_status, match_name, match_short_name, match_result, kick_off_time) WHERE t.match_sk NOT IN (SELECT match_sk FROM {{ this }})"
+            "INSERT INTO {{ this }} SELECT * FROM (VALUES (-1, NULL::INTEGER, 'Unknown Match Round Name', 'Unknown Match Round Type', NULL::INTEGER, 'Unknown Match Status', 'Unknown Match Name', 'Unknown Match Short Name', NULL::VARCHAR, NULL::VARCHAR), (-2, NULL::INTEGER, 'Not Applicable Match Round Name', 'Not Applicable Match Round Type', NULL::INTEGER, 'Not Applicable Match Status', 'Not Applicable Match Name', 'Not Applicable Match Short Name', NULL::VARCHAR, NULL::VARCHAR)) t(match_sk, match_id, match_round_name, match_round_type, match_round_number, match_status, match_name, match_short_name, match_result, kick_off_time) WHERE t.match_sk NOT IN (SELECT match_sk FROM {{ this }})"
         ]
     )
 }}
@@ -26,7 +26,6 @@ team_round AS (
 src AS (
     SELECT
         f.fixture_id,
-        f.season::VARCHAR || '/' || RIGHT((f.season + 1)::VARCHAR, 2)        AS season,
         CASE SPLIT_PART(f.league_round, ' - ', 1)
             WHEN 'Championship Group' THEN 'Championship Group - ' || COALESCE(tr.round_number::VARCHAR, SPLIT_PART(f.league_round, ' - ', 2))
             WHEN 'Championship Round' THEN 'Championship Group - ' || COALESCE(tr.round_number::VARCHAR, SPLIT_PART(f.league_round, ' - ', 2))
@@ -74,7 +73,6 @@ SELECT
     ROW_NUMBER() OVER (ORDER BY src.fixture_id) AS match_sk,
     {% endif %}
     src.fixture_id   AS match_id,
-    src.season,
     src.match_round_name,
     src.match_round_type,
     src.match_round_number,

--- a/docs/_posts/2026-04-14-silver-and-gold-layers.md
+++ b/docs/_posts/2026-04-14-silver-and-gold-layers.md
@@ -76,11 +76,11 @@ We ended up with 10 dimension tables:
 
 | Dimension | What it represents |
 |---|---|
-| `dim_date` | Calendar attributes of the match date |
+| `dim_date` | Calendar attributes of the match date, including season |
 | `dim_time` | Hour of kick-off and period of day (Morning / Afternoon / Evening / Night) |
 | `dim_team` | Club identity — name, code, country, logo |
 | `dim_opponent_team` | Role-playing dimension — same structure as `dim_team`, aliased to represent the opposing club |
-| `dim_match` | Match metadata — round, season, names, status |
+| `dim_match` | Match metadata — round, names, status |
 | `dim_league` | League identity — name, country, logo, flag |
 | `dim_stadium` | Venue — name, city, capacity, surface |
 | `dim_referee` | Referee name |
@@ -157,6 +157,7 @@ erDiagram
         int day_of_week
         varchar day_name
         varchar is_weekend
+        varchar season
     }
     dim_time {
         int time_sk PK
@@ -184,7 +185,6 @@ erDiagram
     dim_match {
         int match_sk PK
         int match_id
-        varchar season
         varchar match_round_name
         varchar match_round_type
         int match_round_number


### PR DESCRIPTION
## Summary
- Adds `season` to `dim_date`, derived from actual league season start/end dates in `silver.leagues` (unnested from the `seasons` JSON column)
- Season boundaries are computed by splitting the off-season gap equally at the midpoint — the first half is attributed to the previous season, the second half to the next. The last season's boundary falls back to its own `season_end` until the following season is ingested
- Removes `season` from `dim_match` (model, `merge_update_columns`, post_hook sentinel rows)
- Adds `dim_date` join to the 9 dashboard source queries that were previously missing it
- Replaces `m.season` → `d.season` across all 15 dashboard source queries
- Updates docs schema diagram: `season` moved from `dim_match` to `dim_date`

Closes #151

## Test plan
- [ ] Run `dbt run --select dim_date dim_match` full-refresh against dev and verify `dim_date.season` is populated correctly for known match dates
- [ ] Verify gaps between seasons are split at the midpoint (e.g. 2022/23 ends 2023-06-30, 2023/24 starts 2023-07-01)
- [ ] Confirm dates after the last season end (e.g. 2026-06-01) return `NULL` season
- [ ] Check all dashboard pages that filter or group by season still work correctly
- [ ] Verify `dim_match` no longer has a `season` column

🤖 Generated with [Claude Code](https://claude.com/claude-code)