### PR TITLE
feat: add League Table with group column to league analysis page

### DIFF
--- a/dashboards/pages/league-analytics.md
+++ b/dashboards/pages/league-analytics.md
@@ -16,10 +16,20 @@ order by season desc
 </Dropdown>
 
 ```sql current_standings
-select team_name, matches_played as mp, total_points as pts
-from superligaen.team_analytics_kpis
+select
+    team_name,
+    gp as mp,
+    pts,
+    round_group
+from superligaen.team_season_stats
 where season = '${inputs.season.value}'
-order by pts desc
+order by
+    case round_group
+        when 'Championship Group' then 1
+        when 'Regular Season'     then 2
+        when 'Relegation Group'   then 3
+    end,
+    pts desc
 ```
 
 ```sql points_progression
@@ -138,12 +148,13 @@ order by goals_for desc
 
 <div>
 
-#### Current Standings
+#### League Table
 
 <DataTable data={current_standings} rows=20>
-    <Column id=team_name title="Team" />
-    <Column id=mp title="MP" align=center />
-    <Column id=pts title="Pts" align=center contentType=colorscale colorPalette={['white','#3b82f6']} />
+    <Column id=team_name  title="Team"  />
+    <Column id=round_group title="Group" />
+    <Column id=mp         title="MP"   align=center />
+    <Column id=pts        title="Pts"  align=center contentType=colorscale colorPalette={['white','#3b82f6']} />
 </DataTable>
 
 </div>


### PR DESCRIPTION
## Summary

- Renamed "Current Standings" → **League Table** (season-agnostic, standard football term)
- Added **Group** column (Championship Group / Regular Season / Relegation Group)
- Switched data source from `team_analytics_kpis` to `team_season_stats` which already carries `round_group`
- Sort order: Championship Group → Regular Season → Relegation Group, then by points within each group

Closes #152

## Test plan

- [ ] League Table shows Group column for current season
- [ ] Switching to a previous season (e.g. 2024/25) shows correct groups and sort order
- [ ] Season with no championship/relegation split (regular season only) still renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)