### PR TITLE
fix: replace uv with pip in bronze CI jobs

### DIFF
--- a/.github/workflows/bronze.yml
+++ b/.github/workflows/bronze.yml
@@ -22,16 +22,20 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@v5
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
 
       - name: Run ingestion
         working-directory: ingestion/sportmonks
         run: |
           if [ "${{ github.event.inputs.mode }}" = "full-load" ]; then
-            uv run --with requests --with python-dotenv --with duckdb python run.py --mode full --db md:superligaen
+            python run.py --mode full --db md:superligaen
           else
-            uv run --with requests --with python-dotenv --with duckdb python run.py --mode incremental --db md:superligaen
+            python run.py --mode incremental --db md:superligaen
           fi
         env:
           SPORTMONKS_API_KEY: ${{ secrets.SPORTMONKS_API_KEY }}

--- a/.github/workflows/bronze.yml
+++ b/.github/workflows/bronze.yml
@@ -25,16 +25,13 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v5
 
-      - name: Install dependencies
-        run: uv pip install --system --break-system-packages requests python-dotenv duckdb
-
       - name: Run ingestion
         working-directory: ingestion/sportmonks
         run: |
           if [ "${{ github.event.inputs.mode }}" = "full-load" ]; then
-            python run.py --mode full --db md:superligaen
+            uv run --with requests --with python-dotenv --with duckdb python run.py --mode full --db md:superligaen
           else
-            python run.py --mode incremental --db md:superligaen
+            uv run --with requests --with python-dotenv --with duckdb python run.py --mode incremental --db md:superligaen
           fi
         env:
           SPORTMONKS_API_KEY: ${{ secrets.SPORTMONKS_API_KEY }}

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -29,17 +29,14 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v5
 
-      - name: Install dependencies
-        run: uv pip install --system --break-system-packages requests python-dotenv duckdb
-
       - name: Run ingestion
         working-directory: ingestion/sportmonks
         run: |
           DB="md:${{ github.event.inputs.target_db || 'superligaen' }}"
           if [ "${{ github.event.inputs.full_load }}" = "true" ]; then
-            python run.py --mode full --db $DB
+            uv run --with requests --with python-dotenv --with duckdb python run.py --mode full --db $DB
           else
-            python run.py --mode incremental --db $DB
+            uv run --with requests --with python-dotenv --with duckdb python run.py --mode incremental --db $DB
           fi
         env:
           SPORTMONKS_API_KEY: ${{ secrets.SPORTMONKS_API_KEY }}

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -26,17 +26,21 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@v5
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
 
       - name: Run ingestion
         working-directory: ingestion/sportmonks
         run: |
           DB="md:${{ github.event.inputs.target_db || 'superligaen' }}"
           if [ "${{ github.event.inputs.full_load }}" = "true" ]; then
-            uv run --with requests --with python-dotenv --with duckdb python run.py --mode full --db $DB
+            python run.py --mode full --db $DB
           else
-            uv run --with requests --with python-dotenv --with duckdb python run.py --mode incremental --db $DB
+            python run.py --mode incremental --db $DB
           fi
         env:
           SPORTMONKS_API_KEY: ${{ secrets.SPORTMONKS_API_KEY }}


### PR DESCRIPTION
## Summary
- All bronze ingestion dependencies (`requests`, `python-dotenv`, `duckdb`) are already in `requirements.txt`
- Replace uv with `pip install -r requirements.txt` to match how silver, gold, and DQ jobs work
- No reason uv was introduced in the first place

## Test plan
- [ ] Merge and re-trigger nightly pipeline — bronze ingestion should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)