### PR TITLE
fix: sort Match Analysis filter to match table order (#182)

### DIFF
--- a/dashboards/pages/match-results.md
+++ b/dashboards/pages/match-results.md
@@ -98,7 +98,7 @@ order by match_date desc
 ```
 
 {#key match_options[0]?.match_key}
-<Dropdown data={match_options} name=match value=match_key label=match_label defaultValue={match_options[0]?.match_key} />
+<Dropdown data={match_options} name=match value=match_key label=match_label defaultValue={match_options[0]?.match_key} order="match_date desc" />
 {/key}
 
 ```sql mc

--- a/dashboards/pages/upcoming-matches.md
+++ b/dashboards/pages/upcoming-matches.md
@@ -38,7 +38,7 @@ order by match_date asc, kick_off_time asc
 
 ## Match Analysis
 
-<Dropdown data={upcoming} name=match value=match_key label=match_name order="match_round_number desc, match_date asc" />
+<Dropdown data={upcoming} name=match value=match_key label=match_name order="match_date asc, kick_off_time asc" />
 
 ```sql match_info
 select


### PR DESCRIPTION
## Summary
- Match Analysis dropdown now mirrors the sort order of the table directly above it on both pages
- **Match Results**: added `order="match_date desc"` (most recent first)
- **Upcoming Fixtures**: changed from `match_round_number desc` to `match_date asc, kick_off_time asc` (earliest fixture first)

Closes #182

🤖 Generated with [Claude Code](https://claude.com/claude-code)