### PR TITLE
feat: apply Danish Superliga tiebreaker rules across all standings and ranking views

### DIFF
--- a/dashboards/pages/league-analytics.md
+++ b/dashboards/pages/league-analytics.md
@@ -32,7 +32,7 @@ order by
 ```
 
 ```sql points_progression
-select round, team_name, cumulative_points
+select round, team_name, cumulative_points, cumulative_gd, cumulative_gf
 from superligaen.points_progression
 where season = '${inputs.season.value}'
 order by max(cumulative_points) over (partition by team_name) desc, team_name, round
@@ -138,7 +138,7 @@ order by goals_for desc
     xAxisTitle="Round"
     yAxisTitle="Cumulative Points"
     title="Points Progression by Round"
-    echartsOptions={{tooltip: {formatter: function(params) { const sorted = [...params].sort((a, b) => b.value[1] - a.value[1]); let out = '<span style="font-weight:600;">Round ' + params[0].value[0] + '</span>'; for (const p of sorted) { out += '<br><span style="font-size:11px;">' + p.marker + ' ' + p.seriesName + '</span><span style="float:right;margin-left:10px;font-size:12px;">' + p.value[1] + '</span>'; } return out; }}}}
+    echartsOptions={{tooltip: {formatter: (function() { const lookup = {}; for (const row of points_progression) { if (!lookup[row.round]) lookup[row.round] = {}; lookup[row.round][row.team_name] = {gd: row.cumulative_gd, gf: row.cumulative_gf}; } return function(params) { const round = params[0].value[0]; const roundData = lookup[round] || {}; const sorted = [...params].sort((a, b) => { if (b.value[1] !== a.value[1]) return b.value[1] - a.value[1]; const pa = roundData[a.seriesName] || {gd: 0, gf: 0}; const pb = roundData[b.seriesName] || {gd: 0, gf: 0}; if (pb.gd !== pa.gd) return pb.gd - pa.gd; return pb.gf - pa.gf; }); let out = '<span style="font-weight:600;">Round ' + round + '</span>'; for (const p of sorted) { out += '<br><span style="font-size:11px;">' + p.marker + ' ' + p.seriesName + '</span><span style="float:right;margin-left:10px;font-size:12px;">' + p.value[1] + '</span>'; } return out; }; })()}}}
     legend=false
     chartAreaHeight=300
 />

--- a/dashboards/pages/league-analytics.md
+++ b/dashboards/pages/league-analytics.md
@@ -27,7 +27,8 @@ order by
         when 'Regular Season'     then 2
         when 'Relegation Group'   then 3
     end,
-    pts desc
+    pts desc, gd desc, gf desc,
+    h2h_pts desc, h2h_gd desc, h2h_gf desc, h2h_away_gf desc
 ```
 
 ```sql points_progression

--- a/dashboards/pages/standings.md
+++ b/dashboards/pages/standings.md
@@ -15,13 +15,18 @@ order by season desc
 
 ```sql standings
 select
-    row_number() over (partition by round_group order by pts desc, gd desc, gf desc) as rank,
+    row_number() over (
+        partition by round_group
+        order by pts desc, gd desc, gf desc,
+                 h2h_pts desc, h2h_gd desc, h2h_gf desc, h2h_away_gf desc
+    ) as rank,
     team_name   as team,
     gp, w, d, l, gf, ga, gd, pts,
     round_group
 from superligaen.team_season_stats
 where season = '${inputs.season.value}'
-order by round_group, pts desc, gd desc, gf desc
+order by round_group, pts desc, gd desc, gf desc,
+         h2h_pts desc, h2h_gd desc, h2h_gf desc, h2h_away_gf desc
 ```
 
 ```sql championship
@@ -38,7 +43,10 @@ where round_group = 'Relegation Group'
 
 ```sql regular
 select
-    row_number() over (order by pts desc, gd desc, gf desc) as rank,
+    row_number() over (
+        order by pts desc, gd desc, gf desc,
+                 h2h_pts desc, h2h_gd desc, h2h_gf desc, h2h_away_gf desc
+    ) as rank,
     team_name as team, gp, w, d, l, gf, ga, gd, pts
 from superligaen.team_regular_season_stats
 where season = '${inputs.season.value}'

