### PR TITLE
feat: add dbt data quality test suite (132 tests)

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -160,12 +160,53 @@ jobs:
           fi
 
   # ---------------------------------------------------------------------------
+  # DQ tests — run after gold, block publish if any test fails
+  # ---------------------------------------------------------------------------
+  dq_tests:
+    name: DQ tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs: gold
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: dbt deps
+        working-directory: dbt
+        env:
+          MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
+        run: dbt deps
+
+      - name: Run DQ tests
+        working-directory: dbt
+        env:
+          MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
+        run: |
+          TARGET=$([ "${{ github.event.inputs.target_db || 'superligaen' }}" = "superligaen" ] && echo "prod" || echo "dev")
+          dbt test --target $TARGET
+
+      - name: Check source freshness
+        working-directory: dbt
+        env:
+          MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
+        run: |
+          TARGET=$([ "${{ github.event.inputs.target_db || 'superligaen' }}" = "superligaen" ] && echo "prod" || echo "dev")
+          dbt source freshness --target $TARGET
+
+  # ---------------------------------------------------------------------------
   # Dashboard — push to publish_dashboard/vercel to trigger Vercel rebuild
   # ---------------------------------------------------------------------------
   publish:
     name: Publish dashboard (Vercel)
     runs-on: ubuntu-latest
-    needs: gold
+    needs: dq_tests
     permissions:
       contents: write
 

--- a/dbt/models/gold/_schema.yml
+++ b/dbt/models/gold/_schema.yml
@@ -1,0 +1,210 @@
+version: 2
+
+models:
+
+  # ─── fct_match_results ───────────────────────────────────────────────────────
+  # The fact table. Relationship tests here are the most powerful DQ check in a
+  # star schema: any SK that doesn't resolve means a dimension lookup will return
+  # nothing, silently corrupting every aggregation that joins through it.
+  - name: fct_match_results
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns: [match_sk, team_side_sk]
+    columns:
+      - name: match_sk
+        tests:
+          - not_null
+          - relationships:
+              to: ref('dim_match')
+              field: match_sk
+      - name: date_sk
+        tests:
+          - not_null
+          - relationships:
+              to: ref('dim_date')
+              field: date_sk
+      - name: time_sk
+        tests:
+          - not_null
+          - relationships:
+              to: ref('dim_time')
+              field: time_sk
+      - name: team_sk
+        tests:
+          - not_null
+          - relationships:
+              to: ref('dim_team')
+              field: team_sk
+      - name: opponent_team_sk
+        tests:
+          - not_null
+          - relationships:
+              to: ref('dim_team')
+              field: team_sk
+      - name: league_sk
+        tests:
+          - not_null
+          - relationships:
+              to: ref('dim_league')
+              field: league_sk
+      - name: stadium_sk
+        tests:
+          - not_null
+          - relationships:
+              to: ref('dim_stadium')
+              field: stadium_sk
+      - name: referee_sk
+        tests:
+          - not_null
+          - relationships:
+              to: ref('dim_referee')
+              field: referee_sk
+      - name: team_side_sk
+        tests:
+          - not_null
+          - relationships:
+              to: ref('dim_team_side')
+              field: team_side_sk
+      - name: match_result_sk
+        tests:
+          - not_null
+          - relationships:
+              to: ref('dim_match_result')
+              field: match_result_sk
+      - name: points_earned
+        tests:
+          - accepted_values:
+              values: [0, 1, 3]
+              quote: false
+      - name: goals_scored
+        tests:
+          - dbt_expectations.expect_column_values_to_be_between:
+              min_value: 0
+              row_condition: "goals_scored IS NOT NULL"
+      - name: goals_conceded
+        tests:
+          - dbt_expectations.expect_column_values_to_be_between:
+              min_value: 0
+              row_condition: "goals_conceded IS NOT NULL"
+      - name: ball_possession_pct
+        tests:
+          - dbt_expectations.expect_column_values_to_be_between:
+              min_value: 0
+              max_value: 100
+              row_condition: "ball_possession_pct IS NOT NULL"
+      - name: yellow_cards
+        tests:
+          - dbt_expectations.expect_column_values_to_be_between:
+              min_value: 0
+              row_condition: "yellow_cards IS NOT NULL"
+      - name: red_cards
+        tests:
+          - dbt_expectations.expect_column_values_to_be_between:
+              min_value: 0
+              row_condition: "red_cards IS NOT NULL"
+      - name: expected_goals
+        tests:
+          - dbt_expectations.expect_column_values_to_be_between:
+              min_value: 0
+              row_condition: "expected_goals IS NOT NULL"
+
+  # ─── dim_team ────────────────────────────────────────────────────────────────
+  - name: dim_team
+    columns:
+      - name: team_sk
+        tests:
+          - unique
+          - not_null
+      - name: team_name
+        tests:
+          - not_null
+
+  # ─── dim_match ───────────────────────────────────────────────────────────────
+  # match_round_type is an open-ended API value — new round types appear when
+  # Superligaen teams enter European play-offs. No accepted_values constraint.
+  - name: dim_match
+    columns:
+      - name: match_sk
+        tests:
+          - unique
+          - not_null
+      - name: match_id
+        tests:
+          - unique
+      - name: match_round_type
+        tests:
+          - not_null
+
+  # ─── dim_league ──────────────────────────────────────────────────────────────
+  - name: dim_league
+    columns:
+      - name: league_sk
+        tests:
+          - unique
+          - not_null
+      - name: league_name
+        tests:
+          - not_null
+
+  # ─── dim_stadium ─────────────────────────────────────────────────────────────
+  - name: dim_stadium
+    columns:
+      - name: stadium_sk
+        tests:
+          - unique
+          - not_null
+      - name: stadium_name
+        tests:
+          - not_null
+
+  # ─── dim_referee ─────────────────────────────────────────────────────────────
+  - name: dim_referee
+    columns:
+      - name: referee_sk
+        tests:
+          - unique
+          - not_null
+
+  # ─── dim_date ────────────────────────────────────────────────────────────────
+  - name: dim_date
+    columns:
+      - name: date_sk
+        tests:
+          - unique
+          - not_null
+      - name: date
+        tests:
+          - unique
+          - not_null
+
+  # ─── dim_time ────────────────────────────────────────────────────────────────
+  - name: dim_time
+    columns:
+      - name: time_sk
+        tests:
+          - unique
+          - not_null
+
+  # ─── dim_match_result ────────────────────────────────────────────────────────
+  - name: dim_match_result
+    columns:
+      - name: match_result_sk
+        tests:
+          - unique
+          - not_null
+      - name: match_result
+        tests:
+          - unique
+          - not_null
+
+  # ─── dim_team_side ───────────────────────────────────────────────────────────
+  - name: dim_team_side
+    columns:
+      - name: team_side_sk
+        tests:
+          - unique
+          - not_null
+      - name: team_side
+        tests:
+          - unique
+          - not_null

