### PR TITLE
revert(pwa): remove service worker cleanup code

### DIFF
--- a/dashboards/pages/+layout.svelte
+++ b/dashboards/pages/+layout.svelte
@@ -13,9 +13,6 @@
   });
 
   onMount(() => {
-    if ('serviceWorker' in navigator) {
-      navigator.serviceWorker.getRegistrations().then((regs) => regs.forEach((r) => r.unregister()));
-    }
     inject();
     const script = document.createElement('script');
     script.defer = true;


### PR DESCRIPTION
## Summary

- Reverts all service worker changes from the cellular performance investigation (PRs #229 and #230)
- The slowness on cellular turned out to be inherent to Evidence's DuckDB-WASM architecture (~35MB WASM download), not caused by any code change
- This brings `+layout.svelte` back to its pre-investigation state

🤖 Generated with [Claude Code](https://claude.com/claude-code)