### PR TITLE
fix: exclude playoff fixtures from fct_match_results

### DIFF
--- a/dbt/models/gold/fct_match_results.sql
+++ b/dbt/models/gold/fct_match_results.sql
@@ -107,6 +107,7 @@ joined AS (
     LEFT JOIN {{ ref('fixture_statistics') }} s
                                              ON s.fixture_id   = ft.fixture_id
                                             AND s.team_id      = ft.team_id
+    WHERE m.match_round_type IN ('Regular Season', 'Championship', 'Relegation')
 )
 SELECT * FROM joined
 {% if is_incremental() %}


### PR DESCRIPTION
## Summary

- Playoff fixtures (e.g. *Conference League Play-offs*) were being included in `fct_match_results` alongside regular season, championship, and relegation rounds
- Adds a `WHERE m.match_round_type IN ('Regular Season', 'Championship', 'Relegation')` filter inside the `joined` CTE to exclude them at source
- Verified against prod: only 5 playoff rows exist, all under `'Conference League Play-offs'`

Closes #161

## Test plan

- [ ] CI dbt compile passes
- [ ] After full-refresh on gold, confirm `SELECT COUNT(*) FROM fct_match_results` drops by 10 rows (5 fixtures × 2 team sides)
- [ ] Confirm no `'Conference League Play-offs'` rows remain via `SELECT DISTINCT match_round_type FROM dim_match JOIN fct_match_results ...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)