### PR TITLE
fix(dim_date): use API is_current flag instead of date range

### DIFF
--- a/dbt/models/gold/dims/dim_date.sql
+++ b/dbt/models/gold/dims/dim_date.sql
@@ -2,13 +2,9 @@ WITH season_ranges AS (
     SELECT
         name          AS season,
         starting_at::DATE AS season_start,
-        ending_at::DATE   AS season_end
+        ending_at::DATE   AS season_end,
+        is_current
     FROM {{ ref('seasons') }}
-),
-current_season AS (
-    SELECT season
-    FROM season_ranges
-    WHERE CURRENT_DATE BETWEEN season_start AND season_end
 )
 SELECT
     (year(d) * 10000 + month(d) * 100 + day(d))::INTEGER AS date_sk,
@@ -22,6 +18,6 @@ SELECT
     dayname(d)                                            AS day_name,
     CASE WHEN isodow(d) IN (6, 7) THEN 'Yes' ELSE 'No' END AS is_weekend,
     LEFT(sr.season, 4) || '/' || RIGHT(sr.season, 2)      AS season,
-    sr.season = (SELECT season FROM current_season)        AS is_current_season
+    COALESCE(sr.is_current, false)                         AS is_current_season
 FROM generate_series(DATE '2010-01-01', DATE '2030-12-31', INTERVAL '1 day') t(d)
 LEFT JOIN season_ranges sr ON d::DATE BETWEEN sr.season_start AND sr.season_end


### PR DESCRIPTION
## Summary
- `is_current_season` was derived from `CURRENT_DATE BETWEEN season_start AND season_end` — this broke on 2026-05-18, one day after the 2025/26 season's `ending_at = 2026-05-17`
- Switched to using the `is_current` boolean from the Sportmonks API (already available in the `seasons` silver model), which is more reliable since Sportmonks controls the transition
- Home page KPI cards were returning empty because all rows had `is_current_season = false`

## Test plan
- [ ] Run gold layer dbt models on GitHub Actions (`dim_date` + downstream)
- [ ] Verify KPI cards show data on production after Vercel redeploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)