### PR TITLE
fix: drive round dropdown by selected season on match results page

### DIFF
--- a/dashboards/pages/match-results.md
+++ b/dashboards/pages/match-results.md
@@ -18,7 +18,7 @@ order by season desc
 ```sql rounds
 select distinct CAST(match_round_number AS INTEGER) as round_number
 from superligaen.match_results_by_match
-where season = (select max(season) from superligaen.match_results_by_match)
+where season = '${inputs.season.value}'
 order by 1 desc
 ```
 


### PR DESCRIPTION
## Summary
- The rounds dropdown was using `where season = (select max(season) ...)`, hardcoding it to the current season regardless of the season the user had selected
- Switching to a previous season (e.g. 2024/25) only showed rounds 1–27 because that's how many rounds the current 2025/26 season has played so far
- Fix: use `'${inputs.season.value}'` so the dropdown reflects the full round range of the selected season

## Test plan
- [ ] Switch to 2024/25 on the match results page — round dropdown should show all 32 rounds
- [ ] Current season (2025/26) still defaults to the latest round

🤖 Generated with [Claude Code](https://claude.com/claude-code)