### PR TITLE
feat(stadium): move Surface Analysis to last section

### DIFF
--- a/dashboards/pages/stadium-analytics.md
+++ b/dashboards/pages/stadium-analytics.md
@@ -209,6 +209,51 @@ from (
 
 ---
 
+## Full Fortress Ranking
+
+*Home record at each stadium. A true fortress keeps opponents at bay.*
+
+<BarChart
+    data={fortress_ranking}
+    x=stadium_name
+    y=home_win_pct
+    title="Home Win Rate by Stadium — {inputs.season.value}"
+    yAxisTitle="Home Win %"
+    yFmt='0.0'
+    sort=true
+    swapXY=true
+    colorPalette={['#3b82f6']}
+/>
+
+<div class="hidden md:block mt-4">
+<DataTable data={fortress_ranking} rows=20>
+    <Column id=home_team_col            title="Home Team"               contentType=html />
+    <Column id=stadium_name             title="Stadium"                 wrap=true />
+    <Column id=stadium_capacity         title="Capacity"                align=center />
+    <Column id=home_win_pct             title="Win %"                   fmt='0.0"%"' contentType=colorscale colorPalette={['white','#3b82f6']} />
+    <Column id=home_wins                title="W"                       align=center />
+    <Column id=home_draws               title="D"                       align=center />
+    <Column id=home_losses              title="L"                       align=center />
+    <Column id=goals_scored_per_match   title="Goals Scored/Match"      />
+    <Column id=goals_conceded_per_match title="Goals Conceded/Match"    />
+</DataTable>
+</div>
+<div class="block md:hidden mt-4">
+<DataTable data={fortress_ranking} rows=20>
+    <Column id=home_team_col_mobile     title="Home Team"               contentType=html width="max-content" />
+    <Column id=stadium_name             title="Stadium"                 wrap=true />
+    <Column id=stadium_capacity         title="Capacity"                align=center />
+    <Column id=home_win_pct             title="Win %"                   fmt='0.0"%"' contentType=colorscale colorPalette={['white','#3b82f6']} />
+    <Column id=home_wins                title="W"                       align=center />
+    <Column id=home_draws               title="D"                       align=center />
+    <Column id=home_losses              title="L"                       align=center />
+    <Column id=goals_scored_per_match   title="Goals Scored/Match"      />
+    <Column id=goals_conceded_per_match title="Goals Conceded/Match"    />
+</DataTable>
+</div>
+
+---
+
 ## Surface Analysis: Grass vs Artificial Turf
 
 *How does the playing surface shape the way football is played?*
@@ -262,49 +307,3 @@ from (
     <Column id=fouls_per_match  title="Fouls/Match"       contentType=colorscale colorPalette={['white','#f97316']} />
     <Column id=goals_per_match  title="Goals/Match"      fmt='0.00'   contentType=colorscale colorPalette={['white','#f59e0b']} />
 </DataTable>
-
----
-
-## Full Fortress Ranking
-
-*Home record at each stadium. A true fortress keeps opponents at bay.*
-
-<BarChart
-    data={fortress_ranking}
-    x=stadium_name
-    y=home_win_pct
-    title="Home Win Rate by Stadium — {inputs.season.value}"
-    yAxisTitle="Home Win %"
-    yFmt='0.0'
-    sort=true
-    swapXY=true
-    colorPalette={['#3b82f6']}
-/>
-
-<div class="hidden md:block mt-4">
-<DataTable data={fortress_ranking} rows=20>
-    <Column id=home_team_col            title="Home Team"               contentType=html />
-    <Column id=stadium_name             title="Stadium"                 wrap=true />
-    <Column id=stadium_capacity         title="Capacity"                align=center />
-    <Column id=home_win_pct             title="Win %"                   fmt='0.0"%"' contentType=colorscale colorPalette={['white','#3b82f6']} />
-    <Column id=home_wins                title="W"                       align=center />
-    <Column id=home_draws               title="D"                       align=center />
-    <Column id=home_losses              title="L"                       align=center />
-    <Column id=goals_scored_per_match   title="Goals Scored/Match"      />
-    <Column id=goals_conceded_per_match title="Goals Conceded/Match"    />
-</DataTable>
-</div>
-<div class="block md:hidden mt-4">
-<DataTable data={fortress_ranking} rows=20>
-    <Column id=home_team_col_mobile     title="Home Team"               contentType=html width="max-content" />
-    <Column id=stadium_name             title="Stadium"                 wrap=true />
-    <Column id=stadium_capacity         title="Capacity"                align=center />
-    <Column id=home_win_pct             title="Win %"                   fmt='0.0"%"' contentType=colorscale colorPalette={['white','#3b82f6']} />
-    <Column id=home_wins                title="W"                       align=center />
-    <Column id=home_draws               title="D"                       align=center />
-    <Column id=home_losses              title="L"                       align=center />
-    <Column id=goals_scored_per_match   title="Goals Scored/Match"      />
-    <Column id=goals_conceded_per_match title="Goals Conceded/Match"    />
-</DataTable>
-</div>
-

--- a/dashboards/pages/stadium-analytics.md
+++ b/dashboards/pages/stadium-analytics.md
@@ -77,7 +77,12 @@ where result in ('Win', 'Draw', 'Loss')
   and stadium_longitude between 7.5 and 15.5
   and season = '${inputs.season.value}'
 group by stadium_surface
-order by matches desc
+order by
+    case
+        when stadium_surface ilike '%grass%' or stadium_surface ilike '%natural%' then 1
+        when stadium_surface ilike '%artif%' or stadium_surface ilike '%turf%'    then 2
+        else 3
+    end
 ```
 
 ```sql fortress_ranking
@@ -267,6 +272,7 @@ from (
     title="Pass Accuracy % by Surface"
     yAxisTitle="Pass Accuracy %"
     colorPalette={['#22c55e','#6366f1','#f59e0b']}
+    sort=false
 />
 
 <BarChart
@@ -276,6 +282,7 @@ from (
     title="Cross Accuracy % by Surface"
     yAxisTitle="Cross Accuracy %"
     colorPalette={['#22c55e','#6366f1','#f59e0b']}
+    sort=false
 />
 
 <BarChart
@@ -285,6 +292,7 @@ from (
     title="Shot Conversion % by Surface"
     yAxisTitle="Shot Conversion %"
     colorPalette={['#22c55e','#6366f1','#f59e0b']}
+    sort=false
 />
 
 <BarChart
@@ -294,6 +302,7 @@ from (
     title="Fouls per Match by Surface"
     yAxisTitle="Fouls / Match"
     colorPalette={['#22c55e','#6366f1','#f59e0b']}
+    sort=false
 />
 
 </div>


### PR DESCRIPTION
Closes #238

## Summary
- Moves "Surface Analysis: Grass vs Artificial Turf" to the last section on the Stadium Intelligence page
- New order: Stadium Map → Top 3 Fortress Stadiums → Full Fortress Ranking → Surface Analysis
- Fixed x-axis ordering: SQL now orders Grass before Artificial Turf consistently across all 4 bar charts (`sort=false` added to prevent per-chart auto-sorting)

🤖 Generated with [Claude Code](https://claude.com/claude-code)