--- a/dashboards/sources/superligaen/current_leader.sql
+++ b/dashboards/sources/superligaen/current_leader.sql
@@ -1,12 +1,69 @@
-select
-    t.team_name,
-    sum(f.points_earned)::integer as pts
-from superligaen.gold.fct_match_results f
-join superligaen.gold.dim_team         t on t.team_sk        = f.team_sk
-join superligaen.gold.dim_match        m on m.match_sk       = f.match_sk
-join superligaen.gold.dim_match_result r on r.match_result_sk = f.match_result_sk
-where m.season = (select max(season) from superligaen.gold.dim_match where season is not null)
-  and r.match_result in ('Win', 'Draw', 'Loss')
-group by t.team_name
-order by pts desc
-limit 1
+WITH base AS (
+    SELECT
+        f.team_sk,
+        f.opponent_team_sk,
+        f.team_side_sk,
+        f.match_result_sk,
+        f.goals_scored,
+        f.goals_conceded,
+        f.points_earned
+    FROM superligaen.gold.fct_match_results f
+    JOIN superligaen.gold.dim_match        m ON m.match_sk        = f.match_sk
+    JOIN superligaen.gold.dim_match_result r ON r.match_result_sk = f.match_result_sk
+    WHERE m.season = (SELECT max(season) FROM superligaen.gold.dim_match WHERE season IS NOT NULL)
+      AND r.match_result IN ('Win', 'Draw', 'Loss')
+),
+team_stats AS (
+    SELECT
+        t.team_name,
+        b.team_sk,
+        SUM(COALESCE(b.points_earned, 0))           AS pts,
+        SUM(b.goals_scored) - SUM(b.goals_conceded) AS gd,
+        SUM(b.goals_scored)                          AS gf
+    FROM base b
+    JOIN superligaen.gold.dim_team t ON t.team_sk = b.team_sk
+    GROUP BY t.team_name, b.team_sk
+),
+h2h_pairwise AS (
+    SELECT
+        b.team_sk,
+        b.opponent_team_sk,
+        SUM(COALESCE(b.points_earned, 0))                                 AS h2h_pts,
+        SUM(b.goals_scored) - SUM(b.goals_conceded)                       AS h2h_gd,
+        SUM(b.goals_scored)                                                AS h2h_gf,
+        SUM(CASE WHEN b.team_side_sk = 2 THEN b.goals_scored ELSE 0 END) AS h2h_away_gf
+    FROM base b
+    GROUP BY b.team_sk, b.opponent_team_sk
+),
+h2h_vs_tied AS (
+    SELECT
+        s.team_sk,
+        COALESCE(SUM(h.h2h_pts),     0) AS h2h_pts,
+        COALESCE(SUM(h.h2h_gd),      0) AS h2h_gd,
+        COALESCE(SUM(h.h2h_gf),      0) AS h2h_gf,
+        COALESCE(SUM(h.h2h_away_gf), 0) AS h2h_away_gf
+    FROM team_stats s
+    JOIN team_stats tied ON
+        tied.pts     = s.pts     AND
+        tied.gd      = s.gd      AND
+        tied.gf      = s.gf      AND
+        tied.team_sk != s.team_sk
+    LEFT JOIN h2h_pairwise h ON
+        h.team_sk          = s.team_sk    AND
+        h.opponent_team_sk = tied.team_sk
+    GROUP BY s.team_sk
+)
+SELECT
+    s.team_name,
+    s.pts::integer AS pts
+FROM team_stats s
+LEFT JOIN h2h_vs_tied h ON h.team_sk = s.team_sk
+ORDER BY
+    s.pts                      DESC,
+    s.gd                       DESC,
+    s.gf                       DESC,
+    COALESCE(h.h2h_pts,     0) DESC,
+    COALESCE(h.h2h_gd,      0) DESC,
+    COALESCE(h.h2h_gf,      0) DESC,
+    COALESCE(h.h2h_away_gf, 0) DESC
+LIMIT 1

--- a/dashboards/sources/superligaen/points_progression.sql
+++ b/dashboards/sources/superligaen/points_progression.sql
@@ -1,11 +1,19 @@
 select
     m.season,
-    m.match_round_number          as round,
+    m.match_round_number                                as round,
     t.team_name,
     sum(f.points_earned) over (
         partition by f.team_sk, m.season
         order by m.match_round_number
-    )                             as cumulative_points
+    )                                                   as cumulative_points,
+    sum(f.goals_scored - f.goals_conceded) over (
+        partition by f.team_sk, m.season
+        order by m.match_round_number
+    )                                                   as cumulative_gd,
+    sum(f.goals_scored) over (
+        partition by f.team_sk, m.season
+        order by m.match_round_number
+    )                                                   as cumulative_gf
 from superligaen.gold.fct_match_results f
 join superligaen.gold.dim_match        m on m.match_sk        = f.match_sk
 join superligaen.gold.dim_team         t on t.team_sk         = f.team_sk

