### PR TITLE
ci: add concurrency controls to all workflows

### DIFF
--- a/.github/workflows/bronze.yml
+++ b/.github/workflows/bronze.yml
@@ -12,6 +12,10 @@ on:
           - incremental
           - full-load
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
 jobs:
   ingest:
     name: Ingest → MotherDuck

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   validate:
     name: Validate

--- a/.github/workflows/dq.yml
+++ b/.github/workflows/dq.yml
@@ -12,6 +12,10 @@ on:
         required: false
         default: ""
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
 jobs:
   dq_tests:
     name: DQ tests

--- a/.github/workflows/gold.yml
+++ b/.github/workflows/gold.yml
@@ -8,6 +8,10 @@ on:
         required: false
         default: ""
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
 jobs:
   gold:
     name: Gold transformation

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -14,6 +14,10 @@ on:
         required: false
         default: ""
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 jobs:
   # ---------------------------------------------------------------------------
   # Bronze — ingest raw API data from Sportmonks

--- a/.github/workflows/silver.yml
+++ b/.github/workflows/silver.yml
@@ -12,6 +12,10 @@ on:
         required: false
         default: ""
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
 jobs:
   transform:
     name: Silver transformation

--- a/.github/workflows/vercel.yml
+++ b/.github/workflows/vercel.yml
@@ -3,6 +3,10 @@ name: Publish to Vercel
 on:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
 jobs:
   deploy:
     name: Publish to Vercel


### PR DESCRIPTION
## Summary
- Adds `concurrency` blocks to all 7 workflow files to prevent queue pileup
- `ci.yml` groups by workflow + ref so concurrent PRs don't interfere with each other
- `master.yml` (Nightly pipeline) uses `cancel-in-progress: false` to avoid killing a long-running pipeline mid-execution
- All other workflows (`bronze`, `silver`, `gold`, `dq`, `vercel`) use `cancel-in-progress: true` to drop stale queued runs on new dispatch

## Test plan
- [ ] Trigger a workflow twice in quick succession and confirm the first queued run is cancelled
- [ ] Verify nightly pipeline is not cancelled when a new dispatch is triggered while it's running

🤖 Generated with [Claude Code](https://claude.com/claude-code)