### PR TITLE
style(home): uniform cards, KPI/nav distinction, Explore label & arrows

### DIFF
--- a/dashboards/pages/index.md
+++ b/dashboards/pages/index.md
@@ -66,111 +66,126 @@ limit 1
 </div>
 
 <div class="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
-  <div class="rounded-xl border border-gray-200 bg-white shadow-sm p-4 text-center"><BigValue data={leader}  value=team_short_name  title="Current Leader"  /></div>
-  <div class="rounded-xl border border-gray-200 bg-white shadow-sm p-4 text-center"><BigValue data={kpis}    value=total_teams    title="Teams"           /></div>
-  <div class="rounded-xl border border-gray-200 bg-white shadow-sm p-4 text-center"><BigValue data={kpis}    value=total_matches  title="Matches Played"  /></div>
-  <div class="rounded-xl border border-gray-200 bg-white shadow-sm p-4 text-center"><BigValue data={kpis}    value=total_goals    title="Goals Scored"    /></div>
+  <div class="rounded-xl border border-gray-200 bg-gray-50 p-4 text-center"><BigValue data={leader}  value=team_short_name  title="Current Leader"  /></div>
+  <div class="rounded-xl border border-gray-200 bg-gray-50 p-4 text-center"><BigValue data={kpis}    value=total_teams    title="Teams"           /></div>
+  <div class="rounded-xl border border-gray-200 bg-gray-50 p-4 text-center"><BigValue data={kpis}    value=total_matches  title="Matches Played"  /></div>
+  <div class="rounded-xl border border-gray-200 bg-gray-50 p-4 text-center"><BigValue data={kpis}    value=total_goals    title="Goals Scored"    /></div>
+</div>
+
+<div class="flex items-center gap-3 mb-4">
+  <span class="text-xs font-semibold text-gray-400 uppercase tracking-widest">Explore</span>
+  <div class="flex-1 h-px bg-gray-100"></div>
 </div>
 
 <div class="grid grid-cols-1 md:grid-cols-2 gap-4" style="grid-auto-rows: 7.5rem">
 
 <a href="/standings" class="flex flex-col justify-center no-underline rounded-xl border border-gray-200 bg-white p-6 hover:border-blue-500 hover:shadow-lg transition-all duration-200 group shadow-sm h-full">
-  <div class="flex items-start gap-4">
+  <div class="flex items-center gap-4">
     <div class="text-3xl">🏆</div>
-    <div>
+    <div class="flex-1">
       <div class="text-base font-bold text-gray-800 group-hover:text-blue-500 transition-colors">Standings</div>
       <div class="text-gray-400 text-sm mt-1">Championship, Relegation &amp; Regular Season tables</div>
     </div>
+    <div class="translate-x-0 shrink-0 text-gray-300 group-hover:text-blue-400 group-hover:translate-x-1 transition-all duration-200 text-lg">→</div>
   </div>
 </a>
 
 <a href="/match-results" class="flex flex-col justify-center no-underline rounded-xl border border-gray-200 bg-white p-6 hover:border-blue-500 hover:shadow-lg transition-all duration-200 group shadow-sm h-full">
-  <div class="flex items-start gap-4">
+  <div class="flex items-center gap-4">
     <div class="text-3xl">⚽</div>
-    <div>
+    <div class="flex-1">
       <div class="text-base font-bold text-gray-800 group-hover:text-blue-500 transition-colors">Match Results</div>
       <div class="text-gray-400 text-sm mt-1">Full match history, scorelines and analytics by round</div>
     </div>
+    <div class="translate-x-0 shrink-0 text-gray-300 group-hover:text-blue-400 group-hover:translate-x-1 transition-all duration-200 text-lg">→</div>
   </div>
 </a>
 
 <a href="/upcoming-matches" class="flex flex-col justify-center no-underline rounded-xl border border-gray-200 bg-white p-6 hover:border-blue-500 hover:shadow-lg transition-all duration-200 group shadow-sm h-full">
-  <div class="flex items-start gap-4">
+  <div class="flex items-center gap-4">
     <div class="text-3xl">📅</div>
-    <div>
+    <div class="flex-1">
       <div class="text-base font-bold text-gray-800 group-hover:text-blue-500 transition-colors">Upcoming Fixtures</div>
       <div class="text-gray-400 text-sm mt-1">Head-to-head history &amp; form guide for upcoming matches</div>
     </div>
