### PR TITLE
fix: resolve short_name column reference in dim_match

### DIFF
--- a/dbt/models/gold/dims/dim_match.sql
+++ b/dbt/models/gold/dims/dim_match.sql
@@ -34,7 +34,7 @@ participants_pivot AS (
     GROUP BY fixture_id
 ),
 name_map AS (
-    SELECT team_id, display_name, short_name
+    SELECT team_id, display_name, team_short_name AS short_name
     FROM {{ ref('team_names') }}
 ),
 scores_pivot AS (


### PR DESCRIPTION
## Summary
- `gold.dim_match` was referencing `short_name` from `team_names`, but the column was renamed to `team_short_name` in the silver layer
- Fixed by aliasing `team_short_name AS short_name` in the `name_map` CTE

## Root cause
Nightly pipeline gold step failed with:
```
Binder Error: Referenced column "short_name" not found in FROM clause!
Candidate bindings: "team_short_name", "display_name", "team_code"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)