### PR TITLE
perf: batch INSERT rows to fix MotherDuck write latency

### DIFF
--- a/ingestion/sportmonks/config.py
+++ b/ingestion/sportmonks/config.py
@@ -9,7 +9,7 @@ MAX_RETRIES       = 8
 REQUEST_TIMEOUT   = 120  # seconds per HTTP request
 PER_PAGE          = 100
 DATE_CHUNK_DAYS   = 90   # stay under the ~100-day API window limit
-API_CALL_DELAY    = 0.2  # seconds between every API request (rate-limit throttle)
+API_CALL_DELAY    = 1.0  # seconds between every API request (rate-limit throttle)
 INCREMENTAL_DAYS_BACK    = 3
 INCREMENTAL_DAYS_FORWARD = 30
 

--- a/ingestion/sportmonks/db.py
+++ b/ingestion/sportmonks/db.py
@@ -120,6 +120,9 @@ def delete_by_date(conn: duckdb.DuckDBPyConnection, table: str,
 
 # ── Insert helpers ────────────────────────────────────────────────────────────
 
+_INSERT_CHUNK = 500  # rows per INSERT statement; keeps parameter count well under DuckDB's 65535 limit
+
+
 def insert_batch(
     conn: duckdb.DuckDBPyConnection,
     table: str,
@@ -129,8 +132,15 @@ def insert_batch(
         return
     now = datetime.now(timezone.utc)
     rows_with_ts = [(*r, now) for r in rows]
-    conn.executemany(
-        f"INSERT INTO bronze.{table} (id, raw_json, _season_id, _fixture_date, _ingested_at) "
-        f"VALUES (?, ?, ?, ?, ?)",
-        rows_with_ts,
-    )
+    # Single multi-row INSERT per chunk instead of executemany (one round trip per row).
+    # Reduces MotherDuck latency from O(n) network round trips to O(n/chunk).
+    for i in range(0, len(rows_with_ts), _INSERT_CHUNK):
+        chunk = rows_with_ts[i : i + _INSERT_CHUNK]
+        placeholders = ",".join(["(?,?,?,?,?)"] * len(chunk))
+        flat = [v for row in chunk for v in row]
+        conn.execute(
+            f"INSERT INTO bronze.{table} "
+            f"(id, raw_json, _season_id, _fixture_date, _ingested_at) "
+            f"VALUES {placeholders}",
+            flat,
+        )


### PR DESCRIPTION
## Summary

- Replace `executemany` in `insert_batch` with chunked multi-row `INSERT ... VALUES` (500 rows/chunk)
- Revert `API_CALL_DELAY` to `1.0s` (conservative; was incorrectly reduced to `0.2s` in #208)

## Root cause

DuckDB's `executemany` sends **one network round trip per row** when connected to MotherDuck. From GitHub Actions (~0.28s latency), this made individual tables take minutes:
- 237 rows (countries): ~66s
- 1304 rows (types): ~362s
- 1191 rows (tv_stations): ~335s

Pipeline was cancelled after 31+ minutes, having barely progressed past the first few tables.

## Fix

Chunked multi-row INSERT reduces round trips from O(n) to O(n/500):
- 1304 rows: 1304 trips → 3 trips
- 5711 rows: 5711 trips → 12 trips

## Test results (local → `md:superligaen`)

| Table | Rows | Before | After |
|---|---|---|---|
| countries | 237 | ~66s | 3s |
| 1304 | types | ~362s | 19s |
| tv_stations | 1191 | ~335s | 17s |

**Total incremental run: 4m 16s** (previously cancelled at 31+ min)

## Test plan
- [ ] Trigger nightly pipeline and verify completes within 3 hours

🤖 Generated with [Claude Code](https://claude.com/claude-code)