### PR TITLE
feat(player): player analytics page overhaul

### DIFF
--- a/dashboards/pages/player-analytics.md
+++ b/dashboards/pages/player-analytics.md
@@ -167,9 +167,12 @@ group by player_name, player_photo, player_nationality, player_detailed_position
 
 ```sql player_trend
 select
-    match_round_number                             as round,
-    goals_scored                                   as goals,
-    assists,
+    match_round_number                                                          as round,
+    goals_scored,
+    big_chances_created,
+    tackles + interceptions                                                     as tkl_int,
+    round(100.0 * passes_accurate / nullif(passes_total, 0), 1)                as pass_acc,
+    round(100.0 * duels_won       / nullif(duels_total,   0), 1)               as duel_win,
     rating
 from superligaen.mart_player_facts
 where season = '${inputs.season.value}'
@@ -473,27 +476,83 @@ select * from ranked where player_name = '${inputs.player.value}'
 
 <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-6">
 
-<LineChart
+<BarChart
     data={player_trend}
     x=round
-    y=rating
+    y=goals_scored
+    y2=rating
+    y2SeriesType=line
+    title="Attacking — Goals per Match"
     xAxisTitle="Round"
-    yAxisTitle="Match Rating"
-    title="Rating per Match"
-    lineColor="#8b5cf6"
+    yAxisTitle="Goals"
+    y2AxisTitle="Rating"
+    colorPalette={['#fbbf24','#94a3b8']}
+    y2Min=0
+    y2Max=10
+    chartAreaHeight=220
+    echartsOptions={{yAxis: [{minInterval: 1, max: 'dataMax'}, {min: 0, max: 10}]}}
+/>
+
+<BarChart
+    data={player_trend}
+    x=round
+    y=big_chances_created
+    y2=rating
+    y2SeriesType=line
+    title="Creativity — Big Chances Created"
+    xAxisTitle="Round"
+    yAxisTitle="Big Chances"
+    y2AxisTitle="Rating"
+    colorPalette={['#38bdf8','#94a3b8']}
+    chartAreaHeight=220
+    echartsOptions={{yAxis: [{minInterval: 1, max: 'dataMax'}, {min: 0, max: 10}]}}
+/>
+
+<BarChart
+    data={player_trend}
+    x=round
+    y=pass_acc
+    y2=rating
+    y2SeriesType=line
+    title="Possession — Pass Accuracy %"
+    xAxisTitle="Round"
+    yAxisTitle="Pass Acc %"
+    y2AxisTitle="Rating"
+    colorPalette={['#6366f1','#94a3b8']}
+    y2Min=0
+    y2Max=10
     chartAreaHeight=220
 />
 
 <BarChart
     data={player_trend}
     x=round
-    y={['goals','assists']}
+    y=tkl_int
+    y2=rating
+    y2SeriesType=line
+    title="Defending — Tackles + Interceptions"
     xAxisTitle="Round"
-    yAxisTitle="Contributions"
-    title="Goals & Assists per Match"
-    colorPalette={['#f59e0b','#3b82f6']}
+    yAxisTitle="Tkl + Int"
+    y2AxisTitle="Rating"
+    colorPalette={['#14b8a6','#94a3b8']}
     chartAreaHeight=220
-    stacked=true
+    echartsOptions={{yAxis: [{minInterval: 1, max: 'dataMax'}, {min: 0, max: 10}]}}
+/>
+
+<BarChart
+    data={player_trend}
+    x=round
+    y=duel_win
+    y2=rating
+    y2SeriesType=line
+    title="Physicality — Duel Win %"
+    xAxisTitle="Round"
+    yAxisTitle="Duel Win %"
+    y2AxisTitle="Rating"
+    colorPalette={['#fb923c','#94a3b8']}
+    y2Min=0
+    y2Max=10
+    chartAreaHeight=220
 />
 
 </div>

--- a/dashboards/pages/player-analytics.md
+++ b/dashboards/pages/player-analytics.md
@@ -407,7 +407,7 @@ select * from ranked where player_name = '${inputs.player.value}'
 
 ## League Standing
 
-*Percentile rank among all players with 450+ minutes in {inputs.season.value}. 100 = best in the league.*
+*Composite percentile score among all players with 450+ minutes in {inputs.season.value}. Each axis combines multiple rate metrics weighted by their importance to that dimension. Higher = better relative to the league.*
 
 {#each league_context as lc}
 <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-6 items-center">

--- a/dashboards/pages/player-analytics.md
+++ b/dashboards/pages/player-analytics.md
@@ -8,12 +8,12 @@ title: Player Intelligence
   import TeamRadar from '../../components/TeamRadar.svelte';
 
   const playerMetrics = [
-    { key: 'goals_per90_pct',   label: 'Attack Score'     },
-    { key: 'assists_per90_pct', label: 'Creativity Score' },
-    { key: 'pass_pct',          label: 'Passing Score'    },
-    { key: 'shot_conv_pct',     label: 'Efficiency Score' },
-    { key: 'rating_pct',        label: 'Overall Score'    },
-    { key: 'defense_pct',       label: 'Defensive Score'  },
+    { key: 'attacking_pct',   label: 'Attacking'   },
+    { key: 'creativity_pct',  label: 'Creativity'  },
+    { key: 'possession_pct',  label: 'Possession'  },
+    { key: 'defending_pct',   label: 'Defending'   },
+    { key: 'physicality_pct', label: 'Physicality' },
+    { key: 'impact_pct',      label: 'Impact'      },
   ];
 </script>
 
@@ -67,15 +67,15 @@ with base as (
         player_name,
         player_photo,
         player_position,
-        max(team_name)                                  as team_name,
-        max(team_logo)                                  as team_logo,
-        count(distinct match_id)                        as matches,
-        sum(goals_scored)                               as goals,
-        sum(assists)                                    as assists,
-        sum(dribbles_completed)                         as dribbles,
-        sum(tackles) + sum(interceptions)               as defensive_actions,
-        sum(crosses_total)                              as crosses,
-        sum(passes_accurate)                            as passes
+        max(team_name)                                              as team_name,
+        max(team_logo)                                             as team_logo,
+        count(distinct match_id)                                   as matches,
+        sum(goals_scored)                                          as goals,
+        sum(assists)                                               as assists,
+        sum(dribbles_completed)                                    as dribbles,
+        sum(tackles_won) + sum(interceptions) + sum(balls_recovered) as defensive_actions,
+        sum(key_passes) + sum(big_chances_created)                 as chances_created,
+        round(avg(rating), 2)                                      as avg_rating
     from superligaen.mart_player_facts
     where season = '${inputs.season.value}'
       and ('All' in ${inputs.team.value} OR team_name in ${inputs.team.value})
@@ -85,26 +85,26 @@ with base as (
 )
 select category, player_name, player_photo, player_position, team_name, team_logo, stat_value, stat_label
 from (
-    select 'Top Scorer'   as category, player_name, player_photo, player_position, team_name, team_logo, goals::int             as stat_value, 'Goals'        as stat_label, row_number() over (order by goals             desc) as rn from base
+    select 'Top Scorer'   as category, player_name, player_photo, player_position, team_name, team_logo, goals::int               as stat_value, 'Goals'          as stat_label, row_number() over (order by goals             desc) as rn from base
     union all
-    select 'Top Assister',              player_name, player_photo, player_position, team_name, team_logo, assists::int,              'Assists',      row_number() over (order by assists           desc) from base
+    select 'Top Assister',              player_name, player_photo, player_position, team_name, team_logo, assists::int,                'Assists',        row_number() over (order by assists           desc) from base
     union all
-    select 'Top Dribbler',              player_name, player_photo, player_position, team_name, team_logo, dribbles::int,             'Dribbles',     row_number() over (order by dribbles          desc) from base
+    select 'Top Creator',               player_name, player_photo, player_position, team_name, team_logo, chances_created::int,        'KP+BC Created',  row_number() over (order by chances_created   desc) from base
     union all
-    select 'Top Defender',              player_name, player_photo, player_position, team_name, team_logo, defensive_actions::int,    'Tkl+Int',      row_number() over (order by defensive_actions desc) from base
+    select 'Top Defender',              player_name, player_photo, player_position, team_name, team_logo, defensive_actions::int,      'Tkl+Int+Rec',    row_number() over (order by defensive_actions desc) from base
     union all
-    select 'Top Crosser',               player_name, player_photo, player_position, team_name, team_logo, crosses::int,              'Crosses',      row_number() over (order by crosses           desc) from base
+    select 'Top Dribbler',              player_name, player_photo, player_position, team_name, team_logo, dribbles::int,               'Dribbles',       row_number() over (order by dribbles          desc) from base
     union all
-    select 'Top Passer',                player_name, player_photo, player_position, team_name, team_logo, passes::int,               'Acc. Passes',  row_number() over (order by passes            desc) from base
+    select 'Top Rated',                 player_name, player_photo, player_position, team_name, team_logo, avg_rating::double,          'Avg Rating',     row_number() over (order by avg_rating        desc) from base where matches >= 5
 )
 where rn = 1
 order by case category
     when 'Top Scorer'   then 1
     when 'Top Assister' then 2
-    when 'Top Dribbler' then 3
+    when 'Top Creator'  then 3
     when 'Top Defender' then 4
-    when 'Top Crosser'  then 5
-    when 'Top Passer'   then 6
+    when 'Top Dribbler' then 5
+    when 'Top Rated'    then 6
 end
 ```
 
