### PR TITLE
fix: normalize match round names and types (#150)

### DIFF
--- a/dashboards/package.json
+++ b/dashboards/package.json
@@ -6,7 +6,7 @@
     "build:strict": "evidence build:strict",
     "dev": "evidence dev --open /",
     "test": "evidence build",
-    "sources": "evidence sources",
+    "sources": "bash scripts/sources.sh",
     "sources:strict": "evidence sources --strict",
     "preview": "evidence preview"
   },

--- a/dashboards/package.json
+++ b/dashboards/package.json
@@ -6,7 +6,7 @@
     "build:strict": "evidence build:strict",
     "dev": "evidence dev --open /",
     "test": "evidence build",
-    "sources": "bash scripts/sources.sh",
+    "sources": "evidence sources",
     "sources:strict": "evidence sources --strict",
     "preview": "evidence preview"
   },

--- a/dashboards/sources/superligaen/mart_match_facts.sql
+++ b/dashboards/sources/superligaen/mart_match_facts.sql
@@ -41,9 +41,9 @@ SELECT
     f.goalkeeper_saves                                                       AS saves,
     ROUND(f.expected_goals::DOUBLE, 2)                                       AS xg,
     CASE
-        WHEN MAX(CASE WHEN m.match_round_type = 'Championship' THEN 1 ELSE 0 END) OVER (PARTITION BY f.team_sk, m.season) = 1
+        WHEN MAX(CASE WHEN m.match_round_type = 'Championship Group' THEN 1 ELSE 0 END) OVER (PARTITION BY f.team_sk, m.season) = 1
             THEN 'Championship Group'
-        WHEN MAX(CASE WHEN m.match_round_type = 'Relegation'   THEN 1 ELSE 0 END) OVER (PARTITION BY f.team_sk, m.season) = 1
+        WHEN MAX(CASE WHEN m.match_round_type = 'Relegation Group'   THEN 1 ELSE 0 END) OVER (PARTITION BY f.team_sk, m.season) = 1
             THEN 'Relegation Group'
         ELSE 'Regular Season'
     END                                                                      AS standings_type,

--- a/dbt/models/gold/dims/dim_match.sql
+++ b/dbt/models/gold/dims/dim_match.sql
@@ -3,7 +3,7 @@
         materialized='incremental',
         incremental_strategy='merge',
         unique_key='match_id',
-        merge_update_columns=['season', 'match_round_type', 'match_round_number', 'match_status', 'match_name', 'match_short_name', 'match_result', 'kick_off_time'],
+        merge_update_columns=['season', 'match_round_name', 'match_round_type', 'match_round_number', 'match_status', 'match_name', 'match_short_name', 'match_result', 'kick_off_time'],
         post_hook=[
             "INSERT INTO {{ this }} SELECT * FROM (VALUES (-1, NULL::INTEGER, NULL::VARCHAR, 'Unknown Match Round Name', 'Unknown Match Round Type', NULL::INTEGER, 'Unknown Match Status', 'Unknown Match Name', 'Unknown Match Short Name', NULL::VARCHAR, NULL::VARCHAR), (-2, NULL::INTEGER, NULL::VARCHAR, 'Not Applicable Match Round Name', 'Not Applicable Match Round Type', NULL::INTEGER, 'Not Applicable Match Status', 'Not Applicable Match Name', 'Not Applicable Match Short Name', NULL::VARCHAR, NULL::VARCHAR)) t(match_sk, match_id, season, match_round_name, match_round_type, match_round_number, match_status, match_name, match_short_name, match_result, kick_off_time) WHERE t.match_sk NOT IN (SELECT match_sk FROM {{ this }})"
         ]
