### PR TITLE
fix: resolve 4 nightly DQ test failures in silver models

### DIFF
--- a/dbt/models/silver/fixture_lineups.sql
+++ b/dbt/models/silver/fixture_lineups.sql
@@ -31,6 +31,7 @@ WITH src AS (
     JOIN {{ source('bronze', 'api_football__fixtures') }} f USING (fixture_id),
     UNNEST(l.raw_json::JSON[]) AS t1(tl),
     UNNEST((tl->'$.startXI')::JSON[]) AS t2(p)
+    WHERE (p->>'$.player.id') IS NOT NULL
     UNION ALL
     SELECT
         l.fixture_id,
@@ -56,6 +57,7 @@ WITH src AS (
     JOIN {{ source('bronze', 'api_football__fixtures') }} f USING (fixture_id),
     UNNEST(l.raw_json::JSON[]) AS t1(tl),
     UNNEST((tl->'$.substitutes')::JSON[]) AS t2(p)
+    WHERE (p->>'$.player.id') IS NOT NULL
 )
 SELECT * FROM src
 {% if is_incremental() %}

--- a/dbt/models/silver/topassists.sql
+++ b/dbt/models/silver/topassists.sql
@@ -65,7 +65,8 @@ SELECT
     ingested_at
 FROM {{ source('bronze', 'api_football__topassists') }},
 UNNEST(raw_json::JSON[]) AS t1(elem),
-UNNEST((elem->'$.statistics')::JSON[]) AS t2(stats)
+UNNEST((elem->'$.statistics')::JSON[]) WITH ORDINALITY AS t2(stats, stats_ord)
 {% if is_incremental() %}
 WHERE {{ season_filter() }}
 {% endif %}
+QUALIFY ROW_NUMBER() OVER (PARTITION BY season, league_id, player_id ORDER BY stats_ord DESC) = 1

--- a/dbt/models/silver/topredcards.sql
+++ b/dbt/models/silver/topredcards.sql
@@ -65,7 +65,8 @@ SELECT
     ingested_at
 FROM {{ source('bronze', 'api_football__topredcards') }},
 UNNEST(raw_json::JSON[]) AS t1(elem),
-UNNEST((elem->'$.statistics')::JSON[]) AS t2(stats)
+UNNEST((elem->'$.statistics')::JSON[]) WITH ORDINALITY AS t2(stats, stats_ord)
 {% if is_incremental() %}
 WHERE {{ season_filter() }}
 {% endif %}
+QUALIFY ROW_NUMBER() OVER (PARTITION BY season, league_id, player_id ORDER BY stats_ord DESC) = 1

--- a/dbt/models/silver/topscorers.sql
+++ b/dbt/models/silver/topscorers.sql
@@ -65,7 +65,8 @@ SELECT
     ingested_at
 FROM {{ source('bronze', 'api_football__topscorers') }},
 UNNEST(raw_json::JSON[]) AS t1(elem),
-UNNEST((elem->'$.statistics')::JSON[]) AS t2(stats)
+UNNEST((elem->'$.statistics')::JSON[]) WITH ORDINALITY AS t2(stats, stats_ord)
 {% if is_incremental() %}
 WHERE {{ season_filter() }}
 {% endif %}
+QUALIFY ROW_NUMBER() OVER (PARTITION BY season, league_id, player_id ORDER BY stats_ord DESC) = 1

--- a/dbt/models/silver/topyellowcards.sql
+++ b/dbt/models/silver/topyellowcards.sql
@@ -65,7 +65,8 @@ SELECT
     ingested_at
 FROM {{ source('bronze', 'api_football__topyellowcards') }},
 UNNEST(raw_json::JSON[]) AS t1(elem),
-UNNEST((elem->'$.statistics')::JSON[]) AS t2(stats)
+UNNEST((elem->'$.statistics')::JSON[]) WITH ORDINALITY AS t2(stats, stats_ord)
 {% if is_incremental() %}
 WHERE {{ season_filter() }}
 {% endif %}
+QUALIFY ROW_NUMBER() OVER (PARTITION BY season, league_id, player_id ORDER BY stats_ord DESC) = 1


### PR DESCRIPTION
## Root cause

May 8 was the **first nightly run with DQ tests enabled** (PR #183 was pulled in via #192). The tests immediately surfaced two pre-existing data issues.

### Issue 1 — `fixture_lineups`: null `player_id` (4 failures)

Fixtures 688081 and 688082 are 2021-season matches. The API-Football historical data for those fixtures emits ghost substitute/starter entries with a player name but no ID. This caused:
- `not_null_fixture_lineups_player_id` — FAIL 4
- `unique_combination_of_columns_fixture_lineups_fixture_id__team_id__player_id__is_starter` — FAIL 1 (two null rows for same fixture/team/is_starter=false)

**Fix:** Added `WHERE (p->>'$.player.id') IS NOT NULL` to both the starters and substitutes branches of the UNION ALL.

### Issue 2 — `topassists` / `topscorers`: players with two teams (3 + 1 failures)

Players who transferred mid-season (e.g. E. Achouri, Viborg → FC Copenhagen) appear once in the top-N list but with multiple entries in `$.statistics` (one per team). `UNNEST` on that array produced 2 rows per such player, violating the `(season, league_id, player_id)` unique key.

**Fix:** Added `QUALIFY ROW_NUMBER() OVER (PARTITION BY season, league_id, player_id ORDER BY stats_ord DESC) = 1` using `WITH ORDINALITY` — picks the **last** entry in the statistics array, which is the most recent/current club.

Also applied the same fix proactively to `topredcards` and `topyellowcards`, which have the identical pattern and would hit the same failure if a dual-team player ever appears in those rankings.

## Prod data cleanup required

After merging, the bad rows already in prod silver need a targeted refresh. Trigger the pipeline manually via **Actions → Nightly pipeline → Run workflow** with:

| Model | Workflow input |
|---|---|
| `fixture_lineups` | `season = 2020` |
| `topassists` / `topscorers` | `season = 2022`, then `season = 2023` |

## Test plan
- [ ] Merge and trigger the workflow for season 2020 — verify null rows are gone from `silver.fixture_lineups`
- [ ] Trigger for season 2022 and 2023 — verify `silver.topassists` and `silver.topscorers` have no duplicates
- [ ] Next nightly pipeline passes all 132 DQ tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)