### PR TITLE
feat(home): homepage redesign v2 — pitch banner and colored nav cards

### DIFF
--- a/dashboards/pages/index.md
+++ b/dashboards/pages/index.md
@@ -48,30 +48,58 @@ order by
 limit 1
 ```
 
-<div class="relative rounded-2xl bg-gradient-to-br from-gray-900 via-gray-800 to-gray-900 p-6 md:p-10 mb-6 shadow-xl overflow-hidden">
-  <div class="absolute inset-0 opacity-[0.06]" style="background-image: radial-gradient(circle, white 1px, transparent 1px); background-size: 22px 22px;"></div>
-  <div class="absolute top-4 right-4 bg-white/10 rounded-xl p-2 backdrop-blur">
-    <img src="{league[0].league_logo}" alt="Superligaen" class="h-8 md:h-12" />
+<div class="relative rounded-2xl overflow-hidden mb-6 shadow-lg" style="background: linear-gradient(135deg, #1e3a5f 0%, #1a5276 40%, #1a6b4a 100%);">
+  <!-- pitch lines overlay -->
+  <div class="absolute inset-0 opacity-[0.08]" style="background-image: repeating-linear-gradient(90deg, white 0px, white 1px, transparent 1px, transparent 80px), repeating-linear-gradient(0deg, white 0px, white 1px, transparent 1px, transparent 80px);"></div>
+  <!-- center circle hint -->
+  <div class="absolute inset-0 flex items-center justify-center pointer-events-none">
+    <div class="rounded-full border border-white opacity-[0.06]" style="width:320px;height:320px;"></div>
   </div>
-  <div class="flex items-center justify-center gap-4 md:gap-6 relative">
-    <img src="{league[0].league_country_flag}" alt="Denmark" class="h-7 md:h-10 rounded-lg shadow-lg opacity-90" />
-    <div class="text-center">
-      <div class="text-3xl md:text-5xl font-extrabold tracking-tight text-white">Superligaen</div>
-      <div class="text-gray-400 text-xs md:text-sm mt-2 md:mt-3 uppercase tracking-widest">Danish Premier Football League</div>
-      <div class="flex items-center justify-center gap-2 mt-3">
-        <div class="inline-block px-3 py-1 rounded-full bg-blue-500/20 border border-blue-400/30 text-blue-300 text-sm font-semibold">{kpis[0].season}</div>
-        <div class="inline-block px-3 py-1 rounded-full bg-green-500/20 border border-green-400/30 text-green-300 text-xs font-semibold uppercase tracking-wide">Live</div>
+
+  <div class="relative px-6 py-8 md:px-12 md:py-10 flex flex-col md:flex-row items-center justify-between gap-6">
+    <!-- left: league identity -->
+    <div class="flex items-center gap-5">
+      <div class="bg-white/10 backdrop-blur rounded-2xl p-3 shadow-inner flex-shrink-0">
+        <img src="{league[0].league_logo}" alt="Superligaen" class="h-14 md:h-20 w-auto" />
+      </div>
+      <div>
+        <div class="flex items-center gap-2 mb-1">
+          <img src="{league[0].league_country_flag}" alt="Denmark" class="h-4 rounded opacity-90" />
+          <span class="text-white/50 text-xs uppercase tracking-widest">Denmark</span>
+        </div>
+        <div class="text-3xl md:text-4xl font-extrabold tracking-tight text-white leading-tight">Superligaen</div>
+        <div class="text-white/50 text-xs mt-1 uppercase tracking-widest">Premier Football League</div>
       </div>
     </div>
-    <img src="{league[0].league_country_flag}" alt="Denmark" class="h-7 md:h-10 rounded-lg shadow-lg opacity-90" />
+
+    <!-- right: live stats pills -->
+    <div class="flex flex-wrap justify-center md:justify-end gap-3">
+      <div class="rounded-xl bg-white/10 backdrop-blur border border-white/20 px-4 py-3 text-center min-w-[80px]">
+        <div class="text-white text-xl font-black leading-none">{kpis[0].total_goals}</div>
+        <div class="text-white/50 text-xs mt-1 uppercase tracking-wide">Goals</div>
+      </div>
+      <div class="rounded-xl bg-white/10 backdrop-blur border border-white/20 px-4 py-3 text-center min-w-[80px]">
+        <div class="text-white text-xl font-black leading-none">{kpis[0].total_matches}</div>
+        <div class="text-white/50 text-xs mt-1 uppercase tracking-wide">Matches</div>
+      </div>
+      <div class="rounded-xl bg-white/10 backdrop-blur border border-white/20 px-4 py-3 text-center min-w-[80px]">
+        <div class="text-white text-xl font-black leading-none">{kpis[0].total_teams}</div>
+        <div class="text-white/50 text-xs mt-1 uppercase tracking-wide">Teams</div>
+      </div>
+      <div class="rounded-xl bg-green-500/20 backdrop-blur border border-green-400/30 px-4 py-3 text-center min-w-[80px]">
+        <div class="text-green-300 text-sm font-black leading-none">{kpis[0].season}</div>
+        <div class="text-green-400/70 text-xs mt-1 uppercase tracking-wide">Live</div>
+      </div>
+    </div>
   </div>
 </div>
 
-<div class="grid grid-cols-2 md:grid-cols-4 gap-4 mb-8">
-  <div class="rounded-xl border border-gray-200 bg-white shadow-sm p-4 text-center"><BigValue data={leader} value=team_short_name title="Season Leader" /></div>
-  <div class="rounded-xl border border-gray-200 bg-white shadow-sm p-4 text-center"><BigValue data={kpis}   value=total_teams   title="Teams"          /></div>
-  <div class="rounded-xl border border-gray-200 bg-white shadow-sm p-4 text-center"><BigValue data={kpis}   value=total_matches title="Matches Played"  /></div>
-  <div class="rounded-xl border border-gray-200 bg-white shadow-sm p-4 text-center"><BigValue data={kpis}   value=total_goals   title="Goals Scored"    /></div>
+<div class="rounded-xl border border-amber-200 bg-amber-50 shadow-sm p-4 mb-8 flex items-center gap-3">
+  <div class="text-amber-400 text-2xl">🏆</div>
+  <div class="text-xs font-semibold text-amber-600 uppercase tracking-widest flex-shrink-0">Season Leader</div>
+  <div class="flex-1 h-px bg-amber-200"></div>
+  <div class="text-sm font-bold text-amber-800">{leader[0]?.team_name}</div>
+  <div class="text-xs text-amber-600 font-semibold">{leader[0]?.pts} pts</div>
 </div>
 
 <div class="flex items-center gap-3 mb-4">

--- a/dashboards/pages/index.md
+++ b/dashboards/pages/index.md
@@ -48,145 +48,127 @@ order by
 limit 1
 ```
 