@@ -27,15 +27,21 @@ src AS (
     SELECT
         f.fixture_id,
         f.season::VARCHAR || '/' || RIGHT((f.season + 1)::VARCHAR, 2)        AS season,
-        f.league_round                                                         AS match_round_name,
         CASE SPLIT_PART(f.league_round, ' - ', 1)
-            WHEN 'Championship Group' THEN 'Championship'
-            WHEN 'Championship Round' THEN 'Championship'
-            WHEN 'Relegation Group'   THEN 'Relegation'
-            WHEN 'Relegation Round'   THEN 'Relegation'
+            WHEN 'Championship Group' THEN 'Championship Group'
+            WHEN 'Championship Round' THEN 'Championship Group'
+            WHEN 'Relegation Group'   THEN 'Relegation Group'
+            WHEN 'Relegation Round'   THEN 'Relegation Group'
+            ELSE SPLIT_PART(f.league_round, ' - ', 1)
+        END || ' - ' || COALESCE(tr.round_number, TRY_CAST(SPLIT_PART(f.league_round, ' - ', 2) AS INTEGER))  AS match_round_name,
+        CASE SPLIT_PART(f.league_round, ' - ', 1)
+            WHEN 'Championship Group' THEN 'Championship Group'
+            WHEN 'Championship Round' THEN 'Championship Group'
+            WHEN 'Relegation Group'   THEN 'Relegation Group'
+            WHEN 'Relegation Round'   THEN 'Relegation Group'
             ELSE SPLIT_PART(f.league_round, ' - ', 1)
         END                                                                   AS match_round_type,
-        tr.round_number                                                       AS match_round_number,
+        COALESCE(tr.round_number, TRY_CAST(SPLIT_PART(f.league_round, ' - ', 2) AS INTEGER)) AS match_round_number,
         f.status_long                                                         AS match_status,
         f.home_team_name || ' - ' || f.away_team_name                        AS match_name,
         COALESCE(ht.team_code, f.home_team_name) || ' - ' || COALESCE(awt.team_code, f.away_team_name) AS match_short_name,

--- a/dbt/models/gold/fct_match_results.sql
+++ b/dbt/models/gold/fct_match_results.sql
@@ -64,13 +64,13 @@ joined AS (
             ELSE -1
         END                          AS match_result_sk,
         CASE
-            WHEN m.match_round_type IN ('Regular Season', 'Championship', 'Relegation')
+            WHEN m.match_round_type IN ('Regular Season', 'Championship Group', 'Relegation Group')
                  AND ft.status_short IN ('FT', 'AET', 'PEN')
                  AND ft.goals_scored  > ft.goals_conceded THEN 3
-            WHEN m.match_round_type IN ('Regular Season', 'Championship', 'Relegation')
+            WHEN m.match_round_type IN ('Regular Season', 'Championship Group', 'Relegation Group')
                  AND ft.status_short IN ('FT', 'AET', 'PEN')
                  AND ft.goals_scored  = ft.goals_conceded THEN 1
-            WHEN m.match_round_type IN ('Regular Season', 'Championship', 'Relegation')
+            WHEN m.match_round_type IN ('Regular Season', 'Championship Group', 'Relegation Group')
                  AND ft.status_short IN ('FT', 'AET', 'PEN')
                  AND ft.goals_scored  < ft.goals_conceded THEN 0
             ELSE NULL
@@ -107,7 +107,7 @@ joined AS (
     LEFT JOIN {{ ref('fixture_statistics') }} s
                                              ON s.fixture_id   = ft.fixture_id
                                             AND s.team_id      = ft.team_id
-    WHERE m.match_round_type IN ('Regular Season', 'Championship', 'Relegation')
+    WHERE m.match_round_type IN ('Regular Season', 'Championship Group', 'Relegation Group')
 )
 SELECT * FROM joined
 {% if is_incremental() %}


### PR DESCRIPTION
## Summary
- `match_round_name` now uses the sequential `round_number` across the full season — championship/relegation rounds continue from where the regular season left off (e.g. `Championship Group - 23`) instead of restarting at 1 in older seasons
- `match_round_type` renamed from `Championship`/`Relegation` to `Championship Group`/`Relegation Group` to match source data naming
- Added `COALESCE` fallback so upcoming matches (not yet in `fixture_statistics`) still resolve a valid round name from the raw `league_round` field
- Added `match_round_name` to `merge_update_columns` so future incremental runs update it
- Updated `fct_match_results` and `mart_match_facts` to use the new type values

## Test plan
- [x] Ran `dbt run --select dim_match --full-refresh` on dev — championship/relegation rounds start at 23 across all seasons
- [x] Ran `dbt run --select fct_match_results --full-refresh` on dev — correct team counts, no stale match_sk joins
- [x] Upcoming matches (status `NS`) correctly show `Championship Group - 30` etc. via COALESCE fallback
- [x] Dashboard launched from dev — 12 teams, standings and points progression unaffected

Closes #150

🤖 Generated with [Claude Code](https://claude.com/claude-code)