--- a/dbt/models/gold/_schema.yml
+++ b/dbt/models/gold/_schema.yml
@@ -6,10 +6,13 @@ models:
   # The fact table. Relationship tests here are the most powerful DQ check in a
   # star schema: any SK that doesn't resolve means a dimension lookup will return
   # nothing, silently corrupting every aggregation that joins through it.
+  # Row count threshold catches a pipeline that ran but loaded nothing.
   - name: fct_match_results
     tests:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns: [match_sk, team_side_sk]
+      - dbt_expectations.expect_table_row_count_to_be_between:
+          min_value: 400
     columns:
       - name: match_sk
         tests:

--- a/dbt/models/silver/_schema.yml
+++ b/dbt/models/silver/_schema.yml
@@ -1,0 +1,154 @@
+version: 2
+
+models:
+
+  # ─── fixtures ────────────────────────────────────────────────────────────────
+  # Gateway model: every downstream gold model traces back to this.
+  # Completeness + validity tests here protect the entire pipeline.
+  - name: fixtures
+    columns:
+      - name: fixture_id
+        tests:
+          - unique
+          - not_null
+      - name: home_team_id
+        tests:
+          - not_null
+      - name: away_team_id
+        tests:
+          - not_null
+      - name: league_id
+        tests:
+          - not_null
+      - name: season
+        tests:
+          - not_null
+      - name: kick_off
+        tests:
+          - not_null
+      - name: status_short
+        tests:
+          - not_null
+          - accepted_values:
+              values:
+                - 'FT'    # Full Time
+                - 'AET'   # After Extra Time
+                - 'PEN'   # After Penalties
+                - 'NS'    # Not Started
+                - 'TBD'   # To Be Defined
+                - '1H'    # First Half
+                - 'HT'    # Half Time
+                - '2H'    # Second Half
+                - 'ET'    # Extra Time
+                - 'BT'    # Break Time
+                - 'P'     # Penalty in Progress
+                - 'LIVE'  # In Play
+                - 'PST'   # Postponed
+                - 'CANC'  # Cancelled
+                - 'ABD'   # Abandoned
+                - 'AWD'   # Technical Loss
+                - 'WO'    # Walk Over
+                - 'SUSP'  # Suspended
+                - 'INT'   # Interrupted
+
+  # ─── fixture_statistics ──────────────────────────────────────────────────────
+  # One row per team per match. Range tests catch JSON parsing failures that
+  # produce nonsensical numbers (e.g. 110% possession).
+  - name: fixture_statistics
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns: [fixture_id, team_id]
+    columns:
+      - name: fixture_id
+        tests:
+          - not_null
+      - name: team_id
+        tests:
+          - not_null
+      - name: ball_possession_pct
+        tests:
+          - dbt_expectations.expect_column_values_to_be_between:
+              min_value: 0
+              max_value: 100
+              row_condition: "ball_possession_pct IS NOT NULL"
+      - name: passes_pct
+        tests:
+          - dbt_expectations.expect_column_values_to_be_between:
+              min_value: 0
+              max_value: 100
+              row_condition: "passes_pct IS NOT NULL"
+      - name: yellow_cards
+        tests:
+          - dbt_expectations.expect_column_values_to_be_between:
+              min_value: 0
+      - name: red_cards
+        tests:
+          - dbt_expectations.expect_column_values_to_be_between:
+              min_value: 0
+      - name: expected_goals
+        tests:
+          - dbt_expectations.expect_column_values_to_be_between:
+              min_value: 0
+              row_condition: "expected_goals IS NOT NULL"
+
+  # ─── standings ───────────────────────────────────────────────────────────────
+  # Consistency tests live here. The played = wins + draws + losses invariant
+  # can't be expressed as a generic test — it needs a singular SQL test.
+  - name: standings
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns: [season, league_id, team_id, standing_group]
+    columns:
+      - name: season
+        tests:
+          - not_null
+      - name: league_id
+        tests:
+          - not_null
+      - name: team_id
+        tests:
+          - not_null
+      - name: points
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_between:
+              min_value: 0
+      - name: played
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_between:
+              min_value: 0
+      - name: wins
+        tests:
+          - dbt_expectations.expect_column_values_to_be_between:
+              min_value: 0
+              row_condition: "wins IS NOT NULL"
+      - name: draws
+        tests:
+          - dbt_expectations.expect_column_values_to_be_between:
+              min_value: 0
+              row_condition: "draws IS NOT NULL"
+      - name: losses
+        tests:
+          - dbt_expectations.expect_column_values_to_be_between:
+              min_value: 0
+              row_condition: "losses IS NOT NULL"
+
+  # ─── teams ───────────────────────────────────────────────────────────────────
+  - name: teams
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns: [season, league_id, team_id]
+    columns:
+      - name: team_id
+        tests:
+          - not_null
+      - name: team_name
+        tests:
+          - not_null
+      - name: season
+        tests:
+          - not_null
+      - name: league_id
+        tests:
+          - not_null