@@ -192,14 +192,34 @@ order by match_date desc
 with base as (
     select
         player_name,
-        sum(goals_scored)                                                          as goals,
-        sum(assists)                                                               as assists,
-        avg(rating)                                                                as avg_rating,
-        sum(goals_scored) * 90.0 / nullif(sum(minutes_played), 0)                 as goals_per90,
-        sum(assists)      * 90.0 / nullif(sum(minutes_played), 0)                 as assists_per90,
-        100.0 * sum(passes_accurate) / nullif(sum(passes_total),  0)              as pass_accuracy,
-        100.0 * sum(goals_scored)    / nullif(sum(shots_total),   0)              as shot_conversion,
-        sum(tackles)      * 90.0 / nullif(sum(minutes_played), 0)                 as tackles_per90
+        -- Attacking
+        sum(goals_scored)         * 90.0 / nullif(sum(minutes_played), 0)                           as goals_per90,
+        sum(shots_on_target)      * 90.0 / nullif(sum(minutes_played), 0)                           as sot_per90,
+        100.0 * sum(goals_scored)          / nullif(sum(shots_total), 0)                            as shot_acc_pct,
+        sum(woodwork_hits)        * 90.0 / nullif(sum(minutes_played), 0)                           as woodwork_per90,
+        -- Creativity
+        sum(big_chances_created)  * 90.0 / nullif(sum(minutes_played), 0)                           as big_chances_per90,
+        sum(chances_created)      * 90.0 / nullif(sum(minutes_played), 0)                           as chances_per90,
+        sum(key_passes)           * 90.0 / nullif(sum(minutes_played), 0)                           as key_passes_per90,
+        100.0 * sum(big_chances_created)   / nullif(sum(chances_created), 0)                        as chance_quality_pct,
+        100.0 * sum(crosses_accurate)      / nullif(sum(crosses_total), 0)                          as cross_acc_pct,
+        sum(passes_final_third)   * 90.0 / nullif(sum(minutes_played), 0)                           as passes_final_third_per90,
+        -- Possession
+        100.0 * sum(passes_accurate)       / nullif(sum(passes_total), 0)                           as pass_acc_pct,
+        100.0 * sum(dribbles_completed)    / nullif(sum(dribbles_attempts), 0)                      as dribble_success_pct,
+        100.0 * sum(long_balls_won)        / nullif(sum(long_balls), 0)                             as long_ball_success_pct,
+        -- Defending
+        (sum(tackles) + sum(interceptions)) * 90.0 / nullif(sum(minutes_played), 0)                as tkl_int_per90,
+        100.0 * sum(tackles_won)           / nullif(sum(tackles), 0)                               as tackle_success_pct,
+        sum(balls_recovered)      * 90.0 / nullif(sum(minutes_played), 0)                           as balls_recovered_per90,
+        sum(times_dribbled_past)  * 90.0 / nullif(sum(minutes_played), 0)                           as times_dribbled_past_per90,
+        sum(errors_leading_to_goal) * 90.0 / nullif(sum(minutes_played), 0)                         as errors_per90,
+        -- Physicality
+        100.0 * sum(duels_won)             / nullif(sum(duels_total), 0)                            as duel_win_pct,
+        sum(fouls_drawn)          * 90.0 / nullif(sum(minutes_played), 0)                           as fouls_drawn_per90,
+        100.0 * sum(aerials_won)           / nullif(sum(aerials_won) + sum(aerials_lost), 0)        as aerial_success_pct,
+        -- Impact
+        avg(rating)                                                                                  as avg_rating
     from superligaen.mart_player_facts
     where season = '${inputs.season.value}'
       and result in ('Win', 'Draw', 'Loss')
@@ -209,14 +229,34 @@ with base as (
 ranked as (
     select
         player_name,
-        round(percent_rank() over (order by goals)           * 100) as goals_pct,
-        round(percent_rank() over (order by assists)         * 100) as assists_pct,
-        round(percent_rank() over (order by avg_rating)      * 100) as rating_pct,
-        round(percent_rank() over (order by goals_per90)     * 100) as goals_per90_pct,
-        round(percent_rank() over (order by assists_per90)   * 100) as assists_per90_pct,
-        round(percent_rank() over (order by pass_accuracy)   * 100) as pass_pct,
-        round(percent_rank() over (order by shot_conversion) * 100) as shot_conv_pct,
-        round(percent_rank() over (order by tackles_per90)   * 100) as defense_pct
+        -- Attacking: anchor goals/90 (2×), + sot/90, shot_acc%, woodwork/90 → /5
+        round((2 * percent_rank() over (order by goals_per90)
+                 + percent_rank() over (order by sot_per90)
+                 + percent_rank() over (order by shot_acc_pct)
+                 + percent_rank() over (order by woodwork_per90)) / 5 * 100)                        as attacking_pct,
+        -- Creativity: anchor big_chances/90 (2×), + chances/90, key_passes/90, chance_quality%, cross_acc%, passes_final_third/90 → /7
+        round((  percent_rank() over (order by chances_per90)
+               + 2 * percent_rank() over (order by big_chances_per90)
+               + percent_rank() over (order by key_passes_per90)
+               + percent_rank() over (order by chance_quality_pct)
+               + percent_rank() over (order by cross_acc_pct)
+               + percent_rank() over (order by passes_final_third_per90)) / 7 * 100)               as creativity_pct,
+        -- Possession: anchor pass_acc% (2×), + dribble_success%, long_ball_success% → /4
+        round((2 * percent_rank() over (order by pass_acc_pct)
+                 + percent_rank() over (order by dribble_success_pct)
+                 + percent_rank() over (order by long_ball_success_pct)) / 4 * 100)                as possession_pct,
+        -- Defending: anchor (tkl+int)/90 (2×), + tackle_success%, balls_recovered/90, times_dribbled_past/90 ↓, errors/90 ↓ → /6
+        round((2 * percent_rank() over (order by tkl_int_per90)
+                 + percent_rank() over (order by tackle_success_pct)
+                 + percent_rank() over (order by balls_recovered_per90)
+                 + percent_rank() over (order by times_dribbled_past_per90 desc)
+                 + percent_rank() over (order by errors_per90 desc)) / 6 * 100)                    as defending_pct,
+        -- Physicality: anchor duel_win% (2×), + fouls_drawn/90, aerial_success% → /4
+        round((2 * percent_rank() over (order by duel_win_pct)
+                 + percent_rank() over (order by fouls_drawn_per90)
+                 + percent_rank() over (order by aerial_success_pct)) / 4 * 100)                   as physicality_pct,
+        -- Impact: avg_rating (single)
+        round(percent_rank() over (order by avg_rating) * 100)                                     as impact_pct
     from base
 )
 select * from ranked where player_name = '${inputs.player.value}'
@@ -375,51 +415,51 @@ select * from ranked where player_name = '${inputs.player.value}'
   <div class="flex flex-col gap-3">
 
     <div class="flex items-center gap-3">
-      <div class="text-xs text-gray-500 w-28 shrink-0 text-right">Goals / 90</div>
+      <div class="text-xs text-gray-500 w-28 shrink-0 text-right">Attacking</div>
       <div class="flex-1 bg-gray-100 rounded-full h-2.5">
-        <div class="h-2.5 rounded-full bg-amber-400" style="width:{lc.goals_per90_pct}%"></div>
+        <div class="h-2.5 rounded-full bg-amber-400" style="width:{lc.attacking_pct}%"></div>
       </div>
-      <div class="text-xs font-bold text-gray-700 w-8 shrink-0 text-right">{lc.goals_per90_pct}</div>
+      <div class="text-xs font-bold text-gray-700 w-8 shrink-0 text-right">{lc.attacking_pct}</div>
     </div>
 
     <div class="flex items-center gap-3">
-      <div class="text-xs text-gray-500 w-28 shrink-0 text-right">Assists / 90</div>
+      <div class="text-xs text-gray-500 w-28 shrink-0 text-right">Creativity</div>
       <div class="flex-1 bg-gray-100 rounded-full h-2.5">
-        <div class="h-2.5 rounded-full bg-sky-400" style="width:{lc.assists_per90_pct}%"></div>
+        <div class="h-2.5 rounded-full bg-sky-400" style="width:{lc.creativity_pct}%"></div>
       </div>
-      <div class="text-xs font-bold text-gray-700 w-8 shrink-0 text-right">{lc.assists_per90_pct}</div>
+      <div class="text-xs font-bold text-gray-700 w-8 shrink-0 text-right">{lc.creativity_pct}</div>
     </div>
 
     <div class="flex items-center gap-3">
-      <div class="text-xs text-gray-500 w-28 shrink-0 text-right">Pass Accuracy</div>
+      <div class="text-xs text-gray-500 w-28 shrink-0 text-right">Possession</div>
       <div class="flex-1 bg-gray-100 rounded-full h-2.5">
-        <div class="h-2.5 rounded-full bg-indigo-500" style="width:{lc.pass_pct}%"></div>
+        <div class="h-2.5 rounded-full bg-indigo-500" style="width:{lc.possession_pct}%"></div>
       </div>
-      <div class="text-xs font-bold text-gray-700 w-8 shrink-0 text-right">{lc.pass_pct}</div>
+      <div class="text-xs font-bold text-gray-700 w-8 shrink-0 text-right">{lc.possession_pct}</div>
     </div>
 
     <div class="flex items-center gap-3">
-      <div class="text-xs text-gray-500 w-28 shrink-0 text-right">Shot Conversion</div>
+      <div class="text-xs text-gray-500 w-28 shrink-0 text-right">Defending</div>
       <div class="flex-1 bg-gray-100 rounded-full h-2.5">
-        <div class="h-2.5 rounded-full bg-orange-400" style="width:{lc.shot_conv_pct}%"></div>
+        <div class="h-2.5 rounded-full bg-teal-500" style="width:{lc.defending_pct}%"></div>
       </div>
-      <div class="text-xs font-bold text-gray-700 w-8 shrink-0 text-right">{lc.shot_conv_pct}</div>
+      <div class="text-xs font-bold text-gray-700 w-8 shrink-0 text-right">{lc.defending_pct}</div>
     </div>
 
     <div class="flex items-center gap-3">
-      <div class="text-xs text-gray-500 w-28 shrink-0 text-right">Avg Rating</div>
+      <div class="text-xs text-gray-500 w-28 shrink-0 text-right">Physicality</div>
       <div class="flex-1 bg-gray-100 rounded-full h-2.5">
-        <div class="h-2.5 rounded-full bg-violet-500" style="width:{lc.rating_pct}%"></div>
+        <div class="h-2.5 rounded-full bg-orange-400" style="width:{lc.physicality_pct}%"></div>
       </div>
-      <div class="text-xs font-bold text-gray-700 w-8 shrink-0 text-right">{lc.rating_pct}</div>
+      <div class="text-xs font-bold text-gray-700 w-8 shrink-0 text-right">{lc.physicality_pct}</div>
     </div>
 
     <div class="flex items-center gap-3">
-      <div class="text-xs text-gray-500 w-28 shrink-0 text-right">Defensive</div>
+      <div class="text-xs text-gray-500 w-28 shrink-0 text-right">Impact</div>
       <div class="flex-1 bg-gray-100 rounded-full h-2.5">
-        <div class="h-2.5 rounded-full bg-teal-500" style="width:{lc.defense_pct}%"></div>
+        <div class="h-2.5 rounded-full bg-violet-500" style="width:{lc.impact_pct}%"></div>
       </div>
-      <div class="text-xs font-bold text-gray-700 w-8 shrink-0 text-right">{lc.defense_pct}</div>
+      <div class="text-xs font-bold text-gray-700 w-8 shrink-0 text-right">{lc.impact_pct}</div>
     </div>
 
   </div>

--- a/dashboards/pages/player-analytics.md
+++ b/dashboards/pages/player-analytics.md
@@ -120,6 +120,12 @@ end
 select
     player_name,
     player_photo,
+    player_nationality,
+    player_detailed_position,
+    max(player_birth_date)                                                                 as birth_date,
+    date_diff('year', max(player_birth_date)::date, current_date)                         as age,
+    max(player_height)                                                                     as height,
+    max(player_weight)                                                                     as weight,
     team_name,
     team_logo,
     player_position,
@@ -140,6 +146,7 @@ select
     sum(passes_accurate)::int                                                             as passes_accurate,
     sum(passes_total)::int                                                                as passes_total,
     sum(yellow_cards)::int                                                                as yellow_cards,
+    sum(case when appearance_type = 'Starter' then 1 else 0 end)::int                    as starts,
     round(avg(rating), 2)                                                                 as avg_rating,
     round(sum(goals_scored)  * 90.0 / nullif(sum(minutes_played), 0), 2)                 as goals_per90,
     round(sum(assists)       * 90.0 / nullif(sum(minutes_played), 0), 2)                 as assists_per90,
@@ -155,7 +162,7 @@ from superligaen.mart_player_facts
 where season = '${inputs.season.value}'
   and player_name = '${inputs.player.value}'
   and result in ('Win', 'Draw', 'Loss')
-group by player_name, player_photo, team_name, team_logo, player_position
+group by player_name, player_photo, player_nationality, player_detailed_position, team_name, team_logo, player_position
 ```
 
 ```sql player_trend
@@ -318,33 +325,14 @@ select * from ranked where player_name = '${inputs.player.value}'
         <span class="text-gray-500 text-sm">·</span>
         <span class="text-gray-400 text-sm">{p.player_position}</span>
       </div>
-      <div class="flex flex-wrap justify-center md:justify-start gap-6 mt-6">
-        <div class="text-center">
-          <div class="text-3xl font-black text-amber-400">{p.goals}</div>
-          <div class="text-xs text-gray-400 uppercase tracking-widest mt-1">Goals</div>
-        </div>
-        <div class="text-center">
-          <div class="text-3xl font-black text-blue-400">{p.assists}</div>
-          <div class="text-xs text-gray-400 uppercase tracking-widest mt-1">Assists</div>
-        </div>
-        <div class="text-center">
-          <div class="text-3xl font-black text-purple-400">{p.avg_rating ?? '—'}</div>
-          <div class="text-xs text-gray-400 uppercase tracking-widest mt-1">Avg Rating</div>
-        </div>
-        <div class="text-center">
-          <div class="text-3xl font-black text-white">{p.matches}</div>
-          <div class="text-xs text-gray-400 uppercase tracking-widest mt-1">Apps</div>
-        </div>
-        <div class="text-center">
-          <div class="text-3xl font-black text-green-400">{p.goals_per90}</div>
-          <div class="text-xs text-gray-400 uppercase tracking-widest mt-1">G/90</div>
-        </div>
-        <div class="text-center">
-          <div class="text-3xl font-black text-teal-400">{p.contributions_per90}</div>
-          <div class="text-xs text-gray-400 uppercase tracking-widest mt-1">G+A/90</div>
-        </div>
+      <div class="text-sm text-gray-400 mt-3">
+        {p.player_nationality ?? '—'} · {p.age != null ? p.age + ' yrs' : '—'} · {p.height ? p.height + ' cm' : '—'} · {p.weight ? p.weight + ' kg' : '—'}
       </div>
-      <div class="flex justify-center md:justify-start gap-3 mt-5">
+      <div class="text-xs text-gray-500 mt-1">{p.player_detailed_position ?? p.player_position}</div>
+      <div class="flex flex-wrap justify-center md:justify-start gap-3 mt-5">
+        {#if p.avg_rating != null}
+        <span class="px-3 py-1 rounded-full bg-white/10 text-white text-sm font-bold">★ {p.avg_rating}</span>
+        {/if}
         <span class="px-3 py-1 rounded-full bg-green-500/20 text-green-400 text-sm font-bold">{p.wins}W</span>
         <span class="px-3 py-1 rounded-full bg-yellow-500/20 text-yellow-400 text-sm font-bold">{p.draws}D</span>
         <span class="px-3 py-1 rounded-full bg-red-500/20 text-red-400 text-sm font-bold">{p.losses}L</span>
@@ -405,9 +393,9 @@ select * from ranked where player_name = '${inputs.player.value}'
   </div>
 
   <div class="rounded-xl border border-gray-200 bg-white shadow-sm p-4 flex flex-col">
-    <div class="text-xs text-gray-500 text-center mb-2">Avg Rating</div>
-    <div class="text-3xl font-black text-center text-gray-900 flex-1 flex items-center justify-center">{p.avg_rating ?? '—'}</div>
-    <div class="text-xs text-gray-400 text-center mt-3">{p.matches} appearances</div>
+    <div class="text-xs text-gray-500 text-center mb-2">Appearances</div>
+    <div class="text-3xl font-black text-center text-gray-900 flex-1 flex items-center justify-center">{p.matches}</div>
+    <div class="text-xs text-gray-400 text-center mt-3">{p.starts} starts</div>
   </div>
 
 </div>

--- a/dashboards/pages/player-analytics.md
+++ b/dashboards/pages/player-analytics.md
@@ -130,7 +130,15 @@ select
     sum(shots_total)::int                                                                 as shots,
     sum(shots_on_target)::int                                                             as shots_on_target,
     sum(key_passes)::int                                                                  as key_passes,
+    sum(big_chances_created)::int                                                         as big_chances_created,
+    sum(chances_created)::int                                                             as chances_created,
     sum(tackles)::int                                                                     as tackles,
+    sum(interceptions)::int                                                               as interceptions,
+    sum(balls_recovered)::int                                                             as balls_recovered,
+    sum(duels_won)::int                                                                   as duels_won,
+    sum(duels_total)::int                                                                 as duels_total,
+    sum(passes_accurate)::int                                                             as passes_accurate,
+    sum(passes_total)::int                                                                as passes_total,
     sum(yellow_cards)::int                                                                as yellow_cards,
     round(avg(rating), 2)                                                                 as avg_rating,
     round(sum(goals_scored)  * 90.0 / nullif(sum(minutes_played), 0), 2)                 as goals_per90,
@@ -138,6 +146,8 @@ select
     round((sum(goals_scored) + sum(assists)) * 90.0 / nullif(sum(minutes_played), 0), 2) as contributions_per90,
     round(100.0 * sum(passes_accurate)  / nullif(sum(passes_total), 0), 1)               as pass_accuracy,
     round(100.0 * sum(goals_scored)     / nullif(sum(shots_total),  0), 1)               as shot_conversion,
+    round(100.0 * sum(duels_won)        / nullif(sum(duels_total),  0), 1)               as duel_win_pct,
+    (sum(tackles) + sum(interceptions) + sum(balls_recovered))::int                      as def_actions,
     sum(case when result = 'Win'  then 1 else 0 end)::int                                as wins,
     sum(case when result = 'Draw' then 1 else 0 end)::int                                as draws,
     sum(case when result = 'Loss' then 1 else 0 end)::int                                as losses
@@ -354,50 +364,50 @@ select * from ranked where player_name = '${inputs.player.value}'
 
   <div class="rounded-xl border border-gray-200 bg-white shadow-sm p-4 flex flex-col">
     <div class="text-xs text-gray-500 text-center mb-2">Goals</div>
-    <div class="text-3xl font-black text-center text-amber-500 flex-1 flex items-center justify-center">{p.goals}</div>
-    <div class="text-xs text-gray-400 text-center mt-3">{p.shots} shots · {p.shots_on_target} on target</div>
+    <div class="text-3xl font-black text-center text-gray-900 flex-1 flex items-center justify-center">{p.goals}</div>
+    <div class="text-xs text-gray-400 text-center mt-3">{p.shots} shots · {p.shot_conversion != null ? p.shot_conversion + '% conv.' : '—'}</div>
   </div>
 
   <div class="rounded-xl border border-gray-200 bg-white shadow-sm p-4 flex flex-col">
     <div class="text-xs text-gray-500 text-center mb-2">Assists</div>
-    <div class="text-3xl font-black text-center text-blue-500 flex-1 flex items-center justify-center">{p.assists}</div>
-    <div class="text-xs text-gray-400 text-center mt-3">{p.key_passes} key passes</div>
+    <div class="text-3xl font-black text-center text-gray-900 flex-1 flex items-center justify-center">{p.assists}</div>
+    <div class="text-xs text-gray-400 text-center mt-3">{p.key_passes} key passes · {p.big_chances_created} big chances</div>
   </div>
 
   <div class="rounded-xl border border-gray-200 bg-white shadow-sm p-4 flex flex-col">
-    <div class="text-xs text-gray-500 text-center mb-2">Goals / 90</div>
-    <div class="text-3xl font-black text-center text-green-600 flex-1 flex items-center justify-center">{p.goals_per90}</div>
-    <div class="text-xs text-gray-400 text-center mt-3">G+A/90: {p.contributions_per90}</div>
+    <div class="text-xs text-gray-500 text-center mb-2">G+A / 90</div>
+    <div class="text-3xl font-black text-center text-gray-900 flex-1 flex items-center justify-center">{p.contributions_per90}</div>
+    <div class="text-xs text-gray-400 text-center mt-3">{p.goals_per90} G · {p.assists_per90} A per 90</div>
   </div>
 
   <div class="rounded-xl border border-gray-200 bg-white shadow-sm p-4 flex flex-col">
-    <div class="text-xs text-gray-500 text-center mb-2">Assists / 90</div>
-    <div class="text-3xl font-black text-center text-blue-600 flex-1 flex items-center justify-center">{p.assists_per90}</div>
-    <div class="text-xs text-gray-400 text-center mt-3">{p.matches} appearances</div>
-  </div>
-
-  <div class="rounded-xl border border-gray-200 bg-white shadow-sm p-4 flex flex-col">
-    <div class="text-xs text-gray-500 text-center mb-2">Pass Accuracy</div>
-    <div class="text-3xl font-black text-center text-purple-600 flex-1 flex items-center justify-center">{p.pass_accuracy}%</div>
-    <div class="text-xs text-gray-400 text-center mt-3">{p.minutes} minutes played</div>
-  </div>
-
-  <div class="rounded-xl border border-gray-200 bg-white shadow-sm p-4 flex flex-col">
-    <div class="text-xs text-gray-500 text-center mb-2">Shot Conversion</div>
-    <div class="text-3xl font-black text-center text-orange-500 flex-1 flex items-center justify-center">{p.shot_conversion != null ? p.shot_conversion + '%' : '—'}</div>
+    <div class="text-xs text-gray-500 text-center mb-2">Shots on Target</div>
+    <div class="text-3xl font-black text-center text-gray-900 flex-1 flex items-center justify-center">{p.shots_on_target}</div>
     <div class="text-xs text-gray-400 text-center mt-3">{p.shots} total shots</div>
   </div>
 
   <div class="rounded-xl border border-gray-200 bg-white shadow-sm p-4 flex flex-col">
-    <div class="text-xs text-gray-500 text-center mb-2">Avg Rating</div>
-    <div class="text-3xl font-black text-center text-violet-600 flex-1 flex items-center justify-center">{p.avg_rating ?? '—'}</div>
-    <div class="text-xs text-gray-400 text-center mt-3">{p.matches} appearances</div>
+    <div class="text-xs text-gray-500 text-center mb-2">Pass Accuracy</div>
+    <div class="text-3xl font-black text-center text-gray-900 flex-1 flex items-center justify-center">{p.pass_accuracy != null ? p.pass_accuracy + '%' : '—'}</div>
+    <div class="text-xs text-gray-400 text-center mt-3">{p.passes_accurate} of {p.passes_total} passes</div>
   </div>
 
   <div class="rounded-xl border border-gray-200 bg-white shadow-sm p-4 flex flex-col">
-    <div class="text-xs text-gray-500 text-center mb-2">Minutes Played</div>
-    <div class="text-3xl font-black text-center text-gray-700 flex-1 flex items-center justify-center">{p.minutes}</div>
-    <div class="text-xs text-gray-400 text-center mt-3">{p.tackles} tackles · {p.yellow_cards} YC</div>
+    <div class="text-xs text-gray-500 text-center mb-2">Duel Win %</div>
+    <div class="text-3xl font-black text-center text-gray-900 flex-1 flex items-center justify-center">{p.duel_win_pct != null ? p.duel_win_pct + '%' : '—'}</div>
+    <div class="text-xs text-gray-400 text-center mt-3">{p.duels_total} total duels</div>
+  </div>
+
+  <div class="rounded-xl border border-gray-200 bg-white shadow-sm p-4 flex flex-col">
+    <div class="text-xs text-gray-500 text-center mb-2">Defensive Actions</div>
+    <div class="text-3xl font-black text-center text-gray-900 flex-1 flex items-center justify-center">{p.def_actions}</div>
+    <div class="text-xs text-gray-400 text-center mt-3">{p.tackles} tkl · {p.interceptions} int · {p.balls_recovered} rec</div>
+  </div>
+
+  <div class="rounded-xl border border-gray-200 bg-white shadow-sm p-4 flex flex-col">
+    <div class="text-xs text-gray-500 text-center mb-2">Avg Rating</div>
+    <div class="text-3xl font-black text-center text-gray-900 flex-1 flex items-center justify-center">{p.avg_rating ?? '—'}</div>
+    <div class="text-xs text-gray-400 text-center mt-3">{p.matches} appearances</div>
   </div>
 
 </div>


### PR DESCRIPTION
## Summary

- **Radar**: Replace 6 single-metric axes with 6 composite dimensions (Attacking, Creativity, Possession, Defending, Physicality, Impact) mirroring team radar logic. Each axis uses weighted percent_rank composites with an anchor metric at 2×. Impact = avg_rating. Defending anchor is (tkl+int)/90 — goals_conceded is not meaningful at player level.
- **League Standing**: Progress bars updated for all 6 new axes with matching colors. Description reflects weighted composite percentile logic.
- **Top Players**: Top Crosser → Top Creator (key passes + big chances); Top Passer → Top Rated (avg rating, min 5 apps); Top Defender enriched with tackles_won + interceptions + balls_recovered.
- **Player Info Banner**: Removed 6 arbitrary-coloured stat blocks that duplicated the KPI cards. Replaced with bio line (nationality, age, height, weight, detailed position), avg_rating badge, and W/D/L + minutes pills.
- **Season Overview KPIs**: Full redesign — Goals, Assists, G+A/90, Shots on Target, Pass Accuracy, Duel Win %, Defensive Actions, Appearances. All arbitrary per-card colours removed (uniform `text-gray-900`). Pass Accuracy shows accurate/total passes; Appearances shows starts in context.
- **Performance Timeline**: 5 dual-Y bar+line charts — one per radar axis (excluding Impact). Anchor metric as bars, match rating as secondary Y line (0–10). Colors match league standing bars. Integer tick enforcement and `max: 'dataMax'` on count axes.
- **player_profile SQL**: Enriched with bio fields (nationality, age, height, weight, detailed position), starts (appearance_type = 'Starter'), big_chances_created, chances_created, interceptions, balls_recovered, duels_won/total, passes_accurate/total, duel_win_pct, def_actions.

## Test plan

- [ ] Select a player with 450+ minutes — verify all 6 radar axes and league standing bars render with correct colors
- [ ] Select a player with < 450 minutes — league standing section should be empty
- [ ] Banner shows bio (nationality, age, height, weight), rating badge, W/D/L pills
- [ ] Season Overview: Goals context shows shot conversion %; Pass Accuracy shows accurate/total; Appearances shows starts
- [ ] Performance Timeline: 5 charts render with colored bars and gray rating line; rating axis capped at 10; count axes show integer ticks only up to data max
- [ ] Top Creator, Top Rated, Top Defender cards populate correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)