### PR TITLE
fix: exclude player_id = 0 rows from dim_player and fct_player_appearances

### DIFF
--- a/dbt/models/gold/dims/dim_player.sql
+++ b/dbt/models/gold/dims/dim_player.sql
@@ -53,3 +53,4 @@ SELECT
     src.player_team_name
 FROM latest src
 WHERE src.player_id IS NOT NULL
+  AND src.player_id > 0

--- a/dbt/models/gold/fct_player_appearances.sql
+++ b/dbt/models/gold/fct_player_appearances.sql
@@ -69,6 +69,7 @@ WITH src AS (
     FROM {{ ref('fixture_players') }} fp
     JOIN {{ ref('fixtures') }} f ON f.fixture_id = fp.fixture_id
     WHERE fp.minutes_played > 0
+      AND fp.player_id > 0
 ),
 joined AS (
     SELECT


### PR DESCRIPTION
## Summary
- API occasionally returns `player_id = 0` for unnamed/unidentified players
- Two such rows in the same match (fixture 688082, team 404) both resolved to `player_sk = -1`, causing a duplicate that failed the uniqueness DQ test on `fct_player_appearances`
- Added `AND player_id > 0` filter to both `dim_player` and `fct_player_appearances` to exclude these invalid rows at source

## Test plan
- [ ] Run gold layer incrementally after merge
- [ ] Run DQ tests — all 36 should pass (verified on prod already before this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)