--- a/dbt/models/silver/_schema.yml
+++ b/dbt/models/silver/_schema.yml
@@ -152,3 +152,143 @@ models:
       - name: league_id
         tests:
           - not_null
+
+  # ─── fixture_events ──────────────────────────────────────────────────────────
+  # Many rows per fixture (one per event). The accepted_values test here is a
+  # strong guard: all 4 event types are known; a new value means the API changed
+  # and our downstream CASE logic may misclassify it.
+  - name: fixture_events
+    columns:
+      - name: fixture_id
+        tests:
+          - not_null
+      - name: team_id
+        tests:
+          - not_null
+      - name: event_type
+        tests:
+          - not_null
+          - accepted_values:
+              values: ['Goal', 'Card', 'subst', 'Var']
+      - name: time_elapsed
+        tests:
+          - dbt_expectations.expect_column_values_to_be_between:
+              min_value: -10  # API uses -5 for pre-match events (tunnel cards, etc.)
+              row_condition: "time_elapsed IS NOT NULL"
+
+  # ─── fixture_lineups ─────────────────────────────────────────────────────────
+  # One row per player per match per team. Unique key includes is_starter because
+  # a player can appear as both starter and substitute (late sub returning).
+  - name: fixture_lineups
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns: [fixture_id, team_id, player_id, is_starter]
+    columns:
+      - name: fixture_id
+        tests:
+          - not_null
+      - name: team_id
+        tests:
+          - not_null
+      - name: player_id
+        tests:
+          - not_null
+
+  # ─── leagues ─────────────────────────────────────────────────────────────────
+  - name: leagues
+    columns:
+      - name: league_id
+        tests:
+          - unique
+          - not_null
+      - name: league_name
+        tests:
+          - not_null
+
+  # ─── rounds ──────────────────────────────────────────────────────────────────
+  - name: rounds
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns: [season, league_id, round_name]
+    columns:
+      - name: season
+        tests:
+          - not_null
+      - name: league_id
+        tests:
+          - not_null
+      - name: round_name
+        tests:
+          - not_null
+
+  # ─── top lists (scorers / assists / cards) ───────────────────────────────────
+  # Shared structure: one row per player per season per league.
+  - name: topscorers
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns: [season, league_id, player_id]
+    columns:
+      - name: player_id
+        tests:
+          - not_null
+      - name: season
+        tests:
+          - not_null
+      - name: league_id
+        tests:
+          - not_null
+      - name: goals
+        tests:
+          - dbt_expectations.expect_column_values_to_be_between:
+              min_value: 0
+              row_condition: "goals IS NOT NULL"
+      - name: appearances
+        tests:
+          - dbt_expectations.expect_column_values_to_be_between:
+              min_value: 0
+              row_condition: "appearances IS NOT NULL"
+
+  - name: topassists
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns: [season, league_id, player_id]
+    columns:
+      - name: player_id
+        tests:
+          - not_null
+      - name: season
+        tests:
+          - not_null
+      - name: league_id
+        tests:
+          - not_null
+
+  - name: topredcards
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns: [season, league_id, player_id]
+    columns:
+      - name: player_id
+        tests:
+          - not_null
+      - name: season
+        tests:
+          - not_null
+      - name: league_id
+        tests:
+          - not_null
+
+  - name: topyellowcards
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns: [season, league_id, player_id]
+    columns:
+      - name: player_id
+        tests:
+          - not_null
+      - name: season
+        tests:
+          - not_null
+      - name: league_id
+        tests:
+          - not_null