-<div class="relative rounded-2xl bg-gradient-to-br from-gray-900 via-gray-800 to-gray-900 p-6 md:p-10 mb-6 shadow-xl">
+<div class="relative rounded-2xl bg-gradient-to-br from-gray-900 via-gray-800 to-gray-900 p-6 md:p-10 mb-6 shadow-xl overflow-hidden">
+  <div class="absolute inset-0 opacity-[0.06]" style="background-image: radial-gradient(circle, white 1px, transparent 1px); background-size: 22px 22px;"></div>
   <div class="absolute top-4 right-4 bg-white/10 rounded-xl p-2 backdrop-blur">
     <img src="{league[0].league_logo}" alt="Superligaen" class="h-8 md:h-12" />
   </div>
-  <div class="flex items-center justify-center gap-4 md:gap-6">
+  <div class="flex items-center justify-center gap-4 md:gap-6 relative">
     <img src="{league[0].league_country_flag}" alt="Denmark" class="h-7 md:h-10 rounded-lg shadow-lg opacity-90" />
     <div class="text-center">
       <div class="text-3xl md:text-5xl font-extrabold tracking-tight text-white">Superligaen</div>
       <div class="text-gray-400 text-xs md:text-sm mt-2 md:mt-3 uppercase tracking-widest">Danish Premier Football League</div>
