### PR TITLE
feat: unify incremental lookback to 7 days across bronze and gold

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -18,6 +18,9 @@ concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: false
 
+env:
+  INCREMENTAL_DAYS_BACK: '7'   # single source of truth — bronze and gold both inherit this
+
 jobs:
   # ---------------------------------------------------------------------------
   # Bronze — ingest raw API data from Sportmonks
@@ -98,7 +101,7 @@ jobs:
           if [ "${{ github.event.inputs.full_load }}" = "true" ]; then
             dbt run --select silver.* --target $TARGET --full-refresh
           else
-            dbt run --select silver.* --target $TARGET
+            dbt run --select silver.* --target $TARGET --vars "{'incremental_days_back': $INCREMENTAL_DAYS_BACK}"
           fi
 
   # ---------------------------------------------------------------------------
@@ -138,7 +141,7 @@ jobs:
           if [ "${{ github.event.inputs.full_load }}" = "true" ]; then
             dbt run --select gold.* --target $TARGET --full-refresh
           else
-            dbt run --select gold.* --target $TARGET
+            dbt run --select gold.* --target $TARGET --vars "{'incremental_days_back': $INCREMENTAL_DAYS_BACK}"
           fi
 
   # ---------------------------------------------------------------------------

--- a/dbt/macros/gold_incremental_filter.sql
+++ b/dbt/macros/gold_incremental_filter.sql
@@ -1,3 +1,3 @@
-{% macro gold_incremental_filter(lookback_days=5) %}
+{% macro gold_incremental_filter(lookback_days=var('incremental_days_back', 7)) %}
     date_sk >= CAST(STRFTIME(CURRENT_DATE - INTERVAL '{{ lookback_days }}' day, '%Y%m%d') AS INTEGER)
 {% endmacro %}

--- a/ingestion/sportmonks/config.py
+++ b/ingestion/sportmonks/config.py
@@ -12,7 +12,7 @@ DATE_CHUNK_DAYS   = 90   # stay under the ~100-day API window limit
 API_CALL_DELAY    = 0.3  # seconds between every API request; rate limit is per entity type
                          # (~3000/hour per entity), so 0.3s is well within budget.
                          # Retry/backoff in api.py handles any 429s gracefully.
-INCREMENTAL_DAYS_BACK    = 3
+INCREMENTAL_DAYS_BACK    = int(os.environ.get("INCREMENTAL_DAYS_BACK", 7))
 INCREMENTAL_DAYS_FORWARD = 30
 
 _PROJECT_ROOT   = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))


### PR DESCRIPTION
## Summary
- `master.yml` defines `INCREMENTAL_DAYS_BACK: '7'` as the single source of truth
- Bronze `config.py` reads from the env var (falls back to 7 if not set)
- `gold_incremental_filter` macro reads from dbt var `incremental_days_back` (falls back to 7)
- Silver/gold incremental dbt runs in `master.yml` pass the var through via `--vars`

Previously bronze used 3 days, gold used 5 days — inconsistent and both too short. 7 days covers a full match week and tolerates 2 nights of pipeline failure.

## Test plan
- [ ] Trigger nightly pipeline and confirm bronze pulls 7 days back
- [ ] Confirm gold incremental only processes fixtures from last 7 days

🤖 Generated with [Claude Code](https://claude.com/claude-code)