### PR TITLE
fix: extract kick_off hour and date in Copenhagen local time (#186)

### DIFF
--- a/dbt/models/gold/fct_match_results.sql
+++ b/dbt/models/gold/fct_match_results.sql
@@ -9,8 +9,8 @@
 WITH fixture_teams AS (
     SELECT
         f.fixture_id,
-        f.kick_off::DATE                         AS match_date,
-        EXTRACT(hour FROM f.kick_off)::INTEGER    AS kick_off_hour,
+        (f.kick_off AT TIME ZONE 'Europe/Copenhagen')::DATE    AS match_date,
+        EXTRACT(hour FROM f.kick_off AT TIME ZONE 'Europe/Copenhagen')::INTEGER AS kick_off_hour,
         f.league_id,
         f.referee,
         f.venue_id,
@@ -26,8 +26,8 @@ WITH fixture_teams AS (
     UNION ALL
     SELECT
         f.fixture_id,
-        f.kick_off::DATE,
-        EXTRACT(hour FROM f.kick_off)::INTEGER,
+        (f.kick_off AT TIME ZONE 'Europe/Copenhagen')::DATE,
+        EXTRACT(hour FROM f.kick_off AT TIME ZONE 'Europe/Copenhagen')::INTEGER,
         f.league_id,
         f.referee,
         f.venue_id,


### PR DESCRIPTION
## Summary
- Fixes `time_sk` in `fct_match_results` to reflect local Danish kickoff time instead of UTC
- Also fixes `match_date` derivation to use local time for consistency
- Root cause: `EXTRACT(hour FROM kick_off)` was operating on the UTC value; winter games were off by 1h, summer games by 2h

## Test plan
- [ ] Verified against `superligaen_dev`: a 19:00 CET game (winter) now yields `time_sk = 19` instead of `18`
- [ ] Confirm `fct_match_results` full-refresh runs clean in prod pipeline

Closes #186

🤖 Generated with [Claude Code](https://claude.com/claude-code)