-      <div class="inline-block mt-2 px-3 py-1 rounded-full bg-blue-500/20 border border-blue-400/30 text-blue-300 text-sm font-semibold">
-        Current Season: {kpis[0].season}
+      <div class="flex items-center justify-center gap-2 mt-3">
+        <div class="inline-block px-3 py-1 rounded-full bg-blue-500/20 border border-blue-400/30 text-blue-300 text-sm font-semibold">{kpis[0].season}</div>
+        <div class="inline-block px-3 py-1 rounded-full bg-green-500/20 border border-green-400/30 text-green-300 text-xs font-semibold uppercase tracking-wide">Live</div>
       </div>
     </div>
     <img src="{league[0].league_country_flag}" alt="Denmark" class="h-7 md:h-10 rounded-lg shadow-lg opacity-90" />
   </div>
 </div>
 
-<div class="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
-  <div class="rounded-xl border border-gray-200 bg-gray-50 p-4 text-center"><BigValue data={leader}  value=team_short_name  title="Season Leader"  /></div>
-  <div class="rounded-xl border border-gray-200 bg-gray-50 p-4 text-center"><BigValue data={kpis}    value=total_teams    title="Teams"           /></div>
-  <div class="rounded-xl border border-gray-200 bg-gray-50 p-4 text-center"><BigValue data={kpis}    value=total_matches  title="Matches Played"  /></div>
-  <div class="rounded-xl border border-gray-200 bg-gray-50 p-4 text-center"><BigValue data={kpis}    value=total_goals    title="Goals Scored"    /></div>
+<div class="grid grid-cols-2 md:grid-cols-4 gap-4 mb-8">
+  <div class="rounded-xl border border-gray-200 bg-white shadow-sm p-4 text-center"><BigValue data={leader} value=team_short_name title="Season Leader" /></div>
+  <div class="rounded-xl border border-gray-200 bg-white shadow-sm p-4 text-center"><BigValue data={kpis}   value=total_teams   title="Teams"          /></div>
+  <div class="rounded-xl border border-gray-200 bg-white shadow-sm p-4 text-center"><BigValue data={kpis}   value=total_matches title="Matches Played"  /></div>
+  <div class="rounded-xl border border-gray-200 bg-white shadow-sm p-4 text-center"><BigValue data={kpis}   value=total_goals   title="Goals Scored"    /></div>
 </div>
 
 <div class="flex items-center gap-3 mb-4">
   <span class="text-xs font-semibold text-gray-400 uppercase tracking-widest">Explore</span>
-  <div class="flex-1 h-px bg-gray-100"></div>
+  <div class="flex-1 h-px bg-gray-200"></div>
 </div>
 
-<div class="grid grid-cols-1 md:grid-cols-2 gap-4" style="grid-auto-rows: 7.5rem">
+<div class="grid grid-cols-1 md:grid-cols-2 gap-3">
 
-<a href="/standings" class="flex flex-col justify-center no-underline rounded-xl border border-gray-200 bg-white p-6 hover:border-blue-500 hover:shadow-lg transition-all duration-200 group shadow-sm h-full">
-  <div class="flex items-center gap-4">
-    <div class="text-3xl">🏆</div>
-    <div class="flex-1">
-      <div class="text-base font-bold text-gray-800 group-hover:text-blue-500 transition-colors">Standings</div>
-      <div class="text-gray-400 text-sm mt-1">Championship, Relegation &amp; Regular Season tables</div>
-    </div>
-    <div class="translate-x-0 shrink-0 text-gray-300 group-hover:text-blue-400 group-hover:translate-x-1 transition-all duration-200 text-lg">→</div>
+<a href="/standings" class="flex items-center no-underline rounded-xl border border-gray-200 bg-white p-4 hover:border-amber-300 hover:shadow-md transition-all duration-200 group shadow-sm">
+  <div class="rounded-xl bg-amber-50 w-11 h-11 flex items-center justify-center text-xl flex-shrink-0 mr-4">🏆</div>
+  <div class="flex-1 min-w-0">
+    <div class="text-sm font-bold text-gray-800 group-hover:text-amber-600 transition-colors">Standings</div>
+    <div class="text-gray-400 text-xs mt-0.5 leading-snug">Championship, Relegation &amp; Regular Season tables</div>
   </div>
