### PR TITLE
feat(sources): exclude seasons before 2020/21 from dashboard

### DIFF
--- a/dashboards/sources/superligaen/mart_match_facts.sql
+++ b/dashboards/sources/superligaen/mart_match_facts.sql
@@ -108,3 +108,4 @@ LEFT JOIN player_agg                         pa  ON pa.match_sk         = f.matc
                                                 AND pa.team_sk          = f.team_sk
 WHERE f.match_result_sk > 0
   AND m.match_round_number IS NOT NULL
+  AND d.season >= '2020/21'

--- a/dashboards/sources/superligaen/mart_player_facts.sql
+++ b/dashboards/sources/superligaen/mart_player_facts.sql
@@ -82,3 +82,4 @@ JOIN superligaen.gold.dim_appearance_type     at_dim ON at_dim.appearance_type_s
 WHERE f.player_sk > 0
   AND f.match_result_sk > 0
   AND m.match_round_number IS NOT NULL
+  AND d.season >= '2020/21'


### PR DESCRIPTION
## Summary
- Added `AND d.season >= '2020/21'` to the `WHERE` clause of both Evidence source queries (`mart_match_facts.sql` and `mart_player_facts.sql`)
- Filters out all pre-2020/21 data at the source level so no older seasons reach any dashboard page

## Test plan
- [ ] Season filter dropdown on any page shows 2020/21 as the earliest option
- [ ] No pre-2020/21 data appears anywhere in the dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)