+    <div class="translate-x-0 shrink-0 text-gray-300 group-hover:text-blue-400 group-hover:translate-x-1 transition-all duration-200 text-lg">→</div>
   </div>
 </a>
 
 <a href="/league-analytics" class="flex flex-col justify-center no-underline rounded-xl border border-gray-200 bg-white p-6 hover:border-blue-500 hover:shadow-lg transition-all duration-200 group shadow-sm h-full">
-  <div class="flex items-start gap-4">
+  <div class="flex items-center gap-4">
     <div class="text-3xl">📈</div>
-    <div>
+    <div class="flex-1">
       <div class="text-base font-bold text-gray-800 group-hover:text-blue-500 transition-colors">League Intelligence</div>
-      <div class="text-gray-400 text-sm mt-1">Season KPIs, standings, points race, team landscape & radar, attack/defence/discipline rankings</div>
+      <div class="text-gray-400 text-sm mt-1">Standings, points race, team radar & discipline rankings</div>
     </div>
+    <div class="translate-x-0 shrink-0 text-gray-300 group-hover:text-blue-400 group-hover:translate-x-1 transition-all duration-200 text-lg">→</div>
   </div>
 </a>
 
 <a href="/team-analytics" class="flex flex-col justify-center no-underline rounded-xl border border-gray-200 bg-white p-6 hover:border-blue-500 hover:shadow-lg transition-all duration-200 group shadow-sm h-full">
-  <div class="flex items-start gap-4">
+  <div class="flex items-center gap-4">
     <div class="text-3xl">👥</div>
-    <div>
+    <div class="flex-1">
       <div class="text-base font-bold text-gray-800 group-hover:text-blue-500 transition-colors">Team Intelligence</div>
-      <div class="text-gray-400 text-sm mt-1">KPIs vs previous season, points race, match log, squad depth &amp; home/away splits</div>
+      <div class="text-gray-400 text-sm mt-1">Points race, match log, squad depth &amp; home/away splits</div>
     </div>
+    <div class="translate-x-0 shrink-0 text-gray-300 group-hover:text-blue-400 group-hover:translate-x-1 transition-all duration-200 text-lg">→</div>
   </div>
 </a>
 
 <a href="/player-analytics" class="flex flex-col justify-center no-underline rounded-xl border border-gray-200 bg-white p-6 hover:border-blue-500 hover:shadow-lg transition-all duration-200 group shadow-sm h-full">
-  <div class="flex items-start gap-4">
+  <div class="flex items-center gap-4">
     <div class="text-3xl">👟</div>
-    <div>
+    <div class="flex-1">
       <div class="text-base font-bold text-gray-800 group-hover:text-blue-500 transition-colors">Player Intelligence</div>
-      <div class="text-gray-400 text-sm mt-1">Individual player profile — league percentile radar, performance timeline &amp; match-by-match log</div>
+      <div class="text-gray-400 text-sm mt-1">Percentile radar, performance timeline &amp; match-by-match log</div>
     </div>
+    <div class="translate-x-0 shrink-0 text-gray-300 group-hover:text-blue-400 group-hover:translate-x-1 transition-all duration-200 text-lg">→</div>
   </div>
 </a>
 
 <a href="/stadium-analytics" class="flex flex-col justify-center no-underline rounded-xl border border-gray-200 bg-white p-6 hover:border-blue-500 hover:shadow-lg transition-all duration-200 group shadow-sm h-full">
-  <div class="flex items-start gap-4">
+  <div class="flex items-center gap-4">
     <div class="text-3xl">🏟️</div>
-    <div>
+    <div class="flex-1">
       <div class="text-base font-bold text-gray-800 group-hover:text-blue-500 transition-colors">Stadium Intelligence</div>
       <div class="text-gray-400 text-sm mt-1">Stadium map, surface effects and home fortress rankings</div>
     </div>
+    <div class="translate-x-0 shrink-0 text-gray-300 group-hover:text-blue-400 group-hover:translate-x-1 transition-all duration-200 text-lg">→</div>
   </div>
 </a>
 
 <a href="/referee-analytics" class="flex flex-col justify-center no-underline rounded-xl border border-gray-200 bg-white p-6 hover:border-blue-500 hover:shadow-lg transition-all duration-200 group shadow-sm h-full">
-  <div class="flex items-start gap-4">
+  <div class="flex items-center gap-4">
     <div class="text-3xl">🟨</div>
-    <div>
+    <div class="flex-1">
       <div class="text-base font-bold text-gray-800 group-hover:text-blue-500 transition-colors">Referee Intelligence</div>
       <div class="text-gray-400 text-sm mt-1">Cards, fouls, home/away bias and discipline trends</div>
     </div>
