### PR TITLE
feat: advanced BI redesign — radar chart, quadrant, heatmap, player analytics

### DIFF
--- a/dashboards/components/RadarChart.svelte
+++ b/dashboards/components/RadarChart.svelte
@@ -1,0 +1,111 @@
+<script>
+    import { onMount, onDestroy } from 'svelte';
+    import * as echarts from 'echarts';
+
+    /** @type {Array<{dimension: string, value: number}>} */
+    export let data = [];
+    export let name = 'Team';
+    export let color = '#236aa4';
+    export let height = 380;
+
+    let container;
+    let chart;
+    let ro;
+
+    function buildOption(rows) {
+        const values = rows.map(r => +(r.value) || 0);
+        return {
+            backgroundColor: 'transparent',
+            tooltip: {
+                trigger: 'item',
+                backgroundColor: '#fff',
+                borderColor: '#e5e7eb',
+                textStyle: { color: '#374151' },
+                formatter: () =>
+                    `<div style="font-size:12px;line-height:2;min-width:180px">` +
+                    `<div style="font-weight:600;margin-bottom:4px;color:#111">${name}</div>` +
+                    rows.map(r =>
+                        `<div style="display:flex;justify-content:space-between;gap:20px">` +
+                        `<span style="color:#6b7280">${r.dimension}</span>` +
+                        `<b style="color:#111">${Math.round(+r.value)}th percentile</b>` +
+                        `</div>`
+                    ).join('') +
+                    `</div>`
+            },
+            legend: {
+                bottom: 0,
+                itemGap: 20,
+                data: ['League Avg', name],
+                textStyle: { color: '#6b7280', fontSize: 12 }
+            },
+            radar: {
+                indicator: rows.map(r => ({ name: r.dimension, max: 100, min: 0 })),
+                shape: 'polygon',
+                radius: '60%',
+                center: ['50%', '47%'],
+                splitNumber: 4,
+                axisName: {
+                    color: '#374151',
+                    fontSize: 12,
+                    fontWeight: '600'
+                },
+                splitLine: { lineStyle: { color: '#e5e7eb', width: 1 } },
+                splitArea: {
+                    areaStyle: {
+                        color: [
+                            'rgba(249,250,251,0.7)',
+                            'rgba(255,255,255,0.7)',
+                            'rgba(249,250,251,0.7)',
+                            'rgba(255,255,255,0.7)'
+                        ]
+                    }
+                },
+                axisLine: { lineStyle: { color: '#d1d5db' } }
+            },
+            series: [
+                {
+                    type: 'radar',
+                    silent: true,
+                    data: [{
+                        value: rows.map(() => 50),
+                        name: 'League Avg',
+                        symbol: 'none',
+                        lineStyle: { color: '#9ca3af', type: 'dashed', width: 1.5 },
+                        areaStyle: { color: 'transparent' },
+                        itemStyle: { color: '#9ca3af' }
+                    }]
+                },
+                {
+                    type: 'radar',
+                    data: [{
+                        value: values,
+                        name,
+                        symbol: 'circle',
+                        symbolSize: 5,
+                        lineStyle: { color, width: 2.5 },
+                        areaStyle: { color, opacity: 0.22 },
+                        itemStyle: { color, borderColor: '#fff', borderWidth: 1.5 }
+                    }]
+                }
+            ]
+        };
+    }
+
+    $: if (chart && data && data.length > 0) {
+        chart.setOption(buildOption(data), true);
+    }
+
+    onMount(() => {
+        chart = echarts.init(container, null, { renderer: 'canvas' });
+        if (data?.length) chart.setOption(buildOption(data));
+        ro = new ResizeObserver(() => chart?.resize());
+        ro.observe(container);
+    });
+
+    onDestroy(() => {
+        ro?.disconnect();
+        chart?.dispose();
+    });
+</script>
+
+<div bind:this={container} style="width: 100%; height: {height}px;"></div>

--- a/dashboards/pages/index.md
+++ b/dashboards/pages/index.md
@@ -123,6 +123,16 @@ limit 1
   </div>
 </a>
 
+<a href="/player-analytics" class="block no-underline rounded-xl border border-gray-200 bg-white p-6 hover:border-blue-500 hover:shadow-lg transition-all duration-200 group shadow-sm">
+  <div class="flex items-start gap-4">
+    <div class="text-3xl">👤</div>
+    <div>
+      <div class="text-base font-bold text-gray-800 group-hover:text-blue-500 transition-colors">Player Analysis</div>
+      <div class="text-gray-400 text-sm mt-1">Top performers, goal contributions per 90 and rating vs playing time</div>
+    </div>
+  </div>
+</a>
+
 <a href="/referee-analytics" class="block no-underline rounded-xl border border-gray-200 bg-white p-6 hover:border-blue-500 hover:shadow-lg transition-all duration-200 group shadow-sm">
   <div class="flex items-start gap-4">
     <div class="text-3xl">🟨</div>

--- a/dashboards/pages/league-analytics.md
+++ b/dashboards/pages/league-analytics.md
@@ -6,6 +6,7 @@ title: League Analysis
 
 ```sql seasons
 select distinct season from superligaen.mart_match_facts
+where result in ('Win', 'Draw', 'Loss')
 order by season desc
 ```
 
@@ -13,149 +14,137 @@ order by season desc
     <DropdownOption value="2025/26" valueLabel="2025/26"/>
 </Dropdown>
 
-```sql current_standings
+```sql league_kpis
 select
-    team_name,
-    count(distinct match_id)                          as mp,
-    sum(points_earned)                                as pts,
-    sum(goals_scored) - sum(goals_conceded)           as gd,
-    sum(goals_scored)                                 as gf,
-    standings_type                                    as round_group
+    count(distinct match_id) / 2                                                              as total_matches,
+    sum(goals_scored) / 2                                                                     as total_goals,
+    round(sum(goals_scored)::double / count(distinct match_id), 2)                           as avg_goals_per_match,
+    round(sum(xg) / count(distinct match_id), 2)                                             as avg_xg_per_match,
+    round(100.0 * sum(goals_scored) / nullif(sum(total_shots), 0), 1)                        as avg_shot_conversion,
+    round(sum(yellow_cards)::double / (count(distinct match_id) / 2), 1)                     as avg_yellow_per_match
 from superligaen.mart_match_facts
 where season = '${inputs.season.value}'
   and result in ('Win', 'Draw', 'Loss')
-group by team_name, standings_type
-order by
-    case standings_type
-        when 'Championship Group' then 1
-        when 'Relegation Group'   then 2
-        else                           3
-    end,
-    pts desc, gd desc, gf desc
+```
+
+```sql attack_defense
+with stats as (
+    select
+        team_name,
+        sum(points_earned)                                                                     as points,
+        count(distinct match_id)                                                               as matches,
+        round(sum(goals_scored)::double / count(distinct match_id), 2)                        as goals_pm,
+        round(sum(goals_conceded)::double / count(distinct match_id), 2)                      as conceded_pm,
+        round(sum(xg)::double / count(distinct match_id), 2)                                  as xg_pm
+    from superligaen.mart_match_facts
+    where season = '${inputs.season.value}'
+      and result in ('Win', 'Draw', 'Loss')
+    group by team_name
+),
+avgs as (
+    select avg(goals_pm) as avg_goals, avg(conceded_pm) as avg_conceded from stats
+)
+select
+    s.team_name,
+    s.points,
+    s.matches,
+    s.goals_pm,
+    s.conceded_pm,
+    s.xg_pm,
+    case
+        when s.goals_pm >= a.avg_goals and s.conceded_pm <= a.avg_conceded then 'Dominant'
+        when s.goals_pm >= a.avg_goals and s.conceded_pm  > a.avg_conceded then 'High Scoring'
+        when s.goals_pm  < a.avg_goals and s.conceded_pm <= a.avg_conceded then 'Defensive'
+        else 'Struggling'
+    end as quadrant
+from stats s cross join avgs a
+order by s.points desc
+```
+
+```sql league_avg
+select
+    round(avg(goals_pm), 2)   as avg_goals_pm,
+    round(avg(conceded_pm), 2) as avg_conceded_pm
+from (
+    select
+        round(sum(goals_scored)::double / count(distinct match_id), 2) as goals_pm,
+        round(sum(goals_conceded)::double / count(distinct match_id), 2) as conceded_pm
+    from superligaen.mart_match_facts
+    where season = '${inputs.season.value}'
+      and result in ('Win', 'Draw', 'Loss')
+    group by team_name
+)
 ```
 
 ```sql points_progression