--- a/dbt/models/silver/_sources.yml
+++ b/dbt/models/silver/_sources.yml
@@ -4,22 +4,37 @@ sources:
   - name: bronze
     database: "{{ 'superligaen' if target.name == 'prod' else 'superligaen_dev' }}"
     schema: bronze
+    # Freshness thresholds for nightly ingestion.
+    # warn_after: 25h covers a missed run; error_after: 49h means two missed runs.
+    # Tables with no `freshness` override inherit these defaults.
+    loaded_at_field: ingested_at
+    freshness:
+      warn_after: {count: 25, period: hour}
+      error_after: {count: 49, period: hour}
     tables:
       - name: api_football__fixtures
-      - name: api_football__leagues
-      - name: api_football__venues
       - name: api_football__fixture_statistics
       - name: api_football__fixture_events
       - name: api_football__fixture_lineups
       - name: api_football__fixture_players
-      - name: api_football__fixture_predictions
-      - name: api_football__fixture_odds
       - name: api_football__standings
-      - name: api_football__teams
       - name: api_football__rounds
-      - name: api_football__players
-      - name: api_football__injuries
       - name: api_football__topassists
       - name: api_football__topscorers
       - name: api_football__topredcards
       - name: api_football__topyellowcards
+      # Static / infrequently updated — no freshness check
+      - name: api_football__leagues
+        freshness: null
+      - name: api_football__venues
+        freshness: null
+      - name: api_football__teams
+        freshness: null
+      - name: api_football__players
+        freshness: null
+      - name: api_football__injuries
+        freshness: null
+      - name: api_football__fixture_predictions
+        freshness: null
+      - name: api_football__fixture_odds
+        freshness: null

--- a/dbt/package-lock.yml
+++ b/dbt/package-lock.yml
@@ -2,4 +2,10 @@ packages:
   - name: dbt_utils
     package: dbt-labs/dbt_utils
     version: 1.3.3
-sha1_hash: dd1e1feb2d2bbce79e7a255cd309a60e6548df0b
+  - name: dbt_expectations
+    package: metaplane/dbt_expectations
+    version: 0.10.10
+  - name: dbt_date
+    package: godatadriven/dbt_date
+    version: 0.17.2
+sha1_hash: 316bd357f8471697719b1651a48a88a0a32fac78

--- a/dbt/packages.yml
+++ b/dbt/packages.yml
@@ -1,3 +1,5 @@
 packages:
   - package: dbt-labs/dbt_utils
     version: [">=1.0.0", "<2.0.0"]