+  <div class="shrink-0 text-gray-300 group-hover:text-amber-400 group-hover:translate-x-1 transition-all duration-200 ml-3">→</div>
 </a>
 
-<a href="/match-results" class="flex flex-col justify-center no-underline rounded-xl border border-gray-200 bg-white p-6 hover:border-blue-500 hover:shadow-lg transition-all duration-200 group shadow-sm h-full">
-  <div class="flex items-center gap-4">
-    <div class="text-3xl">⚽</div>
-    <div class="flex-1">
-      <div class="text-base font-bold text-gray-800 group-hover:text-blue-500 transition-colors">Match Results</div>
-      <div class="text-gray-400 text-sm mt-1">Full match history, scorelines and analytics by round</div>
-    </div>
-    <div class="translate-x-0 shrink-0 text-gray-300 group-hover:text-blue-400 group-hover:translate-x-1 transition-all duration-200 text-lg">→</div>
+<a href="/match-results" class="flex items-center no-underline rounded-xl border border-gray-200 bg-white p-4 hover:border-blue-300 hover:shadow-md transition-all duration-200 group shadow-sm">
+  <div class="rounded-xl bg-blue-50 w-11 h-11 flex items-center justify-center text-xl flex-shrink-0 mr-4">⚽</div>
+  <div class="flex-1 min-w-0">
+    <div class="text-sm font-bold text-gray-800 group-hover:text-blue-600 transition-colors">Match Results</div>
+    <div class="text-gray-400 text-xs mt-0.5 leading-snug">Full match history, scorelines and analytics by round</div>
   </div>
+  <div class="shrink-0 text-gray-300 group-hover:text-blue-400 group-hover:translate-x-1 transition-all duration-200 ml-3">→</div>
 </a>
 
-<a href="/upcoming-matches" class="flex flex-col justify-center no-underline rounded-xl border border-gray-200 bg-white p-6 hover:border-blue-500 hover:shadow-lg transition-all duration-200 group shadow-sm h-full">
-  <div class="flex items-center gap-4">
-    <div class="text-3xl">📅</div>
-    <div class="flex-1">
-      <div class="text-base font-bold text-gray-800 group-hover:text-blue-500 transition-colors">Upcoming Fixtures</div>
-      <div class="text-gray-400 text-sm mt-1">Head-to-head history &amp; form guide for upcoming matches</div>
-    </div>
-    <div class="translate-x-0 shrink-0 text-gray-300 group-hover:text-blue-400 group-hover:translate-x-1 transition-all duration-200 text-lg">→</div>
+<a href="/upcoming-matches" class="flex items-center no-underline rounded-xl border border-gray-200 bg-white p-4 hover:border-violet-300 hover:shadow-md transition-all duration-200 group shadow-sm">
+  <div class="rounded-xl bg-violet-50 w-11 h-11 flex items-center justify-center text-xl flex-shrink-0 mr-4">📅</div>
+  <div class="flex-1 min-w-0">
+    <div class="text-sm font-bold text-gray-800 group-hover:text-violet-600 transition-colors">Upcoming Fixtures</div>
+    <div class="text-gray-400 text-xs mt-0.5 leading-snug">Head-to-head history &amp; form guide for upcoming matches</div>
   </div>
+  <div class="shrink-0 text-gray-300 group-hover:text-violet-400 group-hover:translate-x-1 transition-all duration-200 ml-3">→</div>
 </a>
 