-select match_round_number as round, team_name, cumulative_points, cumulative_gd, cumulative_gf
+select
+    match_round_number as round,
+    team_name,
+    cumulative_points,
+    cumulative_gd,
+    cumulative_gf
 from superligaen.mart_match_facts
 where season = '${inputs.season.value}'
   and result in ('Win', 'Draw', 'Loss')
 order by max(cumulative_points) over (partition by team_name) desc, team_name, match_round_number
 ```
 
-```sql league_kpis
-select
-    sum(goals_scored)                                                                       as total_goals,
-    round(sum(goals_scored)::double / count(distinct match_id), 2)                        as avg_goals_per_match,
-    round(100.0 * sum(goals_scored) / nullif(sum(total_shots), 0), 1)                      as avg_shot_conversion,
-    round(sum(xg), 1)                                                                       as total_xg,
-    sum(yellow_cards)                                                                       as total_yellow_cards,
-    sum(red_cards)                                                                          as total_red_cards
-from superligaen.mart_match_facts
-where season = '${inputs.season.value}'
-  and result in ('Win', 'Draw', 'Loss')
-```
-
-```sql team_season_stats
-select
-    team_name,
-    sum(goals_scored)                                                                       as goals_for,
-    sum(goals_conceded)                                                                     as goals_against,
-    round(sum(xg), 2)                                                                       as total_xg,
-    round(sum(goals_scored) - sum(xg), 2)                                                   as xg_overperformance,
-    round(sum(shots_on_goal)::double / count(distinct match_id), 1)                        as avg_shots_on_goal,
-    round(100.0 * sum(goals_scored) / nullif(sum(total_shots), 0), 1)                      as shot_conversion_pct,
-    round(100.0 * sum(goals_scored) / nullif(sum(shots_on_goal), 0), 1)                    as on_target_conversion_pct,
-    count(distinct match_id) filter (where goals_conceded = 0)                              as clean_sheets,
-    round(sum(saves)::double / count(distinct match_id), 1)                                 as avg_saves,
-    round(sum(goals_conceded)::double / count(distinct match_id), 2)                        as avg_goals_conceded,
-    round(sum(possession_pct)::double / count(distinct match_id), 1)                        as avg_possession,
-    round(100.0 * sum(passes_accurate) / nullif(sum(total_passes), 0), 1)                  as avg_pass_accuracy,
-    round(sum(corner_kicks)::double / count(distinct match_id), 1)                          as avg_corners,
-    round(sum(offsides)::double / count(distinct match_id), 1)                              as avg_offsides,
-    sum(yellow_cards)                                                                       as yellow_cards,
-    sum(red_cards)                                                                          as red_cards,
-    round(sum(fouls)::double / count(distinct match_id), 1)                                 as avg_fouls,
-    round((sum(fouls) + sum(yellow_cards) * 5 + sum(red_cards) * 15)::double / count(distinct match_id), 1) as aggression_index
-from superligaen.mart_match_facts
-where season = '${inputs.season.value}'
-  and result in ('Win', 'Draw', 'Loss')
-group by team_name
-```
-
-```sql attack_rankings
-select
-    team_name,
-    goals_for,
-    total_xg,
-    xg_overperformance,
-    avg_shots_on_goal,
-    shot_conversion_pct,
-    on_target_conversion_pct
-from ${team_season_stats}
-order by goals_for desc
-```
-
-```sql defence_rankings
-select
-    team_name,
-    goals_against,
-    clean_sheets,
-    avg_saves,
-    avg_goals_conceded
-from ${team_season_stats}
-order by clean_sheets desc
-```
-
-```sql possession_rankings
-select
-    team_name,
-    avg_possession,
-    avg_pass_accuracy,
-    avg_corners,
-    avg_offsides
-from ${team_season_stats}
-order by avg_possession desc
-```
-
-```sql discipline_rankings
-select
-    team_name,
-    yellow_cards,
-    red_cards,
-    avg_fouls,
-    aggression_index
-from ${team_season_stats}
-order by aggression_index desc
-```
-
-```sql xg_vs_goals
-select
-    team_name,
-    goals_for,
-    total_xg as expected_goals,
-    xg_overperformance
-from ${team_season_stats}
-order by goals_for desc
+```sql performance_heatmap
+with stats as (
+    select
+        team_name,
+        sum(points_earned)                                                                      as points,
+        round(sum(goals_scored)::double / count(distinct match_id), 2)                         as goals_pm,
+        round(sum(goals_conceded)::double / count(distinct match_id), 2)                       as conceded_pm,
+        round(sum(xg)::double / count(distinct match_id), 2)                                   as xg_pm,
+        round(sum(possession_pct)::double / count(distinct match_id), 1)                       as possession,
+        round(100.0 * sum(passes_accurate) / nullif(sum(total_passes), 0), 1)                  as pass_acc,
+        round((sum(fouls) + sum(yellow_cards)*5 + sum(red_cards)*15)::double / count(distinct match_id), 1) as aggression
+    from superligaen.mart_match_facts
+    where season = '${inputs.season.value}'
+      and result in ('Win', 'Draw', 'Loss')
+    group by team_name
+),
+ranked as (
+    select
+        team_name,
+        points,
+        round(percent_rank() over (order by goals_pm) * 100)           as attack_pct,
+        round(percent_rank() over (order by conceded_pm desc) * 100)   as defense_pct,
+        round(percent_rank() over (order by xg_pm) * 100)              as xg_pct,
+        round(percent_rank() over (order by possession) * 100)         as possession_pct,
+        round(percent_rank() over (order by pass_acc) * 100)           as passing_pct,
+        round(percent_rank() over (order by aggression desc) * 100)    as discipline_pct
+    from stats
+)
+select team_name, points, 'Attack'      as metric, attack_pct      as pct from ranked
+union all
+select team_name, points, 'Defense',    defense_pct    from ranked
+union all
+select team_name, points, 'xG Quality', xg_pct         from ranked
+union all
+select team_name, points, 'Possession', possession_pct from ranked
+union all
+select team_name, points, 'Passing',    passing_pct    from ranked
+union all
+select team_name, points, 'Discipline', discipline_pct from ranked
+order by points desc, team_name
 ```
 
 ## {inputs.season.value} — League Analysis
 
-<div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-6 gap-4 mb-6">
-  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4 text-center"><BigValue data={league_kpis} value=total_goals           title="Goals Scored"       /></div>
-  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4 text-center"><BigValue data={league_kpis} value=avg_goals_per_match   title="Avg Goals / Match"  /></div>
-  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4 text-center"><BigValue data={league_kpis} value=avg_shot_conversion   title="Shot Conversion %"  /></div>
-  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4 text-center"><BigValue data={league_kpis} value=total_xg              title="Total xG"           /></div>
-  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4 text-center"><BigValue data={league_kpis} value=total_yellow_cards    title="Yellow Cards"       /></div>
-  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4 text-center"><BigValue data={league_kpis} value=total_red_cards       title="Red Cards"          /></div>
+<div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-6 gap-3 mb-6">
+  <div class="rounded-xl border border-gray-200 bg-white shadow-sm p-4 text-center"><BigValue data={league_kpis} value=total_matches         title="Matches Played"     /></div>
+  <div class="rounded-xl border border-gray-200 bg-white shadow-sm p-4 text-center"><BigValue data={league_kpis} value=total_goals            title="Goals Scored"       /></div>
+  <div class="rounded-xl border border-gray-200 bg-white shadow-sm p-4 text-center"><BigValue data={league_kpis} value=avg_goals_per_match     title="Avg Goals / Match"  /></div>
+  <div class="rounded-xl border border-gray-200 bg-white shadow-sm p-4 text-center"><BigValue data={league_kpis} value=avg_xg_per_match        title="Avg xG / Match"     /></div>
+  <div class="rounded-xl border border-gray-200 bg-white shadow-sm p-4 text-center"><BigValue data={league_kpis} value=avg_shot_conversion     title="Shot Conversion %"  fmt='0.0"%"' /></div>
+  <div class="rounded-xl border border-gray-200 bg-white shadow-sm p-4 text-center"><BigValue data={league_kpis} value=avg_yellow_per_match    title="Avg YC / Match"     /></div>
 </div>
 
 ---
 
 ## Points Progression
-
-<div class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-6 items-start">
-
-<div>
 
 <LineChart
     data={points_progression}
@@ -165,200 +154,68 @@ order by goals_for desc
     xAxisTitle="Round"
     yAxisTitle="Cumulative Points"
     title="Points Progression by Round"
-    echartsOptions={{tooltip: {formatter: (function() { const lookup = {}; for (const row of points_progression) { if (!lookup[row.round]) lookup[row.round] = {}; lookup[row.round][row.team_name] = {gd: row.cumulative_gd, gf: row.cumulative_gf}; } return function(params) { const round = params[0].value[0]; const roundData = lookup[round] || {}; const sorted = [...params].sort((a, b) => { if (b.value[1] !== a.value[1]) return b.value[1] - a.value[1]; const pa = roundData[a.seriesName] || {gd: 0, gf: 0}; const pb = roundData[b.seriesName] || {gd: 0, gf: 0}; if (pb.gd !== pa.gd) return pb.gd - pa.gd; return pb.gf - pa.gf; }); let out = '<span style="font-weight:600;">Round ' + round + '</span>'; for (const p of sorted) { out += '<br><span style="font-size:11px;">' + p.marker + ' ' + p.seriesName + '</span><span style="float:right;margin-left:10px;font-size:12px;">' + p.value[1] + '</span>'; } return out; }; })()}}}
+    chartAreaHeight=310
     legend=false
