### PR TITLE
feat: replace Evidence logo with Danish flag and Superligaen title

### DIFF
--- a/dashboards/pages/+layout.svelte
+++ b/dashboards/pages/+layout.svelte
@@ -22,6 +22,6 @@
   });
 </script>
 
-<EvidenceDefaultLayout {data} hideBreadcrumbs={true} neverShowQueries={true} hideMenu={true}>
+<EvidenceDefaultLayout {data} hideBreadcrumbs={true} neverShowQueries={true} hideMenu={true} title="🇩🇰 Superligaen">
   <slot slot="content" />
 </EvidenceDefaultLayout>


### PR DESCRIPTION
## Summary
- Replaces the Evidence wordmark in the header with `🇩🇰 Superligaen` using the `title` prop on `EvidenceDefaultLayout`
- The flag emoji renders as the Danish flag natively in all modern browsers
- Clicking the header still navigates to the home page

🤖 Generated with [Claude Code](https://claude.com/claude-code)