-<a href="/league-analytics" class="flex flex-col justify-center no-underline rounded-xl border border-gray-200 bg-white p-6 hover:border-blue-500 hover:shadow-lg transition-all duration-200 group shadow-sm h-full">
-  <div class="flex items-center gap-4">
-    <div class="text-3xl">📈</div>
-    <div class="flex-1">
-      <div class="text-base font-bold text-gray-800 group-hover:text-blue-500 transition-colors">League Intelligence</div>
-      <div class="text-gray-400 text-sm mt-1">Standings, points race, team radar & discipline rankings</div>
-    </div>
-    <div class="translate-x-0 shrink-0 text-gray-300 group-hover:text-blue-400 group-hover:translate-x-1 transition-all duration-200 text-lg">→</div>
+<a href="/league-analytics" class="flex items-center no-underline rounded-xl border border-gray-200 bg-white p-4 hover:border-emerald-300 hover:shadow-md transition-all duration-200 group shadow-sm">
+  <div class="rounded-xl bg-emerald-50 w-11 h-11 flex items-center justify-center text-xl flex-shrink-0 mr-4">📈</div>
+  <div class="flex-1 min-w-0">
+    <div class="text-sm font-bold text-gray-800 group-hover:text-emerald-600 transition-colors">League Intelligence</div>
+    <div class="text-gray-400 text-xs mt-0.5 leading-snug">Standings, points race, team radar &amp; discipline rankings</div>
   </div>
+  <div class="shrink-0 text-gray-300 group-hover:text-emerald-400 group-hover:translate-x-1 transition-all duration-200 ml-3">→</div>
 </a>
 
-<a href="/team-analytics" class="flex flex-col justify-center no-underline rounded-xl border border-gray-200 bg-white p-6 hover:border-blue-500 hover:shadow-lg transition-all duration-200 group shadow-sm h-full">
-  <div class="flex items-center gap-4">
-    <div class="text-3xl">👥</div>
-    <div class="flex-1">
-      <div class="text-base font-bold text-gray-800 group-hover:text-blue-500 transition-colors">Team Intelligence</div>
-      <div class="text-gray-400 text-sm mt-1">Points race, match log, squad depth &amp; home/away splits</div>
-    </div>
-    <div class="translate-x-0 shrink-0 text-gray-300 group-hover:text-blue-400 group-hover:translate-x-1 transition-all duration-200 text-lg">→</div>
+<a href="/team-analytics" class="flex items-center no-underline rounded-xl border border-gray-200 bg-white p-4 hover:border-sky-300 hover:shadow-md transition-all duration-200 group shadow-sm">
+  <div class="rounded-xl bg-sky-50 w-11 h-11 flex items-center justify-center text-xl flex-shrink-0 mr-4">👥</div>
+  <div class="flex-1 min-w-0">
+    <div class="text-sm font-bold text-gray-800 group-hover:text-sky-600 transition-colors">Team Intelligence</div>
+    <div class="text-gray-400 text-xs mt-0.5 leading-snug">Points race, match log, squad depth &amp; home/away splits</div>
   </div>
+  <div class="shrink-0 text-gray-300 group-hover:text-sky-400 group-hover:translate-x-1 transition-all duration-200 ml-3">→</div>
 </a>
 
-<a href="/player-analytics" class="flex flex-col justify-center no-underline rounded-xl border border-gray-200 bg-white p-6 hover:border-blue-500 hover:shadow-lg transition-all duration-200 group shadow-sm h-full">
-  <div class="flex items-center gap-4">
-    <div class="text-3xl">👟</div>
-    <div class="flex-1">
-      <div class="text-base font-bold text-gray-800 group-hover:text-blue-500 transition-colors">Player Intelligence</div>
-      <div class="text-gray-400 text-sm mt-1">Percentile radar, performance timeline &amp; match-by-match log</div>
-    </div>
-    <div class="translate-x-0 shrink-0 text-gray-300 group-hover:text-blue-400 group-hover:translate-x-1 transition-all duration-200 text-lg">→</div>
+<a href="/player-analytics" class="flex items-center no-underline rounded-xl border border-gray-200 bg-white p-4 hover:border-indigo-300 hover:shadow-md transition-all duration-200 group shadow-sm">
+  <div class="rounded-xl bg-indigo-50 w-11 h-11 flex items-center justify-center text-xl flex-shrink-0 mr-4">👟</div>
+  <div class="flex-1 min-w-0">
+    <div class="text-sm font-bold text-gray-800 group-hover:text-indigo-600 transition-colors">Player Intelligence</div>
+    <div class="text-gray-400 text-xs mt-0.5 leading-snug">Percentile radar, performance timeline &amp; match-by-match log</div>
   </div>