-    chartAreaHeight=300
-/>
-
-</div>
-
-<div>
-
-#### League Table
-
-<DataTable data={current_standings} rows=20>
-    <Column id=team_name  title="Team"  />
-    <Column id=round_group title="Group" />
-    <Column id=mp         title="MP"   align=center />
-    <Column id=pts        title="Pts"  align=center contentType=colorscale colorPalette={['white','#3b82f6']} />
-</DataTable>
-
-</div>
-
-</div>
-
----
-
-## Attack — Who's Scoring?
-
-<div class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-6">
-
-<div>
-
-<BarChart
-    data={attack_rankings}
-    x=team_name
-    y=goals_for
-    title="Goals Scored"
-    xAxisTitle="Team"
-    yAxisTitle="Goals"
-    colorPalette={['#22c55e']}
-    swapXY=true
-/>
-
-</div>
-
-<div>
-
-<BarChart
-    data={attack_rankings}
-    x=team_name
-    y=shot_conversion_pct
-    title="Shot Conversion %"
-    xAxisTitle="Team"
-    yAxisTitle="Conversion %"
-    colorPalette={['#f59e0b']}
-    swapXY=true
-/>
-
-</div>
-
-</div>
-
-### Goals vs Expected Goals
-
-<BarChart
-    data={xg_vs_goals}
-    x=team_name
-    y={['goals_for', 'expected_goals']}
-    title="Goals Scored vs xG — Overperformers & Underperformers"
-    xAxisTitle="Team"
-    yAxisTitle="Goals / xG"
-    colorPalette={['#22c55e','#6366f1']}
-    swapXY=true
+    echartsOptions={{tooltip: {formatter: (function() { const lookup = {}; for (const row of points_progression) { if (!lookup[row.round]) lookup[row.round] = {}; lookup[row.round][row.team_name] = {gd: row.cumulative_gd, gf: row.cumulative_gf}; } return function(params) { const round = params[0].value[0]; const roundData = lookup[round] || {}; const sorted = [...params].sort((a, b) => { if (b.value[1] !== a.value[1]) return b.value[1] - a.value[1]; const pa = roundData[a.seriesName] || {gd: 0, gf: 0}; const pb = roundData[b.seriesName] || {gd: 0, gf: 0}; if (pb.gd !== pa.gd) return pb.gd - pa.gd; return pb.gf - pa.gf; }); let out = '<span style="font-weight:600;">Round ' + round + '</span>'; for (const p of sorted) { out += '<br><span style="font-size:11px;">' + p.marker + ' ' + p.seriesName + '</span><span style="float:right;margin-left:10px;font-size:12px;">' + p.value[1] + '</span>'; } return out; }; })()}}}
 />
 
 ---
 
-## Defence — Who's Keeping Clean Sheets?
+## Attack vs Defense — Team Quadrant
 
-<div class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-6">
+<p class="text-sm text-gray-500 mb-2">Goals scored per match (attacking output) vs goals conceded per match (defensive solidity). Dashed lines show league averages. Hover a point to see the team.</p>
 
-<div>
-
-<BarChart
-    data={defence_rankings}
-    x=team_name
-    y=clean_sheets
-    title="Clean Sheets"
-    xAxisTitle="Team"
-    yAxisTitle="Clean Sheets"
-    colorPalette={['#14b8a6']}
-    swapXY=true
+<ScatterPlot
+    data={attack_defense}
+    x=goals_pm
+    y=conceded_pm
+    series=quadrant
+    tooltipTitle=team_name
+    xAxisTitle="Goals Scored / Match  →  more clinical"
+    yAxisTitle="Goals Conceded / Match  ↓  more solid"
+    title="Attack vs Defense — {inputs.season.value}"
+    colorPalette={['#16a34a', '#3b82f6', '#f59e0b', '#dc2626']}
+    chartAreaHeight=360
+    echartsOptions={{
+        yAxis: { inverse: true },
+        series: [
+            {
+                label: { show: true, formatter: '{b}', fontSize: 10, color: '#374151', position: 'right' },
+                markLine: {
+                    silent: true,
+                    symbol: ['none','none'],
+                    lineStyle: { type: 'dashed', color: '#d1d5db', width: 1 },
+                    label: { show: false },
+                    data: [
+                        { xAxis: league_avg[0]?.avg_goals_pm ?? 0 },
+                        { yAxis: league_avg[0]?.avg_conceded_pm ?? 0 }
+                    ]
+                }
+            },
+            { label: { show: true, formatter: '{b}', fontSize: 10, color: '#374151', position: 'right' } },
+            { label: { show: true, formatter: '{b}', fontSize: 10, color: '#374151', position: 'right' } },
+            { label: { show: true, formatter: '{b}', fontSize: 10, color: '#374151', position: 'right' } }
+        ]
+    }}
 />
-
-</div>
-
-<div>
-
-<BarChart
-    data={defence_rankings}
-    x=team_name
-    y=goals_against
-    title="Goals Conceded"
-    xAxisTitle="Team"
-    yAxisTitle="Goals Conceded"
-    colorPalette={['#ef4444']}
-    swapXY=true
-/>
-
-</div>
-
-</div>
 
 ---
 
-## Possession & Passing
+## Team Performance Fingerprints
 
-<div class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-6">
+<p class="text-sm text-gray-500 mb-3">Percentile rank within the league for each dimension. Green = top of the league, red = bottom. Teams sorted by points.</p>
 
-<div>
-
-<BarChart
-    data={possession_rankings}
-    x=team_name
-    y=avg_possession
-    title="Average Possession %"
-    xAxisTitle="Team"
-    yAxisTitle="Possession %"
-    colorPalette={['#8b5cf6']}
-    swapXY=true
+<Heatmap
+    data={performance_heatmap}
+    x=metric
+    y=team_name
+    value=pct
+    title="All Dimensions — Percentile Rankings"
+    colorPalette={['#fca5a5', '#fde68a', '#86efac']}
+    chartAreaHeight=320
+    echartsOptions={{
+        xAxis: { splitArea: { show: true } },
+        yAxis: { splitArea: { show: true } },
+        visualMap: { show: false }
+    }}
 />
-
-</div>
-
-<div>
-
-<BarChart
-    data={possession_rankings}
-    x=team_name
-    y=avg_pass_accuracy
-    title="Average Pass Accuracy %"
-    xAxisTitle="Team"
-    yAxisTitle="Pass Accuracy %"
-    colorPalette={['#0ea5e9']}
-    swapXY=true
-/>
-
-</div>
-
-</div>
-
----
-
-## Discipline
-
-<BarChart
-    data={discipline_rankings}
-    x=team_name
-    y=aggression_index
-    title="Aggression Index — Fouls + Cards Weighted"
-    xAxisTitle="Team"
-    yAxisTitle="Aggression Index"
-    colorPalette={['#f97316']}
-    swapXY=true
-/>
-
-<div class="grid grid-cols-1 md:grid-cols-2 gap-6 mt-6">
-
-<div>
-
-<BarChart
-    data={discipline_rankings}
-    x=team_name
-    y=yellow_cards
-    title="Yellow Cards"
-    xAxisTitle="Team"
-    yAxisTitle="Yellow Cards"
-    colorPalette={['#eab308']}
-    swapXY=true
-/>
-
-</div>
-
-<div>
-
-<BarChart
-    data={discipline_rankings}
-    x=team_name
-    y=red_cards
-    title="Red Cards"
-    xAxisTitle="Team"
-    yAxisTitle="Red Cards"
-    colorPalette={['#dc2626']}
-    swapXY=true
-/>
-
-</div>
-
-</div>

