### PR TITLE
feat: move season attribute from dim_match to dim_date (#151)

### DIFF
--- a/dashboards/sources/superligaen/mart_match_facts.sql
+++ b/dashboards/sources/superligaen/mart_match_facts.sql
@@ -1,6 +1,6 @@
 SELECT
     d.date                                                                   AS match_date,
-    m.season,
+    d.season,
     m.match_round_name,
     m.match_round_type,
     m.match_round_number,
@@ -41,22 +41,22 @@ SELECT
     f.goalkeeper_saves                                                       AS saves,
     ROUND(f.expected_goals::DOUBLE, 2)                                       AS xg,
     CASE
-        WHEN MAX(CASE WHEN m.match_round_type = 'Championship Group' THEN 1 ELSE 0 END) OVER (PARTITION BY f.team_sk, m.season) = 1
+        WHEN MAX(CASE WHEN m.match_round_type = 'Championship Group' THEN 1 ELSE 0 END) OVER (PARTITION BY f.team_sk, d.season) = 1
             THEN 'Championship Group'
-        WHEN MAX(CASE WHEN m.match_round_type = 'Relegation Group'   THEN 1 ELSE 0 END) OVER (PARTITION BY f.team_sk, m.season) = 1
+        WHEN MAX(CASE WHEN m.match_round_type = 'Relegation Group'   THEN 1 ELSE 0 END) OVER (PARTITION BY f.team_sk, d.season) = 1
             THEN 'Relegation Group'
         ELSE 'Regular Season'
     END                                                                      AS standings_type,
     SUM(f.points_earned) OVER (
-        PARTITION BY f.team_sk, m.season
+        PARTITION BY f.team_sk, d.season
         ORDER BY m.match_round_number
     )                                                                        AS cumulative_points,
     SUM(f.goals_scored - f.goals_conceded) OVER (
-        PARTITION BY f.team_sk, m.season
+        PARTITION BY f.team_sk, d.season
         ORDER BY m.match_round_number
     )                                                                        AS cumulative_gd,
     SUM(f.goals_scored) OVER (
-        PARTITION BY f.team_sk, m.season
+        PARTITION BY f.team_sk, d.season
         ORDER BY m.match_round_number
     )                                                                        AS cumulative_gf
 FROM superligaen.gold.fct_match_results  f

--- a/dbt/models/gold/dims/dim_date.sql
+++ b/dbt/models/gold/dims/dim_date.sql
@@ -5,6 +5,16 @@
     )
 }}
 
+WITH season_dates AS (
+    SELECT
+        (s->>'$.year')::INTEGER AS season_year,
+        (s->>'$.start')::DATE   AS season_start,
+        (s->>'$.end')::DATE     AS season_end,
+        (s->>'$.year')::VARCHAR || '/' || RIGHT(((s->>'$.year')::INTEGER + 1)::VARCHAR, 2) AS season
+    FROM {{ ref('leagues') }},
+    UNNEST(seasons::JSON[]) AS t(s)
+    WHERE league_id = 119
+)
 SELECT
     strftime('%Y%m%d', d)::INTEGER           AS date_sk,
     d::DATE                                  AS date,
@@ -15,5 +25,7 @@ SELECT
     weekofyear(d)::INTEGER                   AS week_number,
     isodow(d)::INTEGER                       AS day_of_week,
     dayname(d)                               AS day_name,
-    CASE WHEN isodow(d) IN (6, 7) THEN 'Yes' ELSE 'No' END AS is_weekend
+    CASE WHEN isodow(d) IN (6, 7) THEN 'Yes' ELSE 'No' END AS is_weekend,
+    sd.season
 FROM generate_series(DATE '2020-01-01', DATE '2030-12-31', INTERVAL '1 day') t(d)
+LEFT JOIN season_dates sd ON d::DATE BETWEEN sd.season_start AND sd.season_end

--- a/dbt/models/gold/dims/dim_match.sql
+++ b/dbt/models/gold/dims/dim_match.sql
@@ -3,9 +3,9 @@
         materialized='incremental',
         incremental_strategy='merge',
         unique_key='match_id',
-        merge_update_columns=['season', 'match_round_name', 'match_round_type', 'match_round_number', 'match_status', 'match_name', 'match_short_name', 'match_result', 'kick_off_time'],
+        merge_update_columns=['match_round_name', 'match_round_type', 'match_round_number', 'match_status', 'match_name', 'match_short_name', 'match_result', 'kick_off_time'],
         post_hook=[
-            "INSERT INTO {{ this }} SELECT * FROM (VALUES (-1, NULL::INTEGER, NULL::VARCHAR, 'Unknown Match Round Name', 'Unknown Match Round Type', NULL::INTEGER, 'Unknown Match Status', 'Unknown Match Name', 'Unknown Match Short Name', NULL::VARCHAR, NULL::VARCHAR), (-2, NULL::INTEGER, NULL::VARCHAR, 'Not Applicable Match Round Name', 'Not Applicable Match Round Type', NULL::INTEGER, 'Not Applicable Match Status', 'Not Applicable Match Name', 'Not Applicable Match Short Name', NULL::VARCHAR, NULL::VARCHAR)) t(match_sk, match_id, season, match_round_name, match_round_type, match_round_number, match_status, match_name, match_short_name, match_result, kick_off_time) WHERE t.match_sk NOT IN (SELECT match_sk FROM {{ this }})"
+            "INSERT INTO {{ this }} SELECT * FROM (VALUES (-1, NULL::INTEGER, 'Unknown Match Round Name', 'Unknown Match Round Type', NULL::INTEGER, 'Unknown Match Status', 'Unknown Match Name', 'Unknown Match Short Name', NULL::VARCHAR, NULL::VARCHAR), (-2, NULL::INTEGER, 'Not Applicable Match Round Name', 'Not Applicable Match Round Type', NULL::INTEGER, 'Not Applicable Match Status', 'Not Applicable Match Name', 'Not Applicable Match Short Name', NULL::VARCHAR, NULL::VARCHAR)) t(match_sk, match_id, match_round_name, match_round_type, match_round_number, match_status, match_name, match_short_name, match_result, kick_off_time) WHERE t.match_sk NOT IN (SELECT match_sk FROM {{ this }})"
         ]
     )
 }}
@@ -74,7 +74,6 @@ SELECT
     ROW_NUMBER() OVER (ORDER BY src.fixture_id) AS match_sk,
     {% endif %}
     src.fixture_id   AS match_id,
-    src.season,
     src.match_round_name,
     src.match_round_type,
     src.match_round_number,


### PR DESCRIPTION
## Summary
- Adds `season` to `dim_date` using a range join against `silver.leagues` season start/end dates — correctly handles the COVID 2020 season (started September, not July)
- Dates outside any known season window return NULL (honest — no season to assign)
- Removes `season` from `dim_match` SELECT, `merge_update_columns`, and dummy post_hook rows
- Updates `mart_match_facts.sql` to source `season` from `d.season` (dim_date) instead of `m.season` (dim_match)

## Deployment note
Requires a full refresh of the entire gold layer (`dbt run --full-refresh --select gold`) to rebuild `dim_match` without the season column and keep FK consistency with `fct_match_results`.

Closes #151

🤖 Generated with [Claude Code](https://claude.com/claude-code)