### PR TITLE
feat(radar-chart): add title to TeamRadar component

### DIFF
--- a/dashboards/components/TeamRadar.svelte
+++ b/dashboards/components/TeamRadar.svelte
@@ -1,5 +1,6 @@
 <script>
   export let data = [];
+  export let title = '';
   export let metrics = [
     { key: 'attack_pct',      label: 'Attack Score'     },
     { key: 'passing_pct',     label: 'Passing Score'    },
@@ -49,6 +50,9 @@
 </script>
 
 <div style="display:flex;flex-direction:column;align-items:center;">
+  {#if title}
+    <p style="font-size:0.875rem;font-weight:600;color:#374151;margin:0 0 0.5rem 0;align-self:flex-start;">{title}</p>
+  {/if}
   <svg viewBox="0 0 {W} {H}" style="width:100%;max-width:560px;">
 
     <!-- Background rings -->

--- a/dashboards/pages/league-analytics.md
+++ b/dashboards/pages/league-analytics.md
@@ -543,7 +543,7 @@ select * from ranked where team_name in ${inputs.team.value} order by team_name
 
 <div>
 
-<TeamRadar data={radar_data} />
+<TeamRadar data={radar_data} title="Performance Radar" />
 
 </div>
 

--- a/dashboards/pages/player-analytics.md
+++ b/dashboards/pages/player-analytics.md
@@ -418,7 +418,7 @@ select * from ranked where player_name = '${inputs.player.value}'
 
   </div>
 
-  <TeamRadar data={league_context} metrics={playerMetrics} title="League Context" />
+  <TeamRadar data={league_context} metrics={playerMetrics} />
 
 </div>
 {/each}

--- a/dashboards/pages/player-analytics.md
+++ b/dashboards/pages/player-analytics.md
@@ -418,7 +418,7 @@ select * from ranked where player_name = '${inputs.player.value}'
 
   </div>
 
-  <TeamRadar data={league_context} metrics={playerMetrics} />
+  <TeamRadar data={league_context} metrics={playerMetrics} title="League Context" />
 
 </div>
 {/each}


### PR DESCRIPTION
Closes #241

## Summary
- Adds an optional `title` prop to `TeamRadar.svelte`
- League Analytics radar: "Performance Radar"
- Player Analytics radar: "League Context"
- No title = no element rendered (backwards compatible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)