--- a/dashboards/sources/superligaen/team_regular_season_stats.sql
+++ b/dashboards/sources/superligaen/team_regular_season_stats.sql
@@ -1,18 +1,89 @@
-select
-    t.team_name,
-    m.season,
-    count(*)                                                            as gp,
-    sum(case when f.match_result_sk = 1 then 1 else 0 end)             as w,
-    sum(case when f.match_result_sk = 2 then 1 else 0 end)             as d,
-    sum(case when f.match_result_sk = 3 then 1 else 0 end)             as l,
-    sum(f.goals_scored)                                                 as gf,
-    sum(f.goals_conceded)                                               as ga,
-    sum(f.goals_scored) - sum(f.goals_conceded)                        as gd,
-    sum(coalesce(f.points_earned, 0))                                   as pts
-from superligaen.gold.fct_match_results f
-join superligaen.gold.dim_team t   on t.team_sk  = f.team_sk
-join superligaen.gold.dim_match m  on m.match_sk = f.match_sk
-where f.match_result_sk in (1, 2, 3)
-  and m.match_round_name like 'Regular Season%'
-group by t.team_name, m.season
-order by m.season desc, pts desc, gd desc, gf desc
+WITH base AS (
+    SELECT
+        f.team_sk,
+        f.opponent_team_sk,
+        f.team_side_sk,
+        m.season,
+        f.match_result_sk,
+        f.goals_scored,
+        f.goals_conceded,
+        f.points_earned
+    FROM superligaen.gold.fct_match_results f
+    JOIN superligaen.gold.dim_match m ON m.match_sk = f.match_sk
+    WHERE f.match_result_sk IN (1, 2, 3)
+      AND m.match_round_name LIKE 'Regular Season%'
+),
+team_stats AS (
+    SELECT
+        t.team_name,
+        b.team_sk,
+        b.season,
+        COUNT(*)                                                    AS gp,
+        SUM(CASE WHEN b.match_result_sk = 1 THEN 1 ELSE 0 END)    AS w,
+        SUM(CASE WHEN b.match_result_sk = 2 THEN 1 ELSE 0 END)    AS d,
+        SUM(CASE WHEN b.match_result_sk = 3 THEN 1 ELSE 0 END)    AS l,
+        SUM(b.goals_scored)                                         AS gf,
+        SUM(b.goals_conceded)                                       AS ga,
+        SUM(b.goals_scored) - SUM(b.goals_conceded)                AS gd,
+        SUM(COALESCE(b.points_earned, 0))                          AS pts
+    FROM base b
+    JOIN superligaen.gold.dim_team t ON t.team_sk = b.team_sk
+    GROUP BY t.team_name, b.team_sk, b.season
+),
+h2h_pairwise AS (
+    -- head-to-head stats per (team, opponent, season) within regular season only
+    SELECT
+        b.team_sk,
+        b.opponent_team_sk,
+        b.season,
+        SUM(COALESCE(b.points_earned, 0))                                 AS h2h_pts,
+        SUM(b.goals_scored) - SUM(b.goals_conceded)                       AS h2h_gd,
+        SUM(b.goals_scored)                                                AS h2h_gf,
+        SUM(CASE WHEN b.team_side_sk = 2 THEN b.goals_scored ELSE 0 END) AS h2h_away_gf
+    FROM base b
+    GROUP BY b.team_sk, b.opponent_team_sk, b.season
+),
+h2h_vs_tied AS (
+    -- sum h2h stats only against teams tied on pts, gd, gf
+    SELECT
+        s.team_sk,
+        s.season,
+        COALESCE(SUM(h.h2h_pts),     0) AS h2h_pts,
+        COALESCE(SUM(h.h2h_gd),      0) AS h2h_gd,
+        COALESCE(SUM(h.h2h_gf),      0) AS h2h_gf,
+        COALESCE(SUM(h.h2h_away_gf), 0) AS h2h_away_gf
+    FROM team_stats s
+    JOIN team_stats tied ON
+        tied.season   = s.season   AND
+        tied.pts      = s.pts      AND
+        tied.gd       = s.gd       AND
+        tied.gf       = s.gf       AND
+        tied.team_sk != s.team_sk
+    LEFT JOIN h2h_pairwise h ON
+        h.team_sk          = s.team_sk       AND
+        h.opponent_team_sk = tied.team_sk    AND
+        h.season           = s.season
+    GROUP BY s.team_sk, s.season
+)
+SELECT
+    s.team_name,
+    s.season,
+    s.gp, s.w, s.d, s.l,
+    s.gf, s.ga, s.gd, s.pts,
+    COALESCE(h.h2h_pts,     0) AS h2h_pts,
+    COALESCE(h.h2h_gd,      0) AS h2h_gd,
+    COALESCE(h.h2h_gf,      0) AS h2h_gf,
+    COALESCE(h.h2h_away_gf, 0) AS h2h_away_gf
+FROM team_stats s
+LEFT JOIN h2h_vs_tied h ON
+    h.team_sk = s.team_sk AND
+    h.season  = s.season
+ORDER BY
+    s.season DESC,
+    s.pts          DESC,
+    s.gd           DESC,
+    s.gf           DESC,
+    COALESCE(h.h2h_pts,     0) DESC,
+    COALESCE(h.h2h_gd,      0) DESC,
+    COALESCE(h.h2h_gf,      0) DESC,
+    COALESCE(h.h2h_away_gf, 0) DESC