+    <div class="translate-x-0 shrink-0 text-gray-300 group-hover:text-blue-400 group-hover:translate-x-1 transition-all duration-200 text-lg">→</div>
   </div>
 </a>
 
 <a href="/glossary" class="flex flex-col justify-center no-underline rounded-xl border border-gray-200 bg-white p-6 hover:border-blue-500 hover:shadow-lg transition-all duration-200 group shadow-sm h-full">
-  <div class="flex items-start gap-4">
+  <div class="flex items-center gap-4">
     <div class="text-3xl">📖</div>
-    <div>
+    <div class="flex-1">
       <div class="text-base font-bold text-gray-800 group-hover:text-blue-500 transition-colors">Data Glossary</div>
       <div class="text-gray-400 text-sm mt-1">Definitions and formulas for all KPIs and abbreviations</div>
     </div>
+    <div class="translate-x-0 shrink-0 text-gray-300 group-hover:text-blue-400 group-hover:translate-x-1 transition-all duration-200 text-lg">→</div>
   </div>
 </a>
 
 <a href="/about" class="flex flex-col justify-center no-underline rounded-xl border border-gray-200 bg-white p-6 hover:border-blue-500 hover:shadow-lg transition-all duration-200 group shadow-sm h-full">
-  <div class="flex items-start gap-4">
+  <div class="flex items-center gap-4">
     <div class="text-3xl">👤</div>
-    <div>
+    <div class="flex-1">
       <div class="text-base font-bold text-gray-800 group-hover:text-blue-500 transition-colors">About This Project</div>
       <div class="text-gray-400 text-sm mt-1">The story behind this project, the blog &amp; the author</div>
     </div>
+    <div class="translate-x-0 shrink-0 text-gray-300 group-hover:text-blue-400 group-hover:translate-x-1 transition-all duration-200 text-lg">→</div>
   </div>
 </a>
 

--- a/dashboards/pages/index.md
+++ b/dashboards/pages/index.md
@@ -72,9 +72,9 @@ limit 1
   <div class="rounded-xl border border-gray-200 bg-white shadow-sm p-4 text-center"><BigValue data={kpis}    value=total_goals    title="Goals Scored"    /></div>
 </div>
 
-<div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+<div class="grid grid-cols-1 md:grid-cols-2 gap-4" style="grid-auto-rows: 7.5rem">
 
-<a href="/standings" class="block no-underline rounded-xl border border-gray-200 bg-white p-6 hover:border-blue-500 hover:shadow-lg transition-all duration-200 group shadow-sm">
+<a href="/standings" class="flex flex-col justify-center no-underline rounded-xl border border-gray-200 bg-white p-6 hover:border-blue-500 hover:shadow-lg transition-all duration-200 group shadow-sm h-full">
   <div class="flex items-start gap-4">
     <div class="text-3xl">🏆</div>
     <div>
@@ -84,7 +84,7 @@ limit 1
   </div>
 </a>
 
-<a href="/match-results" class="block no-underline rounded-xl border border-gray-200 bg-white p-6 hover:border-blue-500 hover:shadow-lg transition-all duration-200 group shadow-sm">
+<a href="/match-results" class="flex flex-col justify-center no-underline rounded-xl border border-gray-200 bg-white p-6 hover:border-blue-500 hover:shadow-lg transition-all duration-200 group shadow-sm h-full">
   <div class="flex items-start gap-4">
     <div class="text-3xl">⚽</div>
     <div>
@@ -94,7 +94,7 @@ limit 1
   </div>
 </a>
 
-<a href="/upcoming-matches" class="block no-underline rounded-xl border border-gray-200 bg-white p-6 hover:border-blue-500 hover:shadow-lg transition-all duration-200 group shadow-sm">
+<a href="/upcoming-matches" class="flex flex-col justify-center no-underline rounded-xl border border-gray-200 bg-white p-6 hover:border-blue-500 hover:shadow-lg transition-all duration-200 group shadow-sm h-full">
   <div class="flex items-start gap-4">
     <div class="text-3xl">📅</div>
     <div>
@@ -104,7 +104,7 @@ limit 1
   </div>
 </a>
 
-<a href="/league-analytics" class="block no-underline rounded-xl border border-gray-200 bg-white p-6 hover:border-blue-500 hover:shadow-lg transition-all duration-200 group shadow-sm">
+<a href="/league-analytics" class="flex flex-col justify-center no-underline rounded-xl border border-gray-200 bg-white p-6 hover:border-blue-500 hover:shadow-lg transition-all duration-200 group shadow-sm h-full">
   <div class="flex items-start gap-4">
     <div class="text-3xl">📈</div>
     <div>