+  - package: metaplane/dbt_expectations
+    version: [">=0.10.0", "<0.11.0"]

--- a/dbt/tests/gold/assert_dimension_dummy_rows.sql
+++ b/dbt/tests/gold/assert_dimension_dummy_rows.sql
@@ -1,0 +1,36 @@
+-- Every dimension must have sentinel rows -1 (Unknown) and -2 (Not Applicable).
+-- The fact table uses COALESCE(..., -1) so a missing sentinel row means
+-- unresolved FKs silently disappear from dimension joins.
+-- Any row returned here means a post_hook failed to insert a sentinel.
+SELECT 'dim_team'         AS dim_name, expected_sk FROM (VALUES (-1), (-2)) t(expected_sk)
+WHERE expected_sk NOT IN (SELECT team_sk      FROM {{ ref('dim_team') }})
+
+UNION ALL
+
+SELECT 'dim_match',         expected_sk FROM (VALUES (-1), (-2)) t(expected_sk)
+WHERE expected_sk NOT IN (SELECT match_sk     FROM {{ ref('dim_match') }})
+
+UNION ALL
+
+SELECT 'dim_league',        expected_sk FROM (VALUES (-1), (-2)) t(expected_sk)
+WHERE expected_sk NOT IN (SELECT league_sk    FROM {{ ref('dim_league') }})
+
+UNION ALL
+
+SELECT 'dim_stadium',       expected_sk FROM (VALUES (-1), (-2)) t(expected_sk)
+WHERE expected_sk NOT IN (SELECT stadium_sk   FROM {{ ref('dim_stadium') }})
+
+UNION ALL
+
+SELECT 'dim_referee',       expected_sk FROM (VALUES (-1), (-2)) t(expected_sk)
+WHERE expected_sk NOT IN (SELECT referee_sk   FROM {{ ref('dim_referee') }})
+
+UNION ALL
+
+SELECT 'dim_match_result',  expected_sk FROM (VALUES (-1), (-2)) t(expected_sk)
+WHERE expected_sk NOT IN (SELECT match_result_sk FROM {{ ref('dim_match_result') }})
+
+UNION ALL
+
+SELECT 'dim_team_side',     expected_sk FROM (VALUES (-1), (-2)) t(expected_sk)
+WHERE expected_sk NOT IN (SELECT team_side_sk FROM {{ ref('dim_team_side') }})

--- a/dbt/tests/gold/assert_fct_two_rows_per_match.sql
+++ b/dbt/tests/gold/assert_fct_two_rows_per_match.sql
@@ -1,0 +1,9 @@
+-- Every match in the fact table must have exactly 2 rows: one home, one away.
+-- A broken UNION ALL or a failed incremental merge would violate this.
+SELECT
+    match_sk,
+    count(*) AS row_count
+FROM {{ ref('fct_match_results') }}
+WHERE match_sk > 0
+GROUP BY match_sk
+HAVING count(*) != 2

--- a/dbt/tests/gold/assert_points_earned_consistency.sql
+++ b/dbt/tests/gold/assert_points_earned_consistency.sql
@@ -1,0 +1,18 @@
+-- Business rule: points_earned must match the goal comparison.
+-- Win (goals_scored > goals_conceded)  → 3 pts
+-- Draw (goals_scored = goals_conceded) → 1 pt
+-- Loss (goals_scored < goals_conceded) → 0 pts
+-- Any row returned here means the fact table has a corrupted points value.
+SELECT
+    match_sk,
+    team_side_sk,
+    goals_scored,
+    goals_conceded,
+    points_earned
+FROM {{ ref('fct_match_results') }}
+WHERE points_earned IS NOT NULL
+  AND NOT (
+      (goals_scored > goals_conceded  AND points_earned = 3) OR
+      (goals_scored = goals_conceded  AND points_earned = 1) OR
+      (goals_scored < goals_conceded  AND points_earned = 0)
+  )

--- a/dbt/tests/gold/assert_possession_sums_to_100.sql
+++ b/dbt/tests/gold/assert_possession_sums_to_100.sql
@@ -1,0 +1,10 @@
+-- Home + away possession must sum to 100% per match (within 1pp rounding tolerance).
+-- A violation means the API returned corrupted possession data for that match.
+SELECT
+    match_sk,
+    sum(ball_possession_pct) AS total_possession
+FROM {{ ref('fct_match_results') }}
+WHERE ball_possession_pct IS NOT NULL
+  AND match_sk > 0
+GROUP BY match_sk
+HAVING abs(sum(ball_possession_pct) - 100) > 1