--- a/dashboards/sources/superligaen/team_season_stats.sql
+++ b/dashboards/sources/superligaen/team_season_stats.sql
@@ -1,22 +1,99 @@
-select
-    t.team_name,
-    m.season,
-    count(*)                                                            as gp,
-    sum(case when f.match_result_sk = 1 then 1 else 0 end)             as w,
-    sum(case when f.match_result_sk = 2 then 1 else 0 end)             as d,
-    sum(case when f.match_result_sk = 3 then 1 else 0 end)             as l,
-    sum(f.goals_scored)                                                 as gf,
-    sum(f.goals_conceded)                                               as ga,
-    sum(f.goals_scored) - sum(f.goals_conceded)                        as gd,
-    sum(coalesce(f.points_earned, 0))                                   as pts,
-    case
-        when max(case when m.match_round_type = 'Championship' then 1 else 0 end) = 1 then 'Championship Group'
-        when max(case when m.match_round_type = 'Relegation'   then 1 else 0 end) = 1 then 'Relegation Group'
-        else 'Regular Season'
-    end                                                                 as round_group
-from superligaen.gold.fct_match_results f
-join superligaen.gold.dim_team t   on t.team_sk  = f.team_sk
-join superligaen.gold.dim_match m  on m.match_sk = f.match_sk
-where f.match_result_sk in (1, 2, 3)
-group by t.team_name, m.season
-order by m.season desc, round_group, pts desc, gd desc, gf desc
+WITH base AS (
+    SELECT
+        f.team_sk,
+        f.opponent_team_sk,
+        f.team_side_sk,
+        m.season,
+        m.match_round_type,
+        f.match_result_sk,
+        f.goals_scored,
+        f.goals_conceded,
+        f.points_earned
+    FROM superligaen.gold.fct_match_results f
+    JOIN superligaen.gold.dim_match m ON m.match_sk = f.match_sk
+    WHERE f.match_result_sk IN (1, 2, 3)
+),
+team_stats AS (
+    SELECT
+        t.team_name,
+        b.team_sk,
+        b.season,
+        COUNT(*)                                                    AS gp,
+        SUM(CASE WHEN b.match_result_sk = 1 THEN 1 ELSE 0 END)    AS w,
+        SUM(CASE WHEN b.match_result_sk = 2 THEN 1 ELSE 0 END)    AS d,
+        SUM(CASE WHEN b.match_result_sk = 3 THEN 1 ELSE 0 END)    AS l,
+        SUM(b.goals_scored)                                         AS gf,
+        SUM(b.goals_conceded)                                       AS ga,
+        SUM(b.goals_scored) - SUM(b.goals_conceded)                AS gd,
+        SUM(COALESCE(b.points_earned, 0))                          AS pts,
+        CASE
+            WHEN MAX(CASE WHEN b.match_round_type = 'Championship' THEN 1 ELSE 0 END) = 1 THEN 'Championship Group'
+            WHEN MAX(CASE WHEN b.match_round_type = 'Relegation'   THEN 1 ELSE 0 END) = 1 THEN 'Relegation Group'
+            ELSE 'Regular Season'
+        END                                                         AS round_group
+    FROM base b
+    JOIN superligaen.gold.dim_team t ON t.team_sk = b.team_sk
+    GROUP BY t.team_name, b.team_sk, b.season
+),
+h2h_pairwise AS (
+    -- head-to-head stats per (team, opponent, season) across all round types
+    SELECT
+        b.team_sk,
+        b.opponent_team_sk,
+        b.season,
+        SUM(COALESCE(b.points_earned, 0))                                 AS h2h_pts,
+        SUM(b.goals_scored) - SUM(b.goals_conceded)                       AS h2h_gd,
+        SUM(b.goals_scored)                                                AS h2h_gf,
+        SUM(CASE WHEN b.team_side_sk = 2 THEN b.goals_scored ELSE 0 END) AS h2h_away_gf
+    FROM base b
+    GROUP BY b.team_sk, b.opponent_team_sk, b.season
+),
+h2h_vs_tied AS (
+    -- sum h2h stats only against teams tied on pts, gd, gf within same round_group
+    SELECT
+        s.team_sk,
+        s.season,
+        s.round_group,
+        COALESCE(SUM(h.h2h_pts),     0) AS h2h_pts,
+        COALESCE(SUM(h.h2h_gd),      0) AS h2h_gd,
+        COALESCE(SUM(h.h2h_gf),      0) AS h2h_gf,
+        COALESCE(SUM(h.h2h_away_gf), 0) AS h2h_away_gf
+    FROM team_stats s
+    JOIN team_stats tied ON
+        tied.season      = s.season      AND
+        tied.round_group = s.round_group AND
+        tied.pts         = s.pts         AND
+        tied.gd          = s.gd          AND
+        tied.gf          = s.gf          AND
+        tied.team_sk    != s.team_sk
+    LEFT JOIN h2h_pairwise h ON
+        h.team_sk          = s.team_sk       AND
+        h.opponent_team_sk = tied.team_sk    AND
+        h.season           = s.season
+    GROUP BY s.team_sk, s.season, s.round_group
+)
+SELECT
+    s.team_name,
+    s.season,
+    s.gp, s.w, s.d, s.l,
+    s.gf, s.ga, s.gd, s.pts,
+    s.round_group,
+    COALESCE(h.h2h_pts,     0) AS h2h_pts,
+    COALESCE(h.h2h_gd,      0) AS h2h_gd,
+    COALESCE(h.h2h_gf,      0) AS h2h_gf,
+    COALESCE(h.h2h_away_gf, 0) AS h2h_away_gf
+FROM team_stats s
+LEFT JOIN h2h_vs_tied h ON
+    h.team_sk     = s.team_sk     AND
+    h.season      = s.season      AND
+    h.round_group = s.round_group
+ORDER BY
+    s.season DESC,
+    s.round_group,
+    s.pts          DESC,
+    s.gd           DESC,
+    s.gf           DESC,
+    COALESCE(h.h2h_pts,     0) DESC,
+    COALESCE(h.h2h_gd,      0) DESC,
+    COALESCE(h.h2h_gf,      0) DESC,
+    COALESCE(h.h2h_away_gf, 0) DESC


