### PR TITLE
fix: handle API plan restriction in load_fixtures gracefully

### DIFF
--- a/ingestion/ingest_fixtures.py
+++ b/ingestion/ingest_fixtures.py
@@ -31,7 +31,11 @@ def load_fixtures(conn, league_id: int, season: int,
     if to_date:
         params["to"] = to_date
 
-    data = api_get(endpoint, params)
+    try:
+        data = api_get(endpoint, params)
+    except Exception as exc:
+        log.warning("Failed %s league %d season %d: %s", FIXTURE_TABLE, league_id, season, exc)
+        return
     fixtures = data["response"]
     log.info("League %d season %d: fetched %d fixtures", league_id, season, len(fixtures))
 


### PR DESCRIPTION
## Root cause
The nightly pipeline's bronze ingestion step crashed with exit code 1.

All season-level endpoints (`standings`, `topscorers`, `players`, etc.) wrap their `api_get` calls in `try/except` and log a WARNING when the API free plan blocks a season — they skip and move on. The fixtures bulk fetch in `load_fixtures()` had no such protection. When the free plan blocked season 2025, the unguarded `RuntimeError` propagated all the way up and killed the pipeline.

## Fix
Wrap the `api_get` call in `load_fixtures` with the same `try/except` + `log.warning` + `return` pattern already used in `ingest_season.py`. One logical change, 4 lines.

## Impact
After this fix the nightly pipeline will log a WARNING for blocked seasons (same as all other endpoints) and continue without crashing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)