### PR TITLE
fix: pin dbt-core to 1.11.8 to avoid nightly pipeline failure

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 duckdb==1.5.1
+dbt-core==1.11.8
 dbt-duckdb==1.10.1
 requests>=2.31.0
 python-dotenv>=1.0.0


### PR DESCRIPTION
## Summary

- `dbt-core 1.11.9` was released ~2026-05-13 with a regression in `get_supported_languages()` in `dbt/parser/macros.py`
- When parsing macros from installed packages (`dbt_date 0.17.2`), it now tries to resolve all language values against the `ModelLanguage` enum — including `javascript`, which is not in the enum for dbt-duckdb
- The nightly pipeline was picking up `1.11.9` on every fresh CI runner because `dbt-core` was not pinned in `requirements.txt`
- The May 12 run succeeded on `1.11.8`; the May 13 run failed on `1.11.9`

**Fix**: add `dbt-core==1.11.8` to `requirements.txt` to pin to the last known-good version.

## Test plan

- [ ] Merge this PR
- [ ] Manually trigger the nightly pipeline (`workflow_dispatch`) to verify the Silver transformation passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)