--- a/dashboards/pages/player-analytics.md
+++ b/dashboards/pages/player-analytics.md
@@ -1,0 +1,170 @@
+---
+sidebar: never
+hide_toc: true
+title: Player Analysis
+---
+
+```sql seasons
+select distinct season from superligaen.mart_player_appearances
+order by season desc
+```
+
+```sql positions
+select 'All Positions' as position
+union all
+select distinct player_position
+from superligaen.mart_player_appearances
+where player_position is not null
+  and player_position not in ('Unknown Player Name', 'Not Applicable Player Name')
+order by position
+```
+
+<Dropdown data={seasons} name=season value=season label=season order="season desc">
+    <DropdownOption value="2025/26" valueLabel="2025/26"/>
+</Dropdown>
+
+<Dropdown data={positions} name=position value=position label=position>
+    <DropdownOption value="All Positions" valueLabel="All Positions"/>
+</Dropdown>
+
+```sql player_season_stats
+select
+    player_name,
+    player_position                                                                            as position,
+    team_name                                                                                  as team,
+    count(distinct match_id)                                                                   as matches,
+    sum(minutes_played)                                                                        as minutes,
+    sum(goals_scored)                                                                          as goals,
+    sum(assists)                                                                               as assists,
+    sum(goals_scored) + sum(assists)                                                           as contributions,
+    sum(passes_key)                                                                            as key_passes,
+    sum(tackles_total)                                                                         as tackles,
+    sum(interceptions)                                                                         as interceptions,
+    sum(yellow_cards)                                                                          as yellow_cards,
+    sum(red_cards)                                                                             as red_cards,
+    round(avg(rating) filter (where rating is not null), 2)                                   as avg_rating,
+    round(sum(goals_scored) * 90.0 / nullif(sum(minutes_played), 0), 2)                       as goals_p90,
+    round(sum(assists) * 90.0 / nullif(sum(minutes_played), 0), 2)                            as assists_p90,
+    round((sum(goals_scored) + sum(assists)) * 90.0 / nullif(sum(minutes_played), 0), 2)      as contributions_p90
+from superligaen.mart_player_appearances
+where season = '${inputs.season.value}'
+  and ('${inputs.position.value}' = 'All Positions' or player_position = '${inputs.position.value}')
+group by player_name, player_position, team_name
+having sum(minutes_played) >= 270
+order by contributions desc, avg_rating desc nulls last
+```
+
+```sql league_player_kpis
+select
+    count(distinct player_name)                                                               as total_players,
+    sum(goals_scored)                                                                         as total_goals,
+    sum(assists)                                                                              as total_assists,
+    round(avg(rating) filter (where rating is not null), 2)                                  as avg_rating
+from superligaen.mart_player_appearances
+where season = '${inputs.season.value}'
+  and ('${inputs.position.value}' = 'All Positions' or player_position = '${inputs.position.value}')
+```
+
+```sql top_contributors
+select
+    player_name,
+    team,
+    goals_p90,
+    assists_p90,
+    contributions_p90
+from ${player_season_stats}
+where contributions_p90 > 0
+order by contributions_p90 desc
+limit 20
+```
+
+```sql minutes_rating
+select
+    player_name,
+    team,
+    position,
+    minutes,
+    avg_rating,
+    goals,
+    assists,
+    contributions
+from ${player_season_stats}
+where avg_rating is not null
+order by avg_rating desc
+```
+
+## {inputs.season.value} — Player Analysis
+
+<div class="grid grid-cols-2 md:grid-cols-4 gap-3 mb-6">
+  <div class="rounded-xl border border-gray-200 bg-white shadow-sm p-4 text-center"><BigValue data={league_player_kpis} value=total_players  title="Players"           /></div>
+  <div class="rounded-xl border border-gray-200 bg-white shadow-sm p-4 text-center"><BigValue data={league_player_kpis} value=total_goals    title="Goals Scored"      /></div>
+  <div class="rounded-xl border border-gray-200 bg-white shadow-sm p-4 text-center"><BigValue data={league_player_kpis} value=total_assists   title="Assists"           /></div>
+  <div class="rounded-xl border border-gray-200 bg-white shadow-sm p-4 text-center"><BigValue data={league_player_kpis} value=avg_rating      title="Avg Player Rating" /></div>
+</div>
+
+---
+
+## Top Performers
+
+<p class="text-sm text-gray-500 mb-3">Minimum 270 minutes played. Click a column header to sort.</p>
+
+<DataTable data={player_season_stats} rows=20 search=true>
+    <Column id=player_name    title="Player"       wrap=true />
+    <Column id=position       title="Position"     />
+    <Column id=team           title="Team"         wrap=true />
+    <Column id=matches        title="MP"           align=center />
+    <Column id=minutes        title="Mins"         align=center />
+    <Column id=goals          title="G"            align=center contentType=colorscale colorPalette={['white','#16a34a']} />
+    <Column id=assists        title="A"            align=center contentType=colorscale colorPalette={['white','#3b82f6']} />
+    <Column id=contributions  title="G+A"          align=center contentType=colorscale colorPalette={['white','#8b5cf6']} />
+    <Column id=key_passes     title="KP"           align=center />
+    <Column id=avg_rating     title="Rating"       contentType=colorscale colorPalette={['white','#f59e0b']} />
+    <Column id=goals_p90      title="G/90"         />
+    <Column id=assists_p90    title="A/90"         />
+    <Column id=contributions_p90 title="G+A/90"   contentType=bar colorPalette={['#8b5cf6']} />
+</DataTable>
+
+---
+
+## Goal Contributions per 90 — Top 20
+
+<p class="text-sm text-gray-500 mb-2">Goals and assists per 90 minutes. Filters for players with 270+ minutes to remove small-sample outliers.</p>
+
+<BarChart
+    data={top_contributors}
+    x=player_name
+    y={['goals_p90', 'assists_p90']}
+    labels={['Goals / 90', 'Assists / 90']}
+    title="Goal Contributions per 90 Minutes — Top 20"
+    xAxisTitle="Player"
+    yAxisTitle="Per 90 Minutes"
+    colorPalette={['#16a34a', '#3b82f6']}
+    swapXY=true
+    chartAreaHeight=420
+/>
+
+---
+
+## Minutes Played vs Average Rating
+
+<p class="text-sm text-gray-500 mb-2">Players in the top-right are consistent performers. Top-left are high-impact squad players. Hover for details.</p>
+
+<ScatterPlot
+    data={minutes_rating}
+    x=minutes
+    y=avg_rating
+    series=position
+    tooltipTitle=player_name
+    xAxisTitle="Total Minutes Played"
+    yAxisTitle="Average Match Rating"
+    title="Playing Time vs Performance Rating"
+    chartAreaHeight=360
+    echartsOptions={{
+        series: [
+            { label: { show: false } },
+            { label: { show: false } },
+            { label: { show: false } },
+            { label: { show: false } }
+        ]
+    }}
+/>

--- a/dashboards/pages/referee-analytics.md
+++ b/dashboards/pages/referee-analytics.md
@@ -17,38 +17,38 @@ order by season desc
 ```sql season_stats
 select
     referee_name,
-    count(distinct match_id)                                                                  as matches_managed,
-    sum(yellow_cards)                                                                           as total_yellow_cards,
-    sum(red_cards)                                                                              as total_red_cards,
-    sum(fouls)                                                                                  as total_fouls,
-    round(sum(yellow_cards)::double / count(distinct match_id), 2)                           as avg_yellows_per_match,
-    round(sum(red_cards)::double / count(distinct match_id), 3)                              as avg_reds_per_match,
-    round(sum(fouls)::double / count(distinct match_id), 1)                                  as avg_fouls_per_match,
-    round((sum(yellow_cards) + sum(red_cards) * 3)::double / count(distinct match_id), 2)   as card_severity_index
+    count(distinct match_id)                                                                   as matches,
+    sum(yellow_cards)                                                                          as yellow_cards,
+    sum(red_cards)                                                                             as red_cards,
+    sum(fouls)                                                                                 as total_fouls,
+    round(sum(yellow_cards)::double / count(distinct match_id), 2)                            as avg_yellows_pm,
+    round(sum(red_cards)::double / count(distinct match_id), 3)                               as avg_reds_pm,
+    round(sum(fouls)::double / count(distinct match_id), 1)                                   as avg_fouls_pm,
+    round((sum(yellow_cards) + sum(red_cards) * 3)::double / count(distinct match_id), 2)    as card_severity_index
 from superligaen.mart_match_facts
 where season = '${inputs.season.value}'
   and result in ('Win', 'Draw', 'Loss')
 group by referee_name
-order by matches_managed desc
+order by matches desc
 ```
 
 ```sql season_totals
 select
-    count(distinct referee_name)                          as total_referees,
-    sum(matches_managed)                                  as total_match_slots,
-    round(sum(total_yellow_cards)::double / sum(matches_managed), 2)   as league_avg_yellows,
-    round(sum(total_red_cards)::double   / sum(matches_managed), 3)   as league_avg_reds,
-    round(sum(total_fouls)::double       / sum(matches_managed), 1)   as league_avg_fouls
+    count(distinct referee_name)                                              as total_referees,
+    round(sum(yellow_cards)::double / sum(matches), 2)                       as league_avg_yellows,
+    round(sum(red_cards)::double / sum(matches), 3)                          as league_avg_reds,
+    round(sum(total_fouls)::double / sum(matches), 1)                        as league_avg_fouls,
+    round(sum(card_severity_index * matches) / sum(matches), 2)              as league_avg_severity
 from ${season_stats}
 ```
 
 ## Referee Analysis — {inputs.season.value}
 
-<div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4 mb-6">
-  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4 text-center"><BigValue data={season_totals} value=total_referees      title="Referees Active"    /></div>
-  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4 text-center"><BigValue data={season_totals} value=league_avg_yellows  title="Avg YC / Match"     /></div>
-  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4 text-center"><BigValue data={season_totals} value=league_avg_reds     title="Avg RC / Match"     /></div>
-  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4 text-center"><BigValue data={season_totals} value=league_avg_fouls    title="Avg Fouls / Match"  /></div>
+<div class="grid grid-cols-2 md:grid-cols-4 gap-3 mb-6">
+  <div class="rounded-xl border border-gray-200 bg-white shadow-sm p-4 text-center"><BigValue data={season_totals} value=total_referees      title="Referees Active"    /></div>
+  <div class="rounded-xl border border-gray-200 bg-white shadow-sm p-4 text-center"><BigValue data={season_totals} value=league_avg_yellows  title="Avg YC / Match"     /></div>
+  <div class="rounded-xl border border-gray-200 bg-white shadow-sm p-4 text-center"><BigValue data={season_totals} value=league_avg_reds     title="Avg RC / Match"     /></div>
+  <div class="rounded-xl border border-gray-200 bg-white shadow-sm p-4 text-center"><BigValue data={season_totals} value=league_avg_fouls    title="Avg Fouls / Match"  /></div>
 </div>
 
 ---
@@ -56,45 +56,52 @@ from ${season_stats}
 ## Season Leaderboard
 
 <DataTable data={season_stats} rows=20>