### PR DESCRIPTION
## Summary

- Standings page (Championship, Relegation, Regular Season tables) and League Analysis league table now rank teams using the official Danish Superliga tiebreaker order: **pts → goal difference → goals scored → head-to-head pts → h2h goal difference → h2h goals scored → h2h away goals**
- H2H stats are computed only against teams that are actually tied on pts + gd + gf within the same round group — matching the official rule exactly
- Home page **Current Leader** KPI uses the same full tiebreaker chain
- Points Progression chart tooltip sorts teams by pts → gd → gf at each round (h2h at round level omitted as it would require round-by-round h2h stats)

## Files changed

| File | Change |
|---|---|
| `sources/superligaen/team_season_stats.sql` | Added h2h CTE logic; exposes `h2h_pts/gd/gf/away_gf` columns |
| `sources/superligaen/team_regular_season_stats.sql` | Same, scoped to Regular Season matches only |
| `sources/superligaen/current_leader.sql` | Full h2h tiebreaker chain before `LIMIT 1` |
| `sources/superligaen/points_progression.sql` | Added `cumulative_gd` and `cumulative_gf` window columns |
| `pages/standings.md` | Extended `row_number()` and `ORDER BY` with h2h columns |
| `pages/league-analytics.md` | Updated league table sort + tooltip IIFE closure for gd/gf sort |

## Test plan

- [ ] `npm run sources` completes with no errors
- [ ] Standings page renders Championship, Relegation, and Regular Season tables correctly
- [ ] League Analysis league table and points progression tooltip sort correctly
- [ ] Home page Current Leader KPI displays correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)