@@ -114,7 +114,7 @@ limit 1
   </div>
 </a>
 
-<a href="/team-analytics" class="block no-underline rounded-xl border border-gray-200 bg-white p-6 hover:border-blue-500 hover:shadow-lg transition-all duration-200 group shadow-sm">
+<a href="/team-analytics" class="flex flex-col justify-center no-underline rounded-xl border border-gray-200 bg-white p-6 hover:border-blue-500 hover:shadow-lg transition-all duration-200 group shadow-sm h-full">
   <div class="flex items-start gap-4">
     <div class="text-3xl">👥</div>
     <div>
@@ -124,7 +124,7 @@ limit 1
   </div>
 </a>
 
-<a href="/player-analytics" class="block no-underline rounded-xl border border-gray-200 bg-white p-6 hover:border-blue-500 hover:shadow-lg transition-all duration-200 group shadow-sm">
+<a href="/player-analytics" class="flex flex-col justify-center no-underline rounded-xl border border-gray-200 bg-white p-6 hover:border-blue-500 hover:shadow-lg transition-all duration-200 group shadow-sm h-full">
   <div class="flex items-start gap-4">
     <div class="text-3xl">👟</div>
     <div>
@@ -134,7 +134,7 @@ limit 1
   </div>
 </a>
 
-<a href="/stadium-analytics" class="block no-underline rounded-xl border border-gray-200 bg-white p-6 hover:border-blue-500 hover:shadow-lg transition-all duration-200 group shadow-sm">
+<a href="/stadium-analytics" class="flex flex-col justify-center no-underline rounded-xl border border-gray-200 bg-white p-6 hover:border-blue-500 hover:shadow-lg transition-all duration-200 group shadow-sm h-full">
   <div class="flex items-start gap-4">
     <div class="text-3xl">🏟️</div>
     <div>
@@ -144,7 +144,7 @@ limit 1
   </div>
 </a>
 
-<a href="/referee-analytics" class="block no-underline rounded-xl border border-gray-200 bg-white p-6 hover:border-blue-500 hover:shadow-lg transition-all duration-200 group shadow-sm">
+<a href="/referee-analytics" class="flex flex-col justify-center no-underline rounded-xl border border-gray-200 bg-white p-6 hover:border-blue-500 hover:shadow-lg transition-all duration-200 group shadow-sm h-full">
   <div class="flex items-start gap-4">
     <div class="text-3xl">🟨</div>
     <div>
@@ -154,7 +154,7 @@ limit 1
   </div>
 </a>
 
-<a href="/glossary" class="block no-underline rounded-xl border border-gray-200 bg-white p-6 hover:border-blue-500 hover:shadow-lg transition-all duration-200 group shadow-sm">
+<a href="/glossary" class="flex flex-col justify-center no-underline rounded-xl border border-gray-200 bg-white p-6 hover:border-blue-500 hover:shadow-lg transition-all duration-200 group shadow-sm h-full">
   <div class="flex items-start gap-4">
     <div class="text-3xl">📖</div>
     <div>
@@ -164,7 +164,7 @@ limit 1
   </div>
 </a>
 
-<a href="/about" class="block no-underline rounded-xl border border-gray-200 bg-white p-6 hover:border-blue-500 hover:shadow-lg transition-all duration-200 group shadow-sm">
+<a href="/about" class="flex flex-col justify-center no-underline rounded-xl border border-gray-200 bg-white p-6 hover:border-blue-500 hover:shadow-lg transition-all duration-200 group shadow-sm h-full">
   <div class="flex items-start gap-4">
     <div class="text-3xl">👤</div>
     <div>


### PR DESCRIPTION
## Summary
- All nav cards are now uniform height (7.5rem fixed rows) with vertically centered content
- KPI tiles styled with gray background to signal they are non-interactive data displays
- Added "EXPLORE" section label with hairline separator between KPI tiles and nav cards
- Each nav card now has an animated `→` arrow that slides blue on hover — makes clickability unmistakable
- Shortened League/Team/Player Intelligence descriptions to single line to keep rows visually consistent

## Test plan
- [ ] Home page cards are all the same height
- [ ] KPI tiles look visually distinct from nav cards (gray vs white)
- [ ] Hovering a nav card turns the title blue and slides the arrow right
- [ ] All 10 nav cards link to correct pages
- [ ] Looks good on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)