-    <Column id=referee_name         title="Referee"             wrap=true />
-    <Column id=matches_managed      title="Games"               contentType=colorscale colorPalette={['white','#3b82f6']} align=center />
-    <Column id=total_yellow_cards   title="Yellow Cards"        contentType=colorscale colorPalette={['white','#eab308']} align=center />
-    <Column id=total_red_cards      title="Red Cards"           contentType=colorscale colorPalette={['white','#ef4444']} align=center />
-    <Column id=total_fouls          title="Total Fouls"         contentType=colorscale colorPalette={['white','#f97316']} align=center />
-    <Column id=avg_yellows_per_match title="Avg YC / Match"     contentType=colorscale colorPalette={['white','#eab308']} />
-    <Column id=avg_reds_per_match    title="Avg RC / Match"     contentType=colorscale colorPalette={['white','#ef4444']} />
-    <Column id=avg_fouls_per_match   title="Avg Fouls / Match"  contentType=bar        colorPalette={['#f97316']} />
-    <Column id=card_severity_index   title="Card Severity"      contentType=colorscale colorPalette={['white','#dc2626']} />
+    <Column id=referee_name         title="Referee"            wrap=true />
+    <Column id=matches              title="Games"              contentType=colorscale colorPalette={['white','#3b82f6']} align=center />
+    <Column id=yellow_cards         title="Yellow Cards"       contentType=colorscale colorPalette={['white','#eab308']} align=center />
+    <Column id=red_cards            title="Red Cards"          contentType=colorscale colorPalette={['white','#ef4444']} align=center />
+    <Column id=avg_yellows_pm       title="Avg YC / Match"     contentType=colorscale colorPalette={['white','#eab308']} />
+    <Column id=avg_reds_pm          title="Avg RC / Match"     contentType=colorscale colorPalette={['white','#ef4444']} />
+    <Column id=avg_fouls_pm         title="Fouls / Match"      contentType=bar        colorPalette={['#f97316']} />
+    <Column id=card_severity_index  title="Card Severity"      contentType=colorscale colorPalette={['white','#dc2626']} />
 </DataTable>
 
 ---
 
-## Cards per Match — All Referees
+## Strictness Analysis — Fouls Called vs Card Rate
 
-<BarChart
+<p class="text-sm text-gray-500 mb-2">Referees in the top-right call many fouls <em>and</em> issue many cards — strict across the board. Bottom-right call many fouls but few cards (lenient). Hover for the referee's name.</p>
+
+<ScatterPlot
     data={season_stats}
-    x=referee_name
-    y={['avg_yellows_per_match', 'avg_reds_per_match']}
-    title="Average Cards per Match — {inputs.season.value}"
-    xAxisTitle="Referee"
-    yAxisTitle="Cards per Match"
-    colorPalette={['#eab308','#ef4444']}
-    swapXY=true
-/>
-
----
-
-## Fouls Called per Match
-
-<BarChart
-    data={season_stats}
-    x=referee_name
-    y=avg_fouls_per_match
-    title="Average Fouls per Match — {inputs.season.value}"
-    xAxisTitle="Referee"
-    yAxisTitle="Fouls per Match"
-    colorPalette={['#f97316']}
-    swapXY=true
+    x=avg_fouls_pm
+    y=card_severity_index
+    tooltipTitle=referee_name
+    xAxisTitle="Fouls Called per Match"
+    yAxisTitle="Card Severity Index (YC×1 + RC×3 per match)"
+    title="Referee Strictness — {inputs.season.value}"
+    chartAreaHeight=320
+    echartsOptions={{
+        series: [{
+            label: {
+                show: true,
+                formatter: '{b}',
+                fontSize: 10,
+                color: '#374151',
+                position: 'right'
+            },
+            markLine: {
+                silent: true,
+                symbol: ['none','none'],
+                lineStyle: { type: 'dashed', color: '#d1d5db', width: 1 },
+                label: { show: false },
+                data: [
+                    { xAxis: season_totals[0]?.league_avg_fouls ?? 0 },
+                    { yAxis: season_totals[0]?.league_avg_severity ?? 0 }
+                ]
+            }
+        }]
+    }}
 />
 
 ---
@@ -103,13 +110,18 @@ from ${season_stats}
 
 <Dropdown data={season_stats} name=referee value=referee_name label=referee_name />
 
+```sql referee_kpis
+select * from ${season_stats}
+where referee_name = '${inputs.referee.value}'
+```
+
 ```sql referee_team_exposure
 select
     team_name,
-    count(distinct match_id)  as matches
+    count(distinct match_id) as matches
 from superligaen.mart_match_facts
-where referee_name = '${inputs.referee.value}'
-  and season = '${inputs.season.value}'
+where referee_name  = '${inputs.referee.value}'
+  and season        = '${inputs.season.value}'
   and result in ('Win', 'Draw', 'Loss')
 group by team_name
 order by matches desc
@@ -118,54 +130,48 @@ order by matches desc
 ```sql referee_match_log
 select
     match_date,
-    match_round_name                    as round,
+    match_round_name                as round,
     match_name,
     score,
-    sum(yellow_cards)                   as yellow_cards,
-    sum(red_cards)                      as red_cards,
-    sum(fouls)                          as total_fouls
+    sum(yellow_cards)               as yellow_cards,
+    sum(red_cards)                  as red_cards,
+    sum(fouls)                      as total_fouls
 from superligaen.mart_match_facts
-where referee_name = '${inputs.referee.value}'
-  and season = '${inputs.season.value}'
+where referee_name  = '${inputs.referee.value}'
+  and season        = '${inputs.season.value}'
   and result in ('Win', 'Draw', 'Loss')
 group by match_date, match_round_name, match_name, score
 order by match_date desc
 ```
 
-```sql referee_kpis
-select * from ${season_stats}
-where referee_name = '${inputs.referee.value}'
-```
-
-<div class="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6 mt-4">
-  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4 text-center"><BigValue data={referee_kpis} value=matches_managed       title="Games"              /></div>
-  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4 text-center"><BigValue data={referee_kpis} value=total_yellow_cards    title="Yellow Cards"       /></div>
-  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4 text-center"><BigValue data={referee_kpis} value=total_red_cards       title="Red Cards"          /></div>
-  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4 text-center"><BigValue data={referee_kpis} value=avg_fouls_per_match   title="Avg Fouls / Match"  /></div>
+<div class="grid grid-cols-2 md:grid-cols-4 gap-3 mb-6 mt-4">
+  <div class="rounded-xl border border-gray-200 bg-white shadow-sm p-4 text-center"><BigValue data={referee_kpis} value=matches           title="Games"              /></div>
+  <div class="rounded-xl border border-gray-200 bg-white shadow-sm p-4 text-center"><BigValue data={referee_kpis} value=yellow_cards      title="Yellow Cards"       /></div>
+  <div class="rounded-xl border border-gray-200 bg-white shadow-sm p-4 text-center"><BigValue data={referee_kpis} value=red_cards         title="Red Cards"          /></div>
+  <div class="rounded-xl border border-gray-200 bg-white shadow-sm p-4 text-center"><BigValue data={referee_kpis} value=avg_fouls_pm      title="Avg Fouls / Match"  /></div>
 </div>
 
 <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-6">
 
 <div>
 
-### Team Exposure
+#### Team Exposure
 
 <BarChart
     data={referee_team_exposure}
     x=team_name
     y=matches
     title="Matches per Team — {inputs.referee.value}"
-    xAxisTitle="Team"
-    yAxisTitle="Matches"
     colorPalette={['#6366f1']}
     swapXY=true
+    chartAreaHeight=280
 />
 
 </div>
 
 <div>
 
-### Match Log
+#### Match Log
 
 <DataTable data={referee_match_log} rows=10>
     <Column id=match_date    title="Date"   />

--- a/dashboards/pages/team-analytics.md
+++ b/dashboards/pages/team-analytics.md
@@ -26,87 +26,133 @@ order by team_name
 
 ```sql kpis
 select
-    sum(points_earned)                                                                         as total_points,
+    sum(points_earned)                                                                          as points,
     count(distinct match_id) filter (where result = 'Win')                                     as wins,
     count(distinct match_id) filter (where result = 'Draw')                                    as draws,
     count(distinct match_id) filter (where result = 'Loss')                                    as losses,
+    count(distinct match_id)                                                                    as matches,
     sum(goals_scored)                                                                          as goals_for,
     sum(goals_conceded)                                                                        as goals_against,
     sum(goals_scored) - sum(goals_conceded)                                                    as goal_difference,
     round(100.0 * count(distinct match_id) filter (where result = 'Win') / count(distinct match_id), 1) as win_rate_pct,
+    round(sum(xg), 2)                                                                          as total_xg,
+    round(sum(goals_scored) - sum(xg), 2)                                                      as xg_overperformance,
     round(sum(possession_pct)::double / count(distinct match_id), 1)                           as avg_possession,
     round(100.0 * sum(passes_accurate) / nullif(sum(total_passes), 0), 1)                      as avg_pass_accuracy,
     round(100.0 * sum(goals_scored) / nullif(sum(total_shots), 0), 1)                          as shot_conversion_pct,
-    round(100.0 * sum(goals_scored) / nullif(sum(shots_on_goal), 0), 1)                        as on_target_conversion_pct,
-    round(sum(xg), 2)                                                                          as total_xg,
-    round(sum(goals_scored) - sum(xg), 2)                                                      as xg_overperformance,
-    round((sum(fouls) + sum(yellow_cards) * 5 + sum(red_cards) * 15)::double / count(distinct match_id), 1) as aggression_index,
-    round(sum(saves)::double / count(distinct match_id), 1)                                    as avg_saves,
-    round(sum(goals_conceded)::double / count(distinct match_id), 2)                           as avg_goals_conceded,
-    round(sum(xg) / count(distinct match_id), 2)                                               as avg_xg_per_match,
-    round(sum(shots_on_goal)::double / count(distinct match_id), 1)                            as avg_shots_on_goal,
     round(sum(goals_scored)::double / count(distinct match_id), 2)                             as avg_goals_scored,
