### PR TITLE
fix: explicitly set _ingested_at in bronze insert_batch

### DIFF
--- a/ingestion/sportmonks/db.py
+++ b/ingestion/sportmonks/db.py
@@ -15,6 +15,7 @@ Date-win  : DELETE WHERE _fixture_date BETWEEN — transfers, fixtures
 import json
 import logging
 import os
+from datetime import datetime, timezone
 
 import duckdb
 from dotenv import load_dotenv
@@ -126,8 +127,10 @@ def insert_batch(
 ) -> None:
     if not rows:
         return
+    now = datetime.now(timezone.utc)
+    rows_with_ts = [(*r, now) for r in rows]
     conn.executemany(
-        f"INSERT INTO bronze.{table} (id, raw_json, _season_id, _fixture_date) "
-        f"VALUES (?, ?, ?, ?)",
-        rows,
+        f"INSERT INTO bronze.{table} (id, raw_json, _season_id, _fixture_date, _ingested_at) "
+        f"VALUES (?, ?, ?, ?, ?)",
+        rows_with_ts,
     )


### PR DESCRIPTION
## Summary
- DuckDB's `executemany` does not apply column `DEFAULT` constraints — unspecified columns get `NULL`
- `_ingested_at` was NULL in all bronze rows as a result
- All silver incremental models filter on `WHERE _ingested_at > MAX(_ingested_at)`, so `NULL` bronze timestamps caused silver to silently skip all new data on every nightly run
- Fix: pass timestamp explicitly from Python in `insert_batch`

## Test plan
- [ ] Merge and trigger nightly pipeline
- [ ] Verify bronze rows have non-null `_ingested_at`
- [ ] Verify silver incremental picks up new rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)