### PR TITLE
fix(upcoming-matches): show empty state when no fixtures are scheduled

### DIFF
--- a/dashboards/pages/upcoming-matches.md
+++ b/dashboards/pages/upcoming-matches.md
@@ -11,6 +11,8 @@ where result = 'Pending'
 order by team_name asc
 ```
 
+{#if teams.length > 0}
+
 <Dropdown data={teams} name=team value=team_name label=team_name order="team_name asc" multiple=true selectAllByDefault=true />
 
 ```sql upcoming
@@ -275,3 +277,13 @@ limit 5
 </div>
 
 </div>
+
+{:else}
+
+<div class="flex flex-col items-center justify-center py-24 text-center">
+  <div class="text-5xl mb-4">📅</div>
+  <div class="text-xl font-bold text-gray-700 mb-2">No Upcoming Fixtures</div>
+  <div class="text-gray-400 text-sm">There are no scheduled matches at the moment. Check back soon.</div>
+</div>
+
+{/if}


### PR DESCRIPTION
## Summary
- When there are no pending matches, the `teams` dropdown is empty, causing the DataTable to render as a blank gray box and all match analysis template expressions (e.g. `{match_info[0].home_team_short}`) to show `undefined`
- Wrapped the entire page content in `{#if teams.length > 0}` so everything is hidden when there's no data
- Shows a friendly "No Upcoming Fixtures" empty state instead

## Test plan
- [ ] Verify the empty state message renders correctly when no pending matches exist
- [ ] Verify the full page works as expected once upcoming fixtures are available

🤖 Generated with [Claude Code](https://claude.com/claude-code)