+  <div class="shrink-0 text-gray-300 group-hover:text-indigo-400 group-hover:translate-x-1 transition-all duration-200 ml-3">→</div>
 </a>
 
-<a href="/stadium-analytics" class="flex flex-col justify-center no-underline rounded-xl border border-gray-200 bg-white p-6 hover:border-blue-500 hover:shadow-lg transition-all duration-200 group shadow-sm h-full">
-  <div class="flex items-center gap-4">
-    <div class="text-3xl">🏟️</div>
-    <div class="flex-1">
-      <div class="text-base font-bold text-gray-800 group-hover:text-blue-500 transition-colors">Stadium Intelligence</div>
-      <div class="text-gray-400 text-sm mt-1">Stadium map, surface effects and home fortress rankings</div>
-    </div>
-    <div class="translate-x-0 shrink-0 text-gray-300 group-hover:text-blue-400 group-hover:translate-x-1 transition-all duration-200 text-lg">→</div>
+<a href="/stadium-analytics" class="flex items-center no-underline rounded-xl border border-gray-200 bg-white p-4 hover:border-orange-300 hover:shadow-md transition-all duration-200 group shadow-sm">
+  <div class="rounded-xl bg-orange-50 w-11 h-11 flex items-center justify-center text-xl flex-shrink-0 mr-4">🏟️</div>
+  <div class="flex-1 min-w-0">
+    <div class="text-sm font-bold text-gray-800 group-hover:text-orange-600 transition-colors">Stadium Intelligence</div>
+    <div class="text-gray-400 text-xs mt-0.5 leading-snug">Stadium map, surface effects and home fortress rankings</div>
   </div>
+  <div class="shrink-0 text-gray-300 group-hover:text-orange-400 group-hover:translate-x-1 transition-all duration-200 ml-3">→</div>
 </a>
 
-<a href="/referee-analytics" class="flex flex-col justify-center no-underline rounded-xl border border-gray-200 bg-white p-6 hover:border-blue-500 hover:shadow-lg transition-all duration-200 group shadow-sm h-full">
-  <div class="flex items-center gap-4">
-    <div class="text-3xl">🟨</div>
-    <div class="flex-1">
-      <div class="text-base font-bold text-gray-800 group-hover:text-blue-500 transition-colors">Referee Intelligence</div>
-      <div class="text-gray-400 text-sm mt-1">Cards, fouls, home/away bias and discipline trends</div>
-    </div>
-    <div class="translate-x-0 shrink-0 text-gray-300 group-hover:text-blue-400 group-hover:translate-x-1 transition-all duration-200 text-lg">→</div>
+<a href="/referee-analytics" class="flex items-center no-underline rounded-xl border border-gray-200 bg-white p-4 hover:border-red-300 hover:shadow-md transition-all duration-200 group shadow-sm">
+  <div class="rounded-xl bg-red-50 w-11 h-11 flex items-center justify-center text-xl flex-shrink-0 mr-4">🟨</div>
+  <div class="flex-1 min-w-0">
+    <div class="text-sm font-bold text-gray-800 group-hover:text-red-600 transition-colors">Referee Intelligence</div>
+    <div class="text-gray-400 text-xs mt-0.5 leading-snug">Cards, fouls, home/away bias and discipline trends</div>
   </div>
+  <div class="shrink-0 text-gray-300 group-hover:text-red-400 group-hover:translate-x-1 transition-all duration-200 ml-3">→</div>
 </a>
 
-<a href="/glossary" class="flex flex-col justify-center no-underline rounded-xl border border-gray-200 bg-white p-6 hover:border-blue-500 hover:shadow-lg transition-all duration-200 group shadow-sm h-full">
-  <div class="flex items-center gap-4">
-    <div class="text-3xl">📖</div>
-    <div class="flex-1">
-      <div class="text-base font-bold text-gray-800 group-hover:text-blue-500 transition-colors">Data Glossary</div>
-      <div class="text-gray-400 text-sm mt-1">Definitions and formulas for all KPIs and abbreviations</div>
-    </div>
-    <div class="translate-x-0 shrink-0 text-gray-300 group-hover:text-blue-400 group-hover:translate-x-1 transition-all duration-200 text-lg">→</div>
+<a href="/glossary" class="flex items-center no-underline rounded-xl border border-gray-200 bg-white p-4 hover:border-slate-400 hover:shadow-md transition-all duration-200 group shadow-sm">
+  <div class="rounded-xl bg-slate-100 w-11 h-11 flex items-center justify-center text-xl flex-shrink-0 mr-4">📖</div>
+  <div class="flex-1 min-w-0">
+    <div class="text-sm font-bold text-gray-800 group-hover:text-slate-600 transition-colors">Data Glossary</div>
+    <div class="text-gray-400 text-xs mt-0.5 leading-snug">Definitions and formulas for all KPIs and abbreviations</div>
   </div>
