### PR TITLE
fix: team ranking, KPI arrows, league table logos, player page improvements

### DIFF
--- a/dashboards/pages/league-analytics.md
+++ b/dashboards/pages/league-analytics.md
@@ -342,7 +342,7 @@ select * from ranked where team_name in ${inputs.team.value} order by team_name
     <div class="text-3xl font-black text-center text-gray-900 flex-1 flex items-center justify-center">{k.yc_per_match}</div>
     <div class="flex justify-between items-center mt-3">
       <span class="text-xs text-gray-400">Prev season: {k.prev_yc_per_match ?? '—'}</span>
-      {#if k.yc_ratio != null}<span class="text-sm font-bold {k.yc_ratio <= 1 ? 'text-green-600' : 'text-red-500'}">{k.yc_ratio <= 1 ? '▲' : '▼'}</span>{/if}
+      {#if k.yc_ratio != null}<span class="text-sm font-bold {k.yc_ratio >= 1 ? 'text-green-600' : 'text-red-500'}">{k.yc_ratio >= 1 ? '▲' : '▼'}</span>{/if}
     </div>
   </div>
 
@@ -360,7 +360,7 @@ select * from ranked where team_name in ${inputs.team.value} order by team_name
     <div class="text-3xl font-black text-center text-gray-900 flex-1 flex items-center justify-center">{k.rc_per_match}</div>
     <div class="flex justify-between items-center mt-3">
       <span class="text-xs text-gray-400">Prev season: {k.prev_rc_per_match ?? '—'}</span>
-      {#if k.rc_ratio != null}<span class="text-sm font-bold {k.rc_ratio <= 1 ? 'text-green-600' : 'text-red-500'}">{k.rc_ratio <= 1 ? '▲' : '▼'}</span>{/if}
+      {#if k.rc_ratio != null}<span class="text-sm font-bold {k.rc_ratio >= 1 ? 'text-green-600' : 'text-red-500'}">{k.rc_ratio >= 1 ? '▲' : '▼'}</span>{/if}
     </div>
   </div>
 

--- a/dashboards/pages/league-analytics.md
+++ b/dashboards/pages/league-analytics.md
@@ -155,6 +155,8 @@ where g.rn = 1 and a.rn = 1 and r.rn = 1
 select
     team_name,
     team_short_name,
+    '<div style="display:flex;align-items:center;gap:6px;"><img src="' || team_logo || '" style="height:20px;width:20px;object-fit:contain;" onerror="this.style.display=''none''"><span>' || team_name       || '</span></div>' as team_col,
+    '<div style="display:flex;align-items:center;gap:6px;"><img src="' || team_logo || '" style="height:20px;width:20px;object-fit:contain;" onerror="this.style.display=''none''"><span>' || team_short_name || '</span></div>' as team_col_mobile,
     count(distinct match_id)                          as mp,
     sum(points_earned)                                as pts,
     sum(goals_scored) - sum(goals_conceded)           as gd,
@@ -164,7 +166,7 @@ from superligaen.mart_match_facts
 where ('${inputs.season.value}' = 'All Seasons' or season = '${inputs.season.value}')
   and team_name in ${inputs.team.value}
   and result in ('Win', 'Draw', 'Loss')
-group by team_name, team_short_name, standings_type
+group by team_name, team_short_name, team_logo, standings_type
 order by
     case standings_type
         when 'Championship Group' then 1
@@ -396,7 +398,7 @@ select * from ranked where team_name in ${inputs.team.value} order by team_name
 
 <div class="block md:hidden">
 <DataTable data={current_standings} rows=20>
-    <Column id=team_short_name title="Team"  />
+    <Column id=team_col_mobile title="Team"  contentType=html />
     <Column id=round_group     title="Group" />
     <Column id=mp              title="MP"   align=center />
     <Column id=pts             title="Pts"  align=center contentType=colorscale colorPalette={['white','#3b82f6']} />
@@ -404,7 +406,7 @@ select * from ranked where team_name in ${inputs.team.value} order by team_name
 </div>
 <div class="hidden md:block">
 <DataTable data={current_standings} rows=20>
-    <Column id=team_name   title="Team"  />
+    <Column id=team_col    title="Team"  contentType=html />
     <Column id=round_group title="Group" />
     <Column id=mp          title="MP"   align=center />
     <Column id=pts         title="Pts"  align=center contentType=colorscale colorPalette={['white','#3b82f6']} />

--- a/dashboards/pages/league-analytics.md
+++ b/dashboards/pages/league-analytics.md
@@ -14,20 +14,18 @@ title: League Intelligence
 
 ```sql seasons
 select season from (
-  select season, max(is_current_season::int) as is_current, 0 as sort_key
+  select season, max(is_current_season::int) as is_current
   from superligaen.mart_match_facts
   where result in ('Win', 'Draw', 'Loss')
   group by season
-  union all
-  select 'All Seasons', -1, 1
 )
-order by sort_key, is_current desc, season desc
+order by is_current desc, season desc
 ```
 
 ```sql teams
 select distinct team_name
 from superligaen.mart_match_facts
-where ('${inputs.season.value}' = 'All Seasons' or season = '${inputs.season.value}')
+where season = '${inputs.season.value}'
   and result in ('Win', 'Draw', 'Loss')
 order by team_name
 ```
@@ -53,7 +51,7 @@ with curr as (
         round(sum(red_cards)::double / count(distinct match_id), 2)                                    as rc_per_match,
         round(sum(shots_on_goal)::double / count(distinct match_id), 1)                                as sot_per_match
     from superligaen.mart_match_facts
-    where ('${inputs.season.value}' = 'All Seasons' or season = '${inputs.season.value}')
+    where season = '${inputs.season.value}'
       and team_name in ${inputs.team.value}
       and result in ('Win', 'Draw', 'Loss')
 ),
@@ -72,7 +70,6 @@ prev as (
         select max(season) from superligaen.mart_match_facts
         where season < '${inputs.season.value}'
           and result in ('Win','Draw','Loss')
-          and '${inputs.season.value}' != 'All Seasons'
     )
       and team_name in ${inputs.team.value}
       and result in ('Win', 'Draw', 'Loss')
@@ -97,7 +94,7 @@ with goals_ranked as (
            sum(goals_scored)::int as total_goals,
            row_number() over (order by sum(goals_scored) desc) as rn
     from superligaen.mart_player_facts
-    where ('${inputs.season.value}' = 'All Seasons' or season = '${inputs.season.value}')
+    where season = '${inputs.season.value}'
       and team_name in ${inputs.team.value}
       and result in ('Win', 'Draw', 'Loss')
     group by player_name, player_photo, team_name, team_logo
@@ -108,7 +105,7 @@ assists_ranked as (
            sum(assists)::int as total_assists,
            row_number() over (order by sum(assists) desc) as rn
     from superligaen.mart_player_facts
-    where ('${inputs.season.value}' = 'All Seasons' or season = '${inputs.season.value}')
+    where season = '${inputs.season.value}'
       and team_name in ${inputs.team.value}
       and result in ('Win', 'Draw', 'Loss')
     group by player_name, player_photo, team_name, team_logo
@@ -120,7 +117,7 @@ rating_ranked as (
            count(distinct match_id)::int as matches,
            row_number() over (order by avg(rating) desc) as rn
     from superligaen.mart_player_facts
-    where ('${inputs.season.value}' = 'All Seasons' or season = '${inputs.season.value}')
+    where season = '${inputs.season.value}'
       and team_name in ${inputs.team.value}
       and result in ('Win', 'Draw', 'Loss')
       and rating is not null
@@ -163,7 +160,7 @@ select
     sum(goals_scored)                                 as gf,
     standings_type                                    as round_group
 from superligaen.mart_match_facts
-where ('${inputs.season.value}' = 'All Seasons' or season = '${inputs.season.value}')
+where season = '${inputs.season.value}'
   and team_name in ${inputs.team.value}
   and result in ('Win', 'Draw', 'Loss')
 group by team_name, team_short_name, team_logo, standings_type
@@ -188,17 +185,34 @@ select
     count(distinct match_id) filter (where goals_conceded = 0)::int                         as clean_sheets,
     round(100.0 * sum(passes_accurate) / nullif(sum(total_passes), 0), 1)                   as pass_accuracy
 from superligaen.mart_match_facts
-where ('${inputs.season.value}' = 'All Seasons' or season = '${inputs.season.value}')
+where season = '${inputs.season.value}'
   and team_name in ${inputs.team.value}
   and result in ('Win', 'Draw', 'Loss')
 group by team_name, team_logo
 order by team_name
 ```
 
+```sql team_landscape_bounds
+select
+    floor(min(goals_for)  * 0.9)  as x_min,
+    ceil(max(goals_for)   * 1.1)  as x_max,
+    floor(min(goals_against) * 0.9) as y_min,
+    ceil(max(goals_against)  * 1.1) as y_max
+from (
+    select
+        sum(goals_scored)::int   as goals_for,
+        sum(goals_conceded)::int as goals_against
+    from superligaen.mart_match_facts
+    where season = '${inputs.season.value}'
+      and result in ('Win', 'Draw', 'Loss')
+    group by team_name
+)
+```
+
 ```sql points_progression
 select match_round_number as round, team_name, cumulative_points, cumulative_gd, cumulative_gf
 from superligaen.mart_match_facts
-where ('${inputs.season.value}' = 'All Seasons' or season = '${inputs.season.value}')
+where season = '${inputs.season.value}'
   and team_name in ${inputs.team.value}
   and result in ('Win', 'Draw', 'Loss')
 order by max(cumulative_points) over (partition by team_name) desc, team_name, match_round_number
@@ -222,7 +236,7 @@ select
     sum(yellow_cards)::int                                                                              as yellow_cards,
     sum(red_cards)::int                                                                                 as red_cards
 from superligaen.mart_match_facts
-where ('${inputs.season.value}' = 'All Seasons' or season = '${inputs.season.value}')
+where season = '${inputs.season.value}'
   and team_name in ${inputs.team.value}
   and result in ('Win', 'Draw', 'Loss')
 group by team_name
@@ -263,7 +277,7 @@ with all_teams as (
         100.0 * sum(goals_scored)       / nullif(sum(total_shots), 0)                      as shot_conv,
         100.0 * sum(case when result='Win' then 1 else 0 end) / count(distinct match_id)  as win_rate
     from superligaen.mart_match_facts
-    where ('${inputs.season.value}' = 'All Seasons' or season = '${inputs.season.value}')
+    where season = '${inputs.season.value}'
       and result in ('Win', 'Draw', 'Loss')
     group by team_name
 ),
@@ -421,8 +435,6 @@ select * from ranked where team_name in ${inputs.team.value} order by team_name
 
 ## Season Awards
 
-{#if inputs.season.value !== 'All Seasons'}
-
 <div class="grid grid-cols-1 md:grid-cols-3 gap-6 mb-8">
 
   {#each season_awards as award}
@@ -482,7 +494,6 @@ select * from ranked where team_name in ${inputs.team.value} order by team_name
 
 </div>
 
-{/if}
 
 ---
 
@@ -507,6 +518,10 @@ select * from ranked where team_name in ${inputs.team.value} order by team_name
     tooltipColumns={[{id: 'team_name', title: 'Team'}, {id: 'goals_for', title: 'Goals For'}, {id: 'goals_against', title: 'Goals Against'}, {id: 'points', title: 'Points'}, {id: 'win_pct', title: 'Win %', fmt: '0.0"%"'}]}
     chartAreaHeight=320
     legend=false
+    xMin={team_landscape_bounds[0].x_min}
+    xMax={team_landscape_bounds[0].x_max}
+    yMin={team_landscape_bounds[0].y_min}
+    yMax={team_landscape_bounds[0].y_max}
     echartsOptions={{series: team_landscape.map((row, i) => ({name: row.team_name, itemStyle: {color: selectedTeam === null || row.team_name === selectedTeam ? scatterPalette[i % 12] : '#d1d5db'}}))}}
 />
 <div style="display:flex;flex-wrap:wrap;gap:6px 14px;justify-content:center;margin-top:2px;">

--- a/dashboards/pages/player-analytics.md
+++ b/dashboards/pages/player-analytics.md
@@ -38,7 +38,7 @@ order by team_name
 select distinct player_position
 from superligaen.mart_player_facts
 where season = '${inputs.season.value}'
-  and team_name = '${inputs.team.value}'
+  and team_name in ${inputs.team.value}
   and result in ('Win', 'Draw', 'Loss')
   and player_position is not null
 order by player_position
@@ -48,7 +48,7 @@ order by player_position
 select distinct player_name
 from superligaen.mart_player_facts
 where season = '${inputs.season.value}'
-  and team_name = '${inputs.team.value}'
+  and team_name in ${inputs.team.value}
   and player_position in ${inputs.position.value}
   and result in ('Win', 'Draw', 'Loss')
 order by player_name
@@ -70,7 +70,7 @@ with base as (
         sum(passes_accurate)                            as passes
     from superligaen.mart_player_facts
     where season = '${inputs.season.value}'
-      and team_name = '${inputs.team.value}'
+      and team_name in ${inputs.team.value}
       and result in ('Win', 'Draw', 'Loss')
     group by player_name, player_photo, player_position
     having count(distinct match_id) >= 3
@@ -105,7 +105,7 @@ end
 {/key}
 
 {#key teams[0]?.team_name}
-<Dropdown data={teams} name=team value=team_name label=team_name defaultValue={teams[0]?.team_name} />
+<Dropdown data={teams} name=team value=team_name label=team_name multiple=true defaultValue={teams.map(t => t.team_name)} />
 {/key}
 
 ```sql player_profile
@@ -216,7 +216,7 @@ select * from ranked where player_name = '${inputs.player.value}'
 
 ---
 
-## Team Leaders
+## Top Players
 
 <div class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-4 mb-8">
 {#each top_players as tp}

--- a/dashboards/pages/player-analytics.md
+++ b/dashboards/pages/player-analytics.md
@@ -45,15 +45,13 @@ order by player_position
 ```
 
 ```sql players_in_team
-select
-    player_name,
-    row_number() over (order by sum(goals_scored) desc) as sort_order
+select distinct player_name
 from superligaen.mart_player_facts
 where season = '${inputs.season.value}'
   and team_name = '${inputs.team.value}'
   and player_position in ${inputs.position.value}
   and result in ('Win', 'Draw', 'Loss')
-group by player_name
+order by player_name
 ```
 
 
@@ -242,7 +240,7 @@ select * from ranked where player_name = '${inputs.player.value}'
 {/key}
 
 {#key players_in_team[0]?.player_name}
-<Dropdown data={players_in_team} name=player value=player_name label=player_name order="sort_order" defaultValue={players_in_team[0]?.player_name} />
+<Dropdown data={players_in_team} name=player value=player_name label=player_name defaultValue={players_in_team[0]?.player_name} />
 {/key}
 
 ## Player Profile

--- a/dashboards/pages/player-analytics.md
+++ b/dashboards/pages/player-analytics.md
@@ -34,13 +34,72 @@ where season = '${inputs.season.value}'
 order by team_name
 ```
 
-```sql players_in_team
-select distinct player_name
+```sql positions
+select distinct player_position
 from superligaen.mart_player_facts
 where season = '${inputs.season.value}'
   and team_name = '${inputs.team.value}'
   and result in ('Win', 'Draw', 'Loss')
-order by player_name
+  and player_position is not null
+order by player_position
+```
+
+```sql players_in_team
+select
+    player_name,
+    row_number() over (order by sum(goals_scored) desc) as sort_order
+from superligaen.mart_player_facts
+where season = '${inputs.season.value}'
+  and team_name = '${inputs.team.value}'
+  and player_position in ${inputs.position.value}
+  and result in ('Win', 'Draw', 'Loss')
+group by player_name
+```
+
+
+```sql top_players
+with base as (
+    select
+        player_name,
+        player_photo,
+        player_position,
+        count(distinct match_id)                        as matches,
+        sum(goals_scored)                               as goals,
+        sum(assists)                                    as assists,
+        sum(dribbles_completed)                         as dribbles,
+        sum(tackles) + sum(interceptions)               as defensive_actions,
+        sum(crosses_total)                              as crosses,
+        sum(passes_accurate)                            as passes
+    from superligaen.mart_player_facts
+    where season = '${inputs.season.value}'
+      and team_name = '${inputs.team.value}'
+      and result in ('Win', 'Draw', 'Loss')
+    group by player_name, player_photo, player_position
+    having count(distinct match_id) >= 3
+)
+select category, player_name, player_photo, player_position, stat_value, stat_label
+from (
+    select 'Top Scorer'   as category, player_name, player_photo, player_position, goals::int             as stat_value, 'Goals'        as stat_label, row_number() over (order by goals             desc) as rn from base
+    union all
+    select 'Top Assister',              player_name, player_photo, player_position, assists::int,              'Assists',      row_number() over (order by assists           desc) from base
+    union all
+    select 'Top Dribbler',              player_name, player_photo, player_position, dribbles::int,             'Dribbles',     row_number() over (order by dribbles          desc) from base
+    union all
+    select 'Top Defender',              player_name, player_photo, player_position, defensive_actions::int,    'Tkl+Int',      row_number() over (order by defensive_actions desc) from base
+    union all
+    select 'Top Crosser',               player_name, player_photo, player_position, crosses::int,              'Crosses',      row_number() over (order by crosses           desc) from base
+    union all
+    select 'Top Passer',                player_name, player_photo, player_position, passes::int,               'Acc. Passes',  row_number() over (order by passes            desc) from base
+)
+where rn = 1
+order by case category
+    when 'Top Scorer'   then 1
+    when 'Top Assister' then 2
+    when 'Top Dribbler' then 3
+    when 'Top Defender' then 4
+    when 'Top Crosser'  then 5
+    when 'Top Passer'   then 6
+end
 ```
 
 {#key seasons[0]?.season}
@@ -49,10 +108,6 @@ order by player_name
 
 {#key teams[0]?.team_name}
 <Dropdown data={teams} name=team value=team_name label=team_name defaultValue={teams[0]?.team_name} />
-{/key}
-
-{#key players_in_team[0]?.player_name}
-<Dropdown data={players_in_team} name=player value=player_name label=player_name defaultValue={players_in_team[0]?.player_name} />
 {/key}
 
 ```sql player_profile
@@ -162,6 +217,33 @@ select * from ranked where player_name = '${inputs.player.value}'
 ```
 
 ---
+
+## Team Leaders
+
+<div class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-4 mb-8">
+{#each top_players as tp}
+<div class="rounded-xl border border-gray-200 bg-white shadow-sm p-4 flex flex-col items-center text-center">
+  <div class="text-xs font-semibold text-gray-500 uppercase tracking-widest mb-3">{tp.category}</div>
+  <img src="{tp.player_photo}" alt="{tp.player_name}" class="h-16 w-16 rounded-full object-cover mb-3 border-2 border-gray-100" onerror="this.style.display='none'" />
+  <div class="text-sm font-bold text-gray-900 leading-tight">{tp.player_name}</div>
+  <div class="text-xs text-gray-400 mt-1">{tp.player_position}</div>
+  <div class="mt-3 text-2xl font-black text-blue-600">{tp.stat_value}</div>
+  <div class="text-xs text-gray-400">{tp.stat_label}</div>
+</div>
+{/each}
+</div>
+
+---
+
+## Player Deep Dive
+
+{#key positions.map(p => p.player_position).join(',')}
+<Dropdown data={positions} name=position value=player_position label=player_position multiple=true defaultValue={positions.map(p => p.player_position)} />
+{/key}
+
+{#key players_in_team[0]?.player_name}
+<Dropdown data={players_in_team} name=player value=player_name label=player_name order="sort_order" defaultValue={players_in_team[0]?.player_name} />
+{/key}
 
 ## Player Profile
 

--- a/dashboards/pages/player-analytics.md
+++ b/dashboards/pages/player-analytics.md
@@ -225,7 +225,7 @@ select * from ranked where player_name = '${inputs.player.value}'
   <img src="{tp.player_photo}" alt="{tp.player_name}" class="h-16 w-16 rounded-full object-cover mb-3 border-2 border-gray-100" onerror="this.style.display='none'" />
   <div class="text-sm font-bold text-gray-900 leading-tight">{tp.player_name}</div>
   <div class="text-xs text-gray-400 mt-1">{tp.player_position}</div>
-  <div class="mt-3 text-2xl font-black text-blue-600">{tp.stat_value}</div>
+  <div class="mt-auto pt-3 text-2xl font-black text-blue-600">{tp.stat_value}</div>
   <div class="text-xs text-gray-400">{tp.stat_label}</div>
 </div>
 {/each}

--- a/dashboards/pages/player-analytics.md
+++ b/dashboards/pages/player-analytics.md
@@ -61,6 +61,8 @@ with base as (
         player_name,
         player_photo,
         player_position,
+        max(team_name)                                  as team_name,
+        max(team_logo)                                  as team_logo,
         count(distinct match_id)                        as matches,
         sum(goals_scored)                               as goals,
         sum(assists)                                    as assists,
@@ -75,19 +77,19 @@ with base as (
     group by player_name, player_photo, player_position
     having count(distinct match_id) >= 3
 )
-select category, player_name, player_photo, player_position, stat_value, stat_label
+select category, player_name, player_photo, player_position, team_name, team_logo, stat_value, stat_label
 from (
-    select 'Top Scorer'   as category, player_name, player_photo, player_position, goals::int             as stat_value, 'Goals'        as stat_label, row_number() over (order by goals             desc) as rn from base
+    select 'Top Scorer'   as category, player_name, player_photo, player_position, team_name, team_logo, goals::int             as stat_value, 'Goals'        as stat_label, row_number() over (order by goals             desc) as rn from base
     union all
-    select 'Top Assister',              player_name, player_photo, player_position, assists::int,              'Assists',      row_number() over (order by assists           desc) from base
+    select 'Top Assister',              player_name, player_photo, player_position, team_name, team_logo, assists::int,              'Assists',      row_number() over (order by assists           desc) from base
     union all
-    select 'Top Dribbler',              player_name, player_photo, player_position, dribbles::int,             'Dribbles',     row_number() over (order by dribbles          desc) from base
+    select 'Top Dribbler',              player_name, player_photo, player_position, team_name, team_logo, dribbles::int,             'Dribbles',     row_number() over (order by dribbles          desc) from base
     union all
-    select 'Top Defender',              player_name, player_photo, player_position, defensive_actions::int,    'Tkl+Int',      row_number() over (order by defensive_actions desc) from base
+    select 'Top Defender',              player_name, player_photo, player_position, team_name, team_logo, defensive_actions::int,    'Tkl+Int',      row_number() over (order by defensive_actions desc) from base
     union all
-    select 'Top Crosser',               player_name, player_photo, player_position, crosses::int,              'Crosses',      row_number() over (order by crosses           desc) from base
+    select 'Top Crosser',               player_name, player_photo, player_position, team_name, team_logo, crosses::int,              'Crosses',      row_number() over (order by crosses           desc) from base
     union all
-    select 'Top Passer',                player_name, player_photo, player_position, passes::int,               'Acc. Passes',  row_number() over (order by passes            desc) from base
+    select 'Top Passer',                player_name, player_photo, player_position, team_name, team_logo, passes::int,               'Acc. Passes',  row_number() over (order by passes            desc) from base
 )
 where rn = 1
 order by case category
@@ -223,8 +225,9 @@ select * from ranked where player_name = '${inputs.player.value}'
 <div class="rounded-xl border border-gray-200 bg-white shadow-sm p-4 flex flex-col items-center text-center">
   <div class="text-xs font-semibold text-gray-500 uppercase tracking-widest mb-3">{tp.category}</div>
   <img src="{tp.player_photo}" alt="{tp.player_name}" class="h-16 w-16 rounded-full object-cover mb-3 border-2 border-gray-100" onerror="this.style.display='none'" />
-  <div class="text-sm font-bold text-gray-900 leading-tight">{tp.player_name}</div>
+  <div class="text-sm font-bold text-gray-900 leading-tight min-h-10 flex items-start justify-center">{tp.player_name}</div>
   <div class="text-xs text-gray-400 mt-1">{tp.player_position}</div>
+  <img src="{tp.team_logo}" alt="{tp.team_name}" class="h-7 w-7 object-contain mt-1" onerror="this.style.display='none'" />
   <div class="mt-auto pt-3 text-2xl font-black text-blue-600">{tp.stat_value}</div>
   <div class="text-xs text-gray-400">{tp.stat_label}</div>
 </div>

--- a/dashboards/pages/team-analytics.md
+++ b/dashboards/pages/team-analytics.md
@@ -136,7 +136,8 @@ select
     round(cs.pass_accuracy      / nullif(ps.prev_pass_accuracy,      0), 2)                 as pass_ratio,
     round(cs.shot_conv          / nullif(ps.prev_shot_conv,          0), 2)                 as shot_conv_ratio,
     round(cs.yc_per_match       / nullif(ps.prev_yc_per_match,       0), 2)                 as yc_ratio,
-    round(cs.win_rate           / nullif(ps.prev_win_rate,           0), 2)                 as win_rate_ratio
+    round(cs.win_rate           / nullif(ps.prev_win_rate,           0), 2)                 as win_rate_ratio,
+    round(cs.avg_possession     / nullif(ps.prev_avg_possession,     0), 2)                 as possession_ratio
 from current_stats cs
 left join current_ranking cr on cr.team_name = '${inputs.team.value}'
 left join prev_stats ps on true
@@ -410,7 +411,7 @@ end
     <div class="text-3xl font-black text-center text-gray-900 flex-1 flex items-center justify-center">{k.conceded_per_match}</div>
     <div class="flex justify-between items-center mt-3">
       <span class="text-xs text-gray-400">Prev season: {k.prev_conceded_per_match ?? '—'}</span>
-      <span class="text-sm font-bold {k.conceded_ratio <= 1 ? 'text-green-600' : 'text-red-500'}">{k.conceded_ratio <= 1 ? '▲' : '▼'}</span>
+      <span class="text-sm font-bold {k.conceded_ratio >= 1 ? 'text-green-600' : 'text-red-500'}">{k.conceded_ratio >= 1 ? '▲' : '▼'}</span>
     </div>
   </div>
 
@@ -425,7 +426,11 @@ end
 
   <div class="rounded-xl border border-gray-200 bg-white shadow-sm p-4 flex flex-col">
     <div class="text-xs text-gray-500 text-center mb-2">Avg Possession %</div>
-    <div class="text-3xl font-black text-center flex-1 flex items-center justify-center {k.avg_possession >= 55 ? 'text-green-600' : k.avg_possession < 45 ? 'text-red-500' : 'text-orange-400'}">{k.avg_possession}%</div>
+    <div class="text-3xl font-black text-center text-gray-900 flex-1 flex items-center justify-center">{k.avg_possession}%</div>
+    <div class="flex justify-between items-center mt-3">
+      <span class="text-xs text-gray-400">Prev season: {k.prev_avg_possession != null ? k.prev_avg_possession + '%' : '—'}</span>
+      <span class="text-sm font-bold {k.possession_ratio >= 1 ? 'text-green-600' : 'text-red-500'}">{k.possession_ratio >= 1 ? '▲' : '▼'}</span>
+    </div>
   </div>
 
   <div class="rounded-xl border border-gray-200 bg-white shadow-sm p-4 flex flex-col">
@@ -442,7 +447,7 @@ end
     <div class="text-3xl font-black text-center text-gray-900 flex-1 flex items-center justify-center">{k.yc_per_match}</div>
     <div class="flex justify-between items-center mt-3">
       <span class="text-xs text-gray-400">Prev season: {k.prev_yc_per_match ?? '—'}</span>
-      <span class="text-sm font-bold {k.yc_ratio <= 1 ? 'text-green-600' : 'text-red-500'}">{k.yc_ratio <= 1 ? '▲' : '▼'}</span>
+      <span class="text-sm font-bold {k.yc_ratio >= 1 ? 'text-green-600' : 'text-red-500'}">{k.yc_ratio >= 1 ? '▲' : '▼'}</span>
     </div>
   </div>
 

--- a/dashboards/pages/team-analytics.md
+++ b/dashboards/pages/team-analytics.md
@@ -66,12 +66,24 @@ with current_stats as (
       and result in ('Win', 'Draw', 'Loss')
 ),
 current_ranking as (
-    select row_number() over (order by sum(points_earned) desc, sum(goals_scored - goals_conceded) desc, sum(goals_scored) desc) as rank,
+    select row_number() over (order by group_order, total_pts desc, total_gd desc, total_gf desc) as rank,
            team_name
-    from superligaen.mart_match_facts
-    where season = '${inputs.season.value}'
-      and result in ('Win', 'Draw', 'Loss')
-    group by team_name
+    from (
+        select
+            team_name,
+            sum(points_earned)                          as total_pts,
+            sum(goals_scored - goals_conceded)          as total_gd,
+            sum(goals_scored)                           as total_gf,
+            case max(standings_type)
+                when 'Championship Group' then 1
+                when 'Relegation Group'   then 2
+                else                           3
+            end                                         as group_order
+        from superligaen.mart_match_facts
+        where season = '${inputs.season.value}'
+          and result in ('Win', 'Draw', 'Loss')
+        group by team_name
+    )
 ),
 prev_season as (
     select max(season) as season
@@ -94,13 +106,25 @@ prev_stats as (
       and match_round_number <= (select max_round from current_stats)
 ),
 prev_ranking as (
-    select row_number() over (order by sum(points_earned) desc, sum(goals_scored - goals_conceded) desc, sum(goals_scored) desc) as rank,
+    select row_number() over (order by group_order, total_pts desc, total_gd desc, total_gf desc) as rank,
            team_name
-    from superligaen.mart_match_facts
-    where season = (select season from prev_season)
-      and result in ('Win', 'Draw', 'Loss')
-      and match_round_number <= (select max_round from current_stats)
-    group by team_name
+    from (
+        select
+            team_name,
+            sum(points_earned)                          as total_pts,
+            sum(goals_scored - goals_conceded)          as total_gd,
+            sum(goals_scored)                           as total_gf,
+            case max(standings_type)
+                when 'Championship Group' then 1
+                when 'Relegation Group'   then 2
+                else                           3
+            end                                         as group_order
+        from superligaen.mart_match_facts
+        where season = (select season from prev_season)
+          and result in ('Win', 'Draw', 'Loss')
+          and match_round_number <= (select max_round from current_stats)
+        group by team_name
+    )
 )
 select
     cs.*,


### PR DESCRIPTION
## Summary
- Fix team ranking to respect Championship/Relegation group order (Copenhagen correctly ranks #7)
- Fix KPI arrow direction to consistently show green ▲ when current season metric is higher (Goals Conceded, YC, RC)
- Add `possession_ratio` and prev season comparison to Avg Possession card
- Add team logos to League Table
- Remove All Seasons option from league page season filter
- Fix scatter plot axes to stay static when team filter changes
- Add Top Players section to player page (scorer, assister, dribbler, defender, crosser, passer)
- Add position multi-select filter to player deep dive
- Multi-select team filter on player page with all teams selected by default
- Player filter ordered alphabetically, defaults to first player
- Align stat numbers to bottom of Top Players cards

## Test plan
- [ ] FC København ranks #7 in team page ranking KPI
- [ ] Green ▲ shows when current > prev for all KPI metrics on team and league pages
- [ ] League table shows team logos
- [ ] League page season filter has no All Seasons option
- [ ] Scatter plot axes don't rescale when filtering teams
- [ ] Top Players cards show correctly and numbers are bottom-aligned
- [ ] Position filter limits player dropdown
- [ ] Team filter on player page is multi-select with select all/clear

🤖 Generated with [Claude Code](https://claude.com/claude-code)