### PR TITLE
perf: reduce API_CALL_DELAY from 1.0s to 0.2s

### DIFF
--- a/ingestion/sportmonks/config.py
+++ b/ingestion/sportmonks/config.py
@@ -9,7 +9,7 @@ MAX_RETRIES       = 8
 REQUEST_TIMEOUT   = 120  # seconds per HTTP request
 PER_PAGE          = 100
 DATE_CHUNK_DAYS   = 90   # stay under the ~100-day API window limit
-API_CALL_DELAY    = 1.0  # seconds between every API request (rate-limit throttle)
+API_CALL_DELAY    = 0.2  # seconds between every API request (rate-limit throttle)
 INCREMENTAL_DAYS_BACK    = 3
 INCREMENTAL_DAYS_FORWARD = 30
 


### PR DESCRIPTION
## Summary
- `API_CALL_DELAY` was 1.0s between every API request — overly conservative
- Retry logic in `engine.py` already handles 429s via `retry_after`
- 0.2s cuts ~2 minutes of pure sleeping from incremental runs (150+ requests × 0.8s saved)

## Test plan
- [ ] Merge and trigger nightly pipeline — confirm no 429 rate limit errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)