+  <div class="shrink-0 text-gray-300 group-hover:text-slate-500 group-hover:translate-x-1 transition-all duration-200 ml-3">→</div>
 </a>
 
-<a href="/about" class="flex flex-col justify-center no-underline rounded-xl border border-gray-200 bg-white p-6 hover:border-blue-500 hover:shadow-lg transition-all duration-200 group shadow-sm h-full">
-  <div class="flex items-center gap-4">
-    <div class="text-3xl">👤</div>
-    <div class="flex-1">
-      <div class="text-base font-bold text-gray-800 group-hover:text-blue-500 transition-colors">About This Project</div>
-      <div class="text-gray-400 text-sm mt-1">The story behind this project, the blog &amp; the author</div>
-    </div>
-    <div class="translate-x-0 shrink-0 text-gray-300 group-hover:text-blue-400 group-hover:translate-x-1 transition-all duration-200 text-lg">→</div>
+<a href="/about" class="flex items-center no-underline rounded-xl border border-gray-200 bg-white p-4 hover:border-gray-400 hover:shadow-md transition-all duration-200 group shadow-sm">
+  <div class="rounded-xl bg-gray-100 w-11 h-11 flex items-center justify-center text-xl flex-shrink-0 mr-4">👤</div>
+  <div class="flex-1 min-w-0">
+    <div class="text-sm font-bold text-gray-800 group-hover:text-gray-600 transition-colors">About This Project</div>
+    <div class="text-gray-400 text-xs mt-0.5 leading-snug">The story behind this project, the blog &amp; the author</div>
   </div>
+  <div class="shrink-0 text-gray-300 group-hover:text-gray-500 group-hover:translate-x-1 transition-all duration-200 ml-3">→</div>
 </a>
 
 </div>

--- a/dashboards/pages/index.md
+++ b/dashboards/pages/index.md
@@ -68,7 +68,7 @@ limit 1
           <span class="text-white/50 text-xs uppercase tracking-widest">Denmark</span>
         </div>
         <div class="text-3xl md:text-4xl font-extrabold tracking-tight text-white leading-tight">Superligaen</div>
-        <div class="text-white/50 text-xs mt-1 uppercase tracking-widest">Premier Football League</div>
+        <div class="text-white/50 text-xs mt-1 tracking-wide italic">Powered by data. Built for football.</div>
       </div>
     </div>
 


### PR DESCRIPTION
## Summary

- **Banner** — replaces dark gray gradient with a navy-to-green football pitch gradient, logo left-aligned with flag and tagline *"Powered by data. Built for football."*, goals/matches/teams/season displayed as frosted-glass pills inline
- **Season leader ribbon** — replaces the 4-card KPI row with a slim amber banner showing the current leader and points
- **Nav cards** — each section gets a unique colored icon container (amber, blue, violet, emerald, sky, indigo, orange, red, slate, gray) with matching per-card hover accents
- **KPI cards** — upgraded from `bg-gray-50` to `bg-white shadow-sm` to match individual page styling

> v1 alternative saved on `feat/homepage-redesign` if we ever want to revisit.

## Test plan

- [ ] Banner renders correctly on mobile and desktop
- [ ] League logo and flag load
- [ ] KPI pills in banner show correct values
- [ ] Season leader ribbon shows correct team and points
- [ ] All nav card links work
- [ ] Hover states and transitions look smooth

🤖 Generated with [Claude Code](https://claude.com/claude-code)