-    round(sum(corner_kicks)::double / count(distinct match_id), 1)                             as avg_corners,
-    round(sum(offsides)::double / count(distinct match_id), 1)                                 as avg_offsides,
+    round(sum(goals_conceded)::double / count(distinct match_id), 2)                           as avg_goals_conceded,
+    round(sum(shots_on_goal)::double / count(distinct match_id), 1)                            as avg_shots_on_goal,
+    round(sum(saves)::double / count(distinct match_id), 1)                                    as avg_saves,
+    round(sum(xg) / count(distinct match_id), 2)                                               as avg_xg_per_match,
     round(sum(fouls)::double / count(distinct match_id), 1)                                    as avg_fouls,
     sum(yellow_cards)                                                                          as yellow_cards,
     sum(red_cards)                                                                             as red_cards,
-    sum(shots_insidebox)                                                                       as shots_insidebox,
-    sum(shots_outsidebox)                                                                      as shots_outsidebox
+    round((sum(fouls) + sum(yellow_cards)*5 + sum(red_cards)*15)::double / count(distinct match_id), 1) as aggression_index,
+    count(distinct match_id) filter (where goals_conceded = 0)                                 as clean_sheets
 from superligaen.mart_match_facts
-where team_name = '${inputs.team.value}'
-  and season = '${inputs.season.value}'
+where team_name   = '${inputs.team.value}'
+  and season      = '${inputs.season.value}'
   and result in ('Win', 'Draw', 'Loss')
 ```
 
-```sql form
+```sql team_fingerprint
+with all_stats as (
+    select
+        team_name,
+        round(sum(goals_scored)::double / count(distinct match_id), 2)                         as goals_pm,
+        round(sum(goals_conceded)::double / count(distinct match_id), 2)                       as conceded_pm,
+        round(sum(xg)::double / count(distinct match_id), 2)                                   as xg_pm,
+        round(sum(possession_pct)::double / count(distinct match_id), 1)                       as possession,
+        round(100.0 * sum(passes_accurate) / nullif(sum(total_passes), 0), 1)                  as pass_acc,
+        round((sum(fouls) + sum(yellow_cards)*5 + sum(red_cards)*15)::double / count(distinct match_id), 1) as aggression
+    from superligaen.mart_match_facts
+    where season = '${inputs.season.value}'
+      and result in ('Win', 'Draw', 'Loss')
+    group by team_name
+),
+ranked as (
+    select
+        team_name,
+        round(percent_rank() over (order by goals_pm) * 100)           as attack,
+        round(percent_rank() over (order by conceded_pm desc) * 100)   as defense,
+        round(percent_rank() over (order by xg_pm) * 100)              as xg_quality,
+        round(percent_rank() over (order by possession) * 100)         as possession,
+        round(percent_rank() over (order by pass_acc) * 100)           as passing,
+        round(percent_rank() over (order by aggression desc) * 100)    as discipline
+    from all_stats
+)
+select * from ranked where team_name = '${inputs.team.value}'
+```
+
+```sql team_radar_data
+select 'Attack'      as dimension, attack      as value from ${team_fingerprint}
+union all
+select 'Defense',      defense      from ${team_fingerprint}
+union all
+select 'xG Quality',   xg_quality   from ${team_fingerprint}
+union all
+select 'Possession',   possession   from ${team_fingerprint}
+union all
+select 'Passing',      passing      from ${team_fingerprint}
+union all
+select 'Discipline',   discipline   from ${team_fingerprint}
+```
+
+```sql rolling_form
 select
+    match_round_number                                                                          as round,
     match_date,
-    match_round_name             as round,
-    match_round_number,
-    opponent_team_name           as opponent,
-    team_side                    as side,
-    goals_scored                 as gf,
-    goals_conceded               as ga,
+    opponent_team_name                                                                         as opponent,
     result,
+    goals_scored                                                                               as gf,
+    goals_conceded                                                                             as ga,
     xg,
-    shots_on_goal,
-    possession_pct               as possession,
-    pass_accuracy,
-    fouls,
-    corner_kicks,
-    offsides,
-    yellow_cards,
-    red_cards,
-    saves
+    round(avg(goals_scored::double) over (order by match_round_number rows between 4 preceding and current row), 2) as rolling_gf,
+    round(avg(goals_conceded::double) over (order by match_round_number rows between 4 preceding and current row), 2) as rolling_ga,
+    round(avg(xg::double) over (order by match_round_number rows between 4 preceding and current row), 2) as rolling_xg
 from superligaen.mart_match_facts
 where team_name = '${inputs.team.value}'
-  and season = '${inputs.season.value}'
+  and season    = '${inputs.season.value}'
   and result in ('Win', 'Draw', 'Loss')
-order by match_date asc
+order by match_round_number
+```
+
+```sql xg_scatter
+select
+    match_round_number                                                                         as round,
+    opponent_team_name                                                                         as opponent,
+    xg,
+    goals_scored                                                                               as goals,
+    result,
+    case result when 'Win' then 1 when 'Draw' then 2 else 3 end                               as result_order
+from superligaen.mart_match_facts
+where team_name = '${inputs.team.value}'
+  and season    = '${inputs.season.value}'
+  and result in ('Win', 'Draw', 'Loss')
+order by result_order, match_round_number
 ```
 
 ```sql home_away
 select
     team_side                                                                                  as side,
     count(distinct match_id)                                                                   as matches,
-    count(distinct match_id) filter (where result = 'Win')                                     as wins,
-    count(distinct match_id) filter (where result = 'Draw')                                    as draws,
-    count(distinct match_id) filter (where result = 'Loss')                                    as losses,
-    sum(goals_scored)                                                                          as goals_for,
-    sum(goals_conceded)                                                                        as goals_against,
-    round(100.0 * count(distinct match_id) filter (where result = 'Win') / count(distinct match_id), 1) as win_rate_pct,
-    round(sum(possession_pct)::double / count(distinct match_id), 1)                           as avg_possession,
-    round(sum(shots_on_goal)::double / count(distinct match_id), 1)                            as avg_shots_on_goal,
-    round(sum(xg) / count(distinct match_id), 2)                                               as avg_xg,
-    round(100.0 * sum(goals_scored) / nullif(sum(total_shots), 0), 1)                         as shot_conversion_pct,
-    round(sum(fouls)::double / count(distinct match_id), 1)                                    as avg_fouls,
-    sum(yellow_cards)                                                                          as yellow_cards,
-    sum(red_cards)                                                                             as red_cards,
-    round(sum(saves)::double / count(distinct match_id), 1)                                    as avg_saves
+    count(distinct match_id) filter (where result = 'Win')                                    as wins,
+    count(distinct match_id) filter (where result = 'Draw')                                   as draws,
+    count(distinct match_id) filter (where result = 'Loss')                                   as losses,
+    sum(goals_scored)                                                                          as gf,
+    sum(goals_conceded)                                                                        as ga,
+    round(100.0 * count(distinct match_id) filter (where result = 'Win') / count(distinct match_id), 1) as win_pct,
+    round(sum(possession_pct)::double / count(distinct match_id), 1)                          as avg_possession,
+    round(sum(shots_on_goal)::double / count(distinct match_id), 1)                           as avg_sog,
+    round(sum(xg) / count(distinct match_id), 2)                                              as avg_xg,
+    round(100.0 * sum(goals_scored) / nullif(sum(total_shots), 0), 1)                        as shot_conv_pct,
+    sum(yellow_cards)                                                                         as yc,
+    sum(red_cards)                                                                            as rc,
+    round(sum(saves)::double / count(distinct match_id), 1)                                  as avg_saves
 from superligaen.mart_match_facts
 where team_name = '${inputs.team.value}'
-  and season = '${inputs.season.value}'
+  and season    = '${inputs.season.value}'
   and result in ('Win', 'Draw', 'Loss')
 group by team_side
 order by team_side desc
@@ -114,278 +160,112 @@ order by team_side desc
 
 ---
 
-## {inputs.team.value} — Season Overview
+## {inputs.team.value} — {inputs.season.value}
 
-<div class="grid grid-cols-2 md:grid-cols-4 gap-4 mb-4">
-  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4 text-center"><BigValue data={kpis} value=total_points     title="Points"          /></div>
-  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4 text-center"><BigValue data={kpis} value=wins             title="Wins"            /></div>
-  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4 text-center"><BigValue data={kpis} value=draws            title="Draws"           /></div>
-  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4 text-center"><BigValue data={kpis} value=losses           title="Losses"          /></div>
-  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4 text-center"><BigValue data={kpis} value=goals_for        title="Goals Scored"    /></div>
-  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4 text-center"><BigValue data={kpis} value=goals_against    title="Goals Conceded"  /></div>
-  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4 text-center"><BigValue data={kpis} value=goal_difference  title="Goal Difference" /></div>
-  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4 text-center"><BigValue data={kpis} value=win_rate_pct     title="Win Rate"        fmt='0.0"%"' /></div>
-</div>
-
-<div class="grid grid-cols-2 md:grid-cols-4 gap-4 mb-4">
-  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4 text-center"><BigValue data={kpis} value=avg_possession       title="Avg Possession"    fmt='0.0"%"' /></div>
-  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4 text-center"><BigValue data={kpis} value=avg_pass_accuracy    title="Pass Accuracy"     fmt='0.0"%"' /></div>
-  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4 text-center"><BigValue data={kpis} value=shot_conversion_pct  title="Shot Conversion"   fmt='0.0"%"' /></div>
-  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4 text-center"><BigValue data={kpis} value=on_target_conversion_pct title="On-Target Conv." fmt='0.0"%"' /></div>
-  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4 text-center"><BigValue data={kpis} value=total_xg             title="Total xG"          /></div>
-  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4 text-center"><BigValue data={kpis} value=xg_overperformance   title="xG Overperformance" /></div>
-  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4 text-center"><BigValue data={kpis} value=aggression_index     title="Aggression Index"  /></div>
-  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4 text-center"><BigValue data={kpis} value=avg_saves            title="Avg Saves/Match"   /></div>
+<div class="grid grid-cols-2 md:grid-cols-4 gap-3 mb-6">
+  <div class="rounded-xl border border-gray-200 bg-white shadow-sm p-4 text-center"><BigValue data={kpis} value=points          title="Points"          /></div>
+  <div class="rounded-xl border border-gray-200 bg-white shadow-sm p-4 text-center"><BigValue data={kpis} value=win_rate_pct    title="Win Rate"        fmt='0.0"%"' /></div>
+  <div class="rounded-xl border border-gray-200 bg-white shadow-sm p-4 text-center"><BigValue data={kpis} value=goals_for       title="Goals Scored"    /></div>
+  <div class="rounded-xl border border-gray-200 bg-white shadow-sm p-4 text-center"><BigValue data={kpis} value=goals_against   title="Goals Conceded"  /></div>
 </div>
 
 ---
 
-## Points Progression
+## Performance Fingerprint
 
-```sql points_trend
-select
-    match_date,
-    match_round_name               as round,
-    match_round_number,
-    cumulative_points,
-    result,
-    opponent_team_name             as opponent,
-    goals_scored                   as gf,
-    goals_conceded                 as ga
-from superligaen.mart_match_facts
-where team_name = '${inputs.team.value}'
-  and season = '${inputs.season.value}'
-  and result in ('Win', 'Draw', 'Loss')
-order by match_date asc
-```
+<p class="text-sm text-gray-500 mb-1">Percentile rank vs all teams in {inputs.season.value}. The dashed inner polygon shows the league average (50th percentile) on every dimension.</p>
+
+<div class="max-w-lg mx-auto">
+  <RadarChart data={team_radar_data} name={inputs.team.value} color="#236aa4" height=400 />
+</div>
+
+---
+
+## Form — Rolling 5-Match Average
+
+<p class="text-sm text-gray-500 mb-2">Smoothed over a 5-match window to separate genuine runs of form from single-match outliers.</p>
 
 <LineChart
-    data={points_trend}
-    x=match_round_number
-    y=cumulative_points
-    title="Cumulative Points over Time"
+    data={rolling_form}
+    x=round
+    y={['rolling_gf', 'rolling_ga', 'rolling_xg']}
+    labels={['Goals Scored (5-match avg)', 'Goals Conceded (5-match avg)', 'xG (5-match avg)']}
     xAxisTitle="Round"
-    yAxisTitle="Points"
-    lineColor="#3b82f6"
+    yAxisTitle="Goals / xG"
+    title="Rolling Form — {inputs.team.value}"
+    colorPalette={['#16a34a', '#dc2626', '#3b82f6']}
+    chartAreaHeight=280
 />
 
 ---
 
-## Form Guide
+## Clinical Finishing — xG vs Actual Goals
 
-```sql recent_form
-select
-    match_date,
-    match_round_name               as round,
-    opponent_team_name             as opponent,
-    team_side                      as side,
-    goals_scored                   as gf,
-    goals_conceded                 as ga,
-    result,
-    xg,
-    shots_on_goal,
-    possession_pct                 as possession,
-    fouls,
-    yellow_cards,
-    red_cards
-from superligaen.mart_match_facts
-where team_name = '${inputs.team.value}'
-  and season = '${inputs.season.value}'
-  and result in ('Win', 'Draw', 'Loss')
-order by match_date desc
-limit 10
-```
+<p class="text-sm text-gray-500 mb-2">Points above the dashed diagonal overperformed their xG; points below underperformed. Hover for match details.</p>
 
-<DataTable data={recent_form} rows=10>
-    <Column id=match_date   title="Date"       />
-    <Column id=round        title="Round"      />
-    <Column id=opponent     title="Opponent"   />
-    <Column id=side         title="Side"       />
-    <Column id=gf           title="GF"         />
-    <Column id=ga           title="GA"         />
-    <Column id=result       title="Result"     />
-    <Column id=xg           title="xG"         />
-    <Column id=shots_on_goal title="SoG"       />
-    <Column id=possession   title="Poss %"     fmt='0.0"%"' />
-    <Column id=fouls        title="Fouls"      />
-    <Column id=yellow_cards title="YC"         />
-    <Column id=red_cards    title="RC"         />
-</DataTable>
+<ScatterPlot
+    data={xg_scatter}
+    x=xg
+    y=goals
+    series=result
+    tooltipTitle=opponent
+    xAxisTitle="Expected Goals (xG)"
+    yAxisTitle="Goals Scored"
+    title="xG vs Actual Goals — {inputs.team.value}"
+    colorPalette={['#16a34a', '#f59e0b', '#dc2626']}
+    chartAreaHeight=300
+    echartsOptions={{
+        series: [
+            {
+                markLine: {
+                    silent: true,
+                    symbol: ['none', 'none'],
+                    lineStyle: { type: 'dashed', color: '#9ca3af', width: 1.5 },
+                    label: { show: true, formatter: 'xG = Goals', position: 'insideEndBottom', color: '#9ca3af', fontSize: 10 },
+                    data: [[ { coord: [0, 0] }, { coord: [5, 5] } ]]
+                }
+            }
+        ]
+    }}
+/>
 
 ---
 
-## Attack
+## Season Summary
 
-<div class="grid grid-cols-2 md:grid-cols-4 gap-4 mb-4">
-  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4 text-center"><BigValue data={kpis} value=avg_xg_per_match      title="xG per Match"        /></div>
-  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4 text-center"><BigValue data={kpis} value=avg_shots_on_goal     title="Shots on Goal/Match" /></div>
-  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4 text-center"><BigValue data={kpis} value=avg_goals_scored      title="Goals Scored/Match"  /></div>
-  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4 text-center"><BigValue data={kpis} value=shot_conversion_pct   title="Shot Conversion %"   fmt='0.0"%"' /></div>
+<div class="grid grid-cols-2 md:grid-cols-4 gap-3 mb-4">
+  <div class="rounded-xl border border-gray-200 bg-white shadow-sm p-4 text-center"><BigValue data={kpis} value=wins               title="Wins"              /></div>
+  <div class="rounded-xl border border-gray-200 bg-white shadow-sm p-4 text-center"><BigValue data={kpis} value=draws              title="Draws"             /></div>
+  <div class="rounded-xl border border-gray-200 bg-white shadow-sm p-4 text-center"><BigValue data={kpis} value=losses             title="Losses"            /></div>
+  <div class="rounded-xl border border-gray-200 bg-white shadow-sm p-4 text-center"><BigValue data={kpis} value=clean_sheets       title="Clean Sheets"      /></div>
+  <div class="rounded-xl border border-gray-200 bg-white shadow-sm p-4 text-center"><BigValue data={kpis} value=avg_xg_per_match   title="xG / Match"        /></div>
+  <div class="rounded-xl border border-gray-200 bg-white shadow-sm p-4 text-center"><BigValue data={kpis} value=xg_overperformance title="xG Overperformance" /></div>
+  <div class="rounded-xl border border-gray-200 bg-white shadow-sm p-4 text-center"><BigValue data={kpis} value=avg_possession     title="Avg Possession %"  fmt='0.0"%"' /></div>
+  <div class="rounded-xl border border-gray-200 bg-white shadow-sm p-4 text-center"><BigValue data={kpis} value=shot_conversion_pct title="Shot Conversion %" fmt='0.0"%"' /></div>
+  <div class="rounded-xl border border-gray-200 bg-white shadow-sm p-4 text-center"><BigValue data={kpis} value=avg_shots_on_goal  title="Shots on Goal / Match" /></div>
+  <div class="rounded-xl border border-gray-200 bg-white shadow-sm p-4 text-center"><BigValue data={kpis} value=avg_saves          title="Saves / Match"     /></div>
+  <div class="rounded-xl border border-gray-200 bg-white shadow-sm p-4 text-center"><BigValue data={kpis} value=avg_fouls          title="Fouls / Match"     /></div>
+  <div class="rounded-xl border border-gray-200 bg-white shadow-sm p-4 text-center"><BigValue data={kpis} value=aggression_index   title="Aggression Index"  /></div>
 </div>
-
-<BarChart
-    data={form}
-    x=match_round_number
-    y=gf
-    title="Goals Scored per Match"
-    xAxisTitle="Round"
-    yAxisTitle="Goals"
-    colorPalette={['#22c55e']}
-/>
-
-<BarChart
-    data={form}
-    x=match_round_number
-    y=xg
-    title="xG per Match"
-    xAxisTitle="Round"
-    yAxisTitle="xG"
-    colorPalette={['#3b82f6']}
-/>
-
-```sql shot_location
-select 'Inside Box' as location, shots_insidebox as shots from ${kpis}
-union all
-select 'Outside Box', shots_outsidebox from ${kpis}
-```
-
-<BarChart
-    data={shot_location}
-    x=location
-    y=shots
-    title="Shot Locations — Season Total"
-    xAxisTitle="Location"
-    yAxisTitle="Shots"
-    colorPalette={['#f59e0b', '#ef4444']}
-    swapXY=true
-/>
-
----
-
-## Defence
-
-<div class="grid grid-cols-2 gap-4 mb-4">
-  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4 text-center"><BigValue data={kpis} value=avg_goals_conceded title="Goals Conceded/Match" /></div>
-  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4 text-center"><BigValue data={kpis} value=avg_saves          title="Saves/Match"          /></div>
-</div>
-
-<BarChart
-    data={form}
-    x=match_round_number
-    y=ga
-    title="Goals Conceded per Match"
-    xAxisTitle="Round"
-    yAxisTitle="Goals Conceded"
-    colorPalette={['#ef4444']}
-/>
-
-<BarChart
-    data={form}
-    x=match_round_number
-    y=saves
-    title="Goalkeeper Saves per Match"
-    xAxisTitle="Round"
-    yAxisTitle="Saves"
-    colorPalette={['#6366f1']}
-/>
-
----
-
-## Passing & Possession
-
-<div class="grid grid-cols-2 md:grid-cols-4 gap-4 mb-4">
-  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4 text-center"><BigValue data={kpis} value=avg_possession     title="Avg Possession %"  fmt='0.0"%"' /></div>
-  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4 text-center"><BigValue data={kpis} value=avg_pass_accuracy  title="Avg Pass Accuracy" fmt='0.0"%"' /></div>
-  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4 text-center"><BigValue data={kpis} value=avg_corners        title="Corners/Match"               /></div>
-  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4 text-center"><BigValue data={kpis} value=avg_offsides       title="Offsides/Match"              /></div>
-</div>
-
-<BarChart
-    data={form}
-    x=match_round_number
-    y=possession
-    title="Possession % per Match"
-    xAxisTitle="Round"
-    yAxisTitle="Possession %"
-    colorPalette={['#14b8a6']}
-/>
-
-<BarChart
-    data={form}
-    x=match_round_number
-    y=pass_accuracy
-    title="Pass Accuracy % per Match"
-    xAxisTitle="Round"
-    yAxisTitle="Pass Accuracy %"
-    colorPalette={['#8b5cf6']}
-/>
-
----
-
-## Discipline
-
-<div class="grid grid-cols-2 md:grid-cols-4 gap-4 mb-4">
-  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4 text-center"><BigValue data={kpis} value=avg_fouls        title="Fouls/Match"      /></div>
-  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4 text-center"><BigValue data={kpis} value=yellow_cards     title="Yellow Cards"     /></div>
-  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4 text-center"><BigValue data={kpis} value=red_cards        title="Red Cards"        /></div>
-  <div class="rounded-xl border border-gray-300 bg-gray-100 p-4 text-center"><BigValue data={kpis} value=aggression_index title="Aggression Index" /></div>
-</div>
-
-<BarChart
-    data={form}
-    x=match_round_number
-    y=fouls
-    title="Fouls per Match"
-    xAxisTitle="Round"
-    yAxisTitle="Fouls"
-    colorPalette={['#f97316']}
-/>
-
-<BarChart
-    data={form}
-    x=match_round_number
-    y={['yellow_cards', 'red_cards']}
-    title="Cards per Match"
-    xAxisTitle="Round"
-    yAxisTitle="Cards"
-    colorPalette={['#eab308', '#dc2626']}
-/>
 
 ---
 
 ## Home vs Away
 
-<div class="overflow-x-auto">
 <DataTable data={home_away}>
-    <Column id=side               title="Side"             />
-    <Column id=matches            title="MP"               />
-    <Column id=wins               title="W"                />
-    <Column id=draws              title="D"                />
-    <Column id=losses             title="L"                />
-    <Column id=goals_for          title="GF"               />
-    <Column id=goals_against      title="GA"               />
-    <Column id=win_rate_pct       title="Win %"            fmt='0.0"%"' />
-    <Column id=avg_possession     title="Avg Poss %"       fmt='0.0"%"' />
-    <Column id=avg_shots_on_goal  title="Avg SoG"          />
-    <Column id=avg_xg             title="Avg xG"           />
-    <Column id=shot_conversion_pct title="Shot Conv %"     fmt='0.0"%"' />
-    <Column id=avg_fouls          title="Avg Fouls"        />
-    <Column id=yellow_cards       title="YC"               />
-    <Column id=red_cards          title="RC"               />
-    <Column id=avg_saves          title="Avg Saves"        />
+    <Column id=side        title="Side"         />
+    <Column id=matches     title="MP"    align=center />
+    <Column id=wins        title="W"     align=center />
+    <Column id=draws       title="D"     align=center />
+    <Column id=losses      title="L"     align=center />
+    <Column id=gf          title="GF"    align=center />
+    <Column id=ga          title="GA"    align=center />
+    <Column id=win_pct     title="Win %" align=center fmt='0.0"%"' contentType=colorscale colorPalette={['white','#3b82f6']} />
+    <Column id=avg_possession title="Poss %"  fmt='0.0"%"' />
+    <Column id=avg_sog     title="SoG"   />
+    <Column id=avg_xg      title="xG"    />
+    <Column id=shot_conv_pct title="Conv %" fmt='0.0"%"' />
+    <Column id=yc          title="YC"    align=center />
+    <Column id=rc          title="RC"    align=center />
+    <Column id=avg_saves   title="Saves" />
 </DataTable>
-</div>
-
-```sql home_away_chart
-select side, avg_shots_on_goal as "Shots on Goal", avg_xg as "xG", avg_possession / 10 as "Possession / 10", win_rate_pct / 10 as "Win Rate / 10"
-from ${home_away}
-```
-
-<BarChart
-    data={home_away_chart}
-    x=side
-    y={['Shots on Goal', 'xG', 'Possession / 10', 'Win Rate / 10']}
-    title="Home vs Away — Key Metrics"
-    xAxisTitle="Side"
-    swapXY=false
-/>

--- a/dashboards/sources/superligaen/mart_player_appearances.sql
+++ b/dashboards/sources/superligaen/mart_player_appearances.sql
@@ -1,0 +1,46 @@
+SELECT
+    d.season,
+    d.date                              AS match_date,
+    m.match_round_number,
+    m.match_round_name,
+    m.match_id,
+    p.player_id,
+    p.player_name,
+    p.player_position,
+    p.player_nationality,
+    t.team_name,
+    COALESCE(opp.team_name, 'Unknown')  AS opponent_team_name,
+    r.match_result                      AS result,
+    a.appearance_type,
+    f.minutes_played,
+    f.goals_scored,
+    f.assists,
+    f.goals_conceded,
+    f.saves,
+    f.total_shots,
+    f.shots_on_goal,
+    f.total_passes,
+    f.passes_accurate,
+    f.passes_key,
+    f.tackles_total,
+    f.interceptions,
+    f.duels_total,
+    f.duels_won,
+    f.dribbles_attempts,
+    f.dribbles_success,
+    f.fouls_committed,
+    f.fouls_drawn,
+    f.yellow_cards,
+    f.red_cards,
+    f.offsides,
+    f.rating
+FROM superligaen.gold.fct_player_appearances     f
+JOIN superligaen.gold.dim_date                   d   ON d.date_sk              = f.date_sk
+JOIN superligaen.gold.dim_match                  m   ON m.match_sk             = f.match_sk
+JOIN superligaen.gold.dim_player                 p   ON p.player_sk            = f.player_sk
+JOIN superligaen.gold.dim_team                   t   ON t.team_sk              = f.team_sk
+LEFT JOIN superligaen.gold.dim_team              opp ON opp.team_sk            = f.opponent_team_sk
+JOIN superligaen.gold.dim_match_result           r   ON r.match_result_sk      = f.match_result_sk
+JOIN superligaen.gold.dim_appearance_type        a   ON a.appearance_type_sk   = f.appearance_type_sk
+WHERE f.player_sk > 0
+  AND f.match_result_sk IN (1, 2, 3)


### PR DESCRIPTION
## Summary
- **League Analytics** — replaced 8 isolated bar charts with an attack vs defense quadrant scatter (team labels + league average crosshairs) and a full team performance heatmap showing percentile rankings across 6 dimensions (Attack, Defense, xG Quality, Possession, Passing, Discipline)
- **Team Analytics** — rebuilt around a custom ECharts radar fingerprint showing the team's profile vs league average, rolling 5-match form line chart, and a per-match xG vs actual goals scatter with diagonal reference line
- **Player Analytics** — new page at `/player-analytics` powered by `mart_player_appearances`; includes a sortable top performer leaderboard, goal contributions per 90 bar chart (top 20), and minutes vs rating scatter
- **Referee Analytics** — added fouls vs card severity scatter with league average crosshairs; removed redundant bar charts that duplicated the leaderboard table
- **Home page** — added Player Analysis navigation card
- **New source** — `mart_player_appearances.sql` (35,221 rows across all seasons)
- **New component** — `components/RadarChart.svelte` (custom ECharts radar, responsive, with league average overlay)

## Test plan
- [ ] `npm run sources` — verify mart_player_appearances loads (should be ~35k rows)
- [ ] Open `/league-analytics` — verify quadrant scatter with team labels and heatmap
- [ ] Open `/team-analytics` — verify radar chart renders and updates on team/season change
- [ ] Open `/player-analytics` — verify leaderboard, contributions chart, scatter
- [ ] Open `/referee-analytics` — verify strictness scatter with referee labels
- [ ] Check home page has Player Analysis card

🤖 Generated with [Claude Code](https://claude.com/claude-code)