### PR TITLE
feat(pwa): add mobile install guide to about page, fix short_name

### DIFF
--- a/dashboards/components/InstallGuide.svelte
+++ b/dashboards/components/InstallGuide.svelte
@@ -1,0 +1,60 @@
+<script>
+  import { onMount } from 'svelte';
+
+  let platform = 'other';
+
+  onMount(() => {
+    const ua = navigator.userAgent;
+    if (/iphone|ipad|ipod/i.test(ua)) {
+      platform = 'ios';
+    } else if (/android/i.test(ua)) {
+      platform = 'android';
+    }
+  });
+</script>
+
+<div class="rounded-xl border border-blue-100 bg-blue-50 p-5 mt-2">
+
+  {#if platform === 'ios'}
+    <p class="text-sm font-semibold text-blue-700 mb-3">📱 You're on iOS — follow these steps in Safari:</p>
+    <ol class="text-sm text-gray-700 space-y-2 list-none pl-0">
+      <li class="flex items-start gap-2"><span class="font-bold text-blue-600 shrink-0">1.</span> Open this page in <strong>Safari</strong> (not Chrome or Firefox)</li>
+      <li class="flex items-start gap-2"><span class="font-bold text-blue-600 shrink-0">2.</span> Tap the <strong>Share</strong> button <span class="inline-block px-1.5 py-0.5 bg-gray-200 rounded text-xs font-mono">⎙</span> at the bottom of the screen</li>
+      <li class="flex items-start gap-2"><span class="font-bold text-blue-600 shrink-0">3.</span> Scroll down and tap <strong>Add to Home Screen</strong></li>
+      <li class="flex items-start gap-2"><span class="font-bold text-blue-600 shrink-0">4.</span> Tap <strong>Add</strong> — the app appears on your home screen</li>
+    </ol>
+
+  {:else if platform === 'android'}
+    <p class="text-sm font-semibold text-blue-700 mb-3">📱 You're on Android — follow these steps in Chrome:</p>
+    <ol class="text-sm text-gray-700 space-y-2 list-none pl-0">
+      <li class="flex items-start gap-2"><span class="font-bold text-blue-600 shrink-0">1.</span> Open this page in <strong>Chrome</strong></li>
+      <li class="flex items-start gap-2"><span class="font-bold text-blue-600 shrink-0">2.</span> Tap the <strong>⋮</strong> menu in the top-right corner</li>
+      <li class="flex items-start gap-2"><span class="font-bold text-blue-600 shrink-0">3.</span> Tap <strong>Add to Home screen</strong></li>
+      <li class="flex items-start gap-2"><span class="font-bold text-blue-600 shrink-0">4.</span> Tap <strong>Add</strong> — the app appears on your home screen</li>
+    </ol>
+
+  {:else}
+    <p class="text-sm font-semibold text-blue-700 mb-3">📱 Open this page on your phone to install the app:</p>
+    <div class="grid grid-cols-1 sm:grid-cols-2 gap-4 text-sm text-gray-700">
+      <div>
+        <p class="font-semibold mb-1">iOS (Safari)</p>
+        <ol class="space-y-1 list-none pl-0">
+          <li>1. Open in <strong>Safari</strong></li>
+          <li>2. Tap <strong>Share ⎙</strong></li>
+          <li>3. Tap <strong>Add to Home Screen</strong></li>
+          <li>4. Tap <strong>Add</strong></li>
+        </ol>
+      </div>
+      <div>
+        <p class="font-semibold mb-1">Android (Chrome)</p>
+        <ol class="space-y-1 list-none pl-0">
+          <li>1. Open in <strong>Chrome</strong></li>
+          <li>2. Tap <strong>⋮</strong> menu</li>
+          <li>3. Tap <strong>Add to Home screen</strong></li>
+          <li>4. Tap <strong>Add</strong></li>
+        </ol>
+      </div>
+    </div>
+  {/if}
+
+</div>

--- a/dashboards/pages/about.md
+++ b/dashboards/pages/about.md
@@ -49,6 +49,12 @@ Have a suggestion for the dashboard? Open an issue on GitHub — no account need
 </a>
 </div>
 
+## Install on Mobile
+
+Get quick access to Superligaen Analytics directly from your phone's home screen — no app store needed.
+
+<InstallGuide />
+
 ## Connect
 
 <div class="mt-2">

--- a/dashboards/pages/about.md
+++ b/dashboards/pages/about.md
@@ -4,6 +4,10 @@ hide_toc: true
 title: About This Project
 ---
 
+<script>
+  import InstallGuide from '../../components/InstallGuide.svelte';
+</script>
+
 ## The Idea
 
 I am **Salih Ugur Kimilli**, a data engineer who loves turning raw data into insights. I wanted to build a real end-to-end data engineering project using only free, open-source tools — no vendor lock-in, no cloud bills. Around the same time, I had recently moved to Denmark and realised I knew very little about Danish football.

--- a/dashboards/pages/manifest.webmanifest/+server.js
+++ b/dashboards/pages/manifest.webmanifest/+server.js
@@ -2,7 +2,7 @@ export const prerender = true;
 
 const webmanifest = {
 	name: 'Superliga Analytics',
-	short_name: 'Superliga',
+	short_name: 'Superligaen',
 	description: 'Danish Premier Football League — standings, match results, player & team intelligence.',
 	start_url: '/',
 	display: 'standalone',


### PR DESCRIPTION
## Summary

- Adds `InstallGuide.svelte` component that detects iOS / Android and shows platform-specific "Add to Home Screen" steps. Desktop visitors see both sets of instructions side by side
- Adds a new **Install on Mobile** section to the About page (after Share an Idea) using the component
- Fixes PWA `short_name` from `Superliga` → `Superligaen` (home screen label)

## Test plan
- [ ] Open `/about` on an iOS device — confirm iOS-specific steps are shown
- [ ] Open `/about` on an Android device — confirm Android-specific steps are shown
- [ ] Open `/about` on desktop — confirm both columns are shown
- [ ] Install app and verify home screen label reads "Superligaen"

🤖 Generated with [Claude Code](https://claude.com/claude-code)