--- a/dbt/tests/silver/assert_fixture_stats_two_per_match.sql
+++ b/dbt/tests/silver/assert_fixture_stats_two_per_match.sql
@@ -1,0 +1,11 @@
+-- Every completed match must have exactly 2 rows in fixture_statistics (one per team).
+-- Fewer means a team's stats went missing. More means a duplicate was ingested.
+SELECT
+    s.fixture_id,
+    f.status_short,
+    count(*) AS stat_rows
+FROM {{ ref('fixture_statistics') }} s
+JOIN {{ ref('fixtures') }} f ON f.fixture_id = s.fixture_id
+WHERE f.status_short IN ('FT', 'AET', 'PEN')
+GROUP BY s.fixture_id, f.status_short
+HAVING count(*) != 2

--- a/dbt/tests/silver/assert_halftime_leq_fulltime.sql
+++ b/dbt/tests/silver/assert_halftime_leq_fulltime.sql
@@ -1,0 +1,16 @@
+-- Halftime goals can never exceed fulltime goals — physics, not an API choice.
+-- Any row here means the score JSON was corrupted or misread during ingestion.
+SELECT
+    fixture_id,
+    goals_home,
+    goals_away,
+    score_ht_home,
+    score_ht_away
+FROM {{ ref('fixtures') }}
+WHERE status_short IN ('FT', 'AET', 'PEN')
+  AND score_ht_home IS NOT NULL
+  AND score_ht_away IS NOT NULL
+  AND (
+      score_ht_home > goals_home
+      OR score_ht_away > goals_away
+  )

--- a/dbt/tests/silver/assert_standings_played_equals_wdl.sql
+++ b/dbt/tests/silver/assert_standings_played_equals_wdl.sql
@@ -1,0 +1,18 @@
+-- Standings consistency: a team's played count must equal wins + draws + losses.
+-- Any row returned here means the API sent internally inconsistent data.
+SELECT
+    season,
+    league_id,
+    team_id,
+    team_name,
+    played,
+    wins,
+    draws,
+    losses,
+    wins + draws + losses AS wdl_sum
+FROM {{ ref('standings') }}
+WHERE played IS NOT NULL
+  AND wins    IS NOT NULL
+  AND draws   IS NOT NULL
+  AND losses  IS NOT NULL
+  AND played != wins + draws + losses


### PR DESCRIPTION
## Summary

- Adds a full DQ test suite across all pipeline layers — 132 tests, all passing
- Covers silver (12 models), gold (fact + 9 dims), and source freshness
- Discovered and fixed two real data issues during implementation

## What's covered

**Silver layer**
- Uniqueness on every composite key (fixtures, fixture_statistics, standings, teams, fixture_lineups, rounds, top lists)
- `not_null` on all required fields
- `accepted_values` on `status_short` (19 API codes) and `event_type` (4 known types)
- Range checks: possession 0–100%, passes % 0–100%, cards ≥0, xG ≥0, time_elapsed ≥-10 (API uses -5 for pre-match tunnel cards)

**Gold layer**
- Uniqueness on `[match_sk, team_side_sk]` in fact table
- FK relationships from `fct_match_results` to all 8 dimensions
- `accepted_values` on `points_earned` (0, 1, 3)
- Range checks on goals, cards, xG, possession
- Row count floor of 400 on `fct_match_results` (catches empty pipeline runs)

**Source freshness**
- 11 nightly tables: warn after 25h, error after 49h
- 7 static tables (leagues, venues, teams, players, etc.): no freshness check

**Singular SQL tests (business logic)**
- `assert_points_earned_consistency` — points must match the scoreline
- `assert_standings_played_equals_wdl` — played = wins + draws + losses
- `assert_halftime_leq_fulltime` — HT goals can never exceed FT goals
- `assert_fixture_stats_two_per_match` — every completed match has exactly 2 stat rows
- `assert_fct_two_rows_per_match` — every match_sk has exactly 2 fact rows
- `assert_possession_sums_to_100` — home + away possession = 100 (±1pp)
- `assert_dimension_dummy_rows` — sentinel rows (-1/-2) present in all dims

## Real findings during test run
- **standings unique key** was wrong — API returns each team twice (overall + group standings); fixed to include `standing_group`
- **`time_elapsed = -5`** — API sentinel for pre-match cards (tunnel incidents); not a bug, test adjusted accordingly

## New package
- Added `metaplane/dbt_expectations` for statistical checks (`expect_column_values_to_be_between`, `expect_table_row_count_to_be_between`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)