### PR TITLE
feat(pwa): add caching strategy to service worker for cellular performance

### DIFF
--- a/dashboards/pages/+layout.svelte
+++ b/dashboards/pages/+layout.svelte
@@ -13,6 +13,9 @@
   });
 
   onMount(() => {
+    if ('serviceWorker' in navigator) {
+      navigator.serviceWorker.register('/service-worker.js');
+    }
     inject();
     const script = document.createElement('script');
     script.defer = true;

--- a/dashboards/static/service-worker.js
+++ b/dashboards/static/service-worker.js
@@ -1,0 +1,66 @@
+const CACHE_VERSION = 'v1';
+const DATA_CACHE = `data-${CACHE_VERSION}`;
+const ASSET_CACHE = `assets-${CACHE_VERSION}`;
+const DATA_MAX_AGE = 24 * 60 * 60 * 1000; // 24 hours in ms
+
+self.addEventListener('install', () => self.skipWaiting());
+
+self.addEventListener('activate', (e) => {
+  e.waitUntil(
+    caches.keys().then((keys) =>
+      Promise.all(
+        keys
+          .filter((k) => k !== DATA_CACHE && k !== ASSET_CACHE)
+          .map((k) => caches.delete(k))
+      )
+    ).then(() => self.clients.claim())
+  );
+});
+
+self.addEventListener('fetch', (e) => {
+  const { request } = e;
+  const url = new URL(request.url);
+
+  // Only handle same-origin GET requests
+  if (request.method !== 'GET' || url.origin !== self.location.origin) return;
+
+  if (url.pathname.startsWith('/data/')) {
+    e.respondWith(cacheFirstWithExpiry(request, DATA_CACHE, DATA_MAX_AGE));
+  } else if (url.pathname.startsWith('/_app/')) {
+    e.respondWith(cacheFirst(request, ASSET_CACHE));
+  }
+  // All other requests (HTML, third-party) go straight to network
+});
+
+async function cacheFirst(request, cacheName) {
+  const cached = await caches.match(request);
+  if (cached) return cached;
+  const response = await fetch(request);
+  if (response.ok) {
+    const cache = await caches.open(cacheName);
+    cache.put(request, response.clone());
+  }
+  return response;
+}
+
+async function cacheFirstWithExpiry(request, cacheName, maxAge) {
+  const cache = await caches.open(cacheName);
+  const cached = await cache.match(request);
+  if (cached) {
+    const cachedAt = cached.headers.get('sw-cached-at');
+    if (cachedAt && Date.now() - Number(cachedAt) < maxAge) return cached;
+  }
+  const response = await fetch(request);
+  if (response.ok) {
+    const headers = new Headers(response.headers);
+    headers.set('sw-cached-at', String(Date.now()));
+    const stamped = new Response(await response.arrayBuffer(), {
+      status: response.status,
+      statusText: response.statusText,
+      headers,
+    });
+    cache.put(request, stamped);
+    return stamped;
+  }
+  return cached ?? response; // fall back to stale cache if fetch fails
+}


### PR DESCRIPTION
## Summary

- The previous service worker forwarded every request directly to the network, adding overhead with no benefit — noticeably slow on cellular (high latency)
- Parquet data files (`/data/**`) are now cached for 24 hours, which is safe since data only updates at night
- Hashed JS/CSS/WASM assets (`/_app/**`) are cached indefinitely — their URLs change on each deploy so stale content is never served
- HTML pages and third-party scripts (Vercel analytics, Cloudflare beacon) still go straight to the network
- Stale parquet cache is used as fallback if the network is unavailable

## Test plan

- [ ] First visit: network requests behave as before
- [ ] Second visit on same day: parquet and JS assets load from cache (DevTools → Application → Cache Storage)
- [ ] Standings/stats data appears correct after a nightly data push
- [ ] Deploying a new build invalidates `/_app/**` assets (new hashed filenames)

🤖 Generated with [Claude Code](https://claude.com/claude-code)