### PR TITLE
feat(home): homepage redesign v2 — data-driven season + dynamic Live/Ended badge

### DIFF
--- a/dashboards/pages/index.md
+++ b/dashboards/pages/index.md
@@ -12,18 +12,44 @@ select * from superligaen.league_info
 select * from superligaen.last_updated
 ```
 
-```sql kpis
+```sql season_info
+with max_s as (
+    select max(season) as season
+    from superligaen.mart_match_facts
+    where result in ('Win', 'Draw', 'Loss')
+)
 select
-    count(distinct match_id)    as total_matches,
-    sum(goals_scored)           as total_goals,
-    count(distinct team_name)   as total_teams,
-    max(season)                 as season
-from superligaen.mart_match_facts
-where is_current_season = true
-  and result in ('Win', 'Draw', 'Loss')
+    max_s.season,
+    max(f.match_date)::varchar as season_end
+from superligaen.mart_match_facts f
+join max_s on f.season = max_s.season
+where f.result in ('Win', 'Draw', 'Loss')
+group by max_s.season
+```
+
+```sql kpis
+with max_s as (
+    select max(season) as season
+    from superligaen.mart_match_facts
+    where result in ('Win', 'Draw', 'Loss')
+)
+select
+    count(distinct f.match_id)  as total_matches,
+    sum(f.goals_scored)         as total_goals,
+    count(distinct f.team_name) as total_teams,
+    f.season
+from superligaen.mart_match_facts f
+join max_s on f.season = max_s.season
+where f.result in ('Win', 'Draw', 'Loss')
+group by f.season
 ```
 
 ```sql leader
+with max_s as (
+    select max(season) as season
+    from superligaen.mart_match_facts
+    where result in ('Win', 'Draw', 'Loss')
+)
 select team_name, team_short_name, pts
 from (
     select
@@ -33,9 +59,9 @@ from (
         sum(points_earned)                      as pts,
         sum(goals_scored) - sum(goals_conceded) as gd,
         sum(goals_scored)                       as gf
-    from superligaen.mart_match_facts
-    where is_current_season = true
-      and result in ('Win', 'Draw', 'Loss')
+    from superligaen.mart_match_facts f
+    join max_s on f.season = max_s.season
+    where f.result in ('Win', 'Draw', 'Loss')
     group by team_name, team_short_name, standings_type
 )
 order by
@@ -86,16 +112,19 @@ limit 1
         <div class="text-white text-xl font-black leading-none">{kpis[0].total_teams}</div>
         <div class="text-white/50 text-xs mt-1 uppercase tracking-wide">Teams</div>
       </div>
-      <div class="rounded-xl bg-green-500/20 backdrop-blur border border-green-400/30 px-4 py-3 text-center min-w-[80px]">
-        <div class="text-green-300 text-sm font-black leading-none">{kpis[0].season}</div>
-        <div class="text-green-400/70 text-xs mt-1 uppercase tracking-wide">Live</div>
+      <div class="rounded-xl backdrop-blur px-4 py-3 text-center min-w-[80px]"
+           style="{new Date() > new Date(season_info[0].season_end) ? 'background:rgba(100,116,139,0.2);border:1px solid rgba(148,163,184,0.3)' : 'background:rgba(74,222,128,0.2);border:1px solid rgba(74,222,128,0.3)'}">
+        <div class="text-sm font-black leading-none"
+             style="{new Date() > new Date(season_info[0].season_end) ? 'color:rgb(203,213,225)' : 'color:rgb(134,239,172)'}">{kpis[0].season}</div>
+        <div class="text-xs mt-1 uppercase tracking-wide"
+             style="{new Date() > new Date(season_info[0].season_end) ? 'color:rgba(148,163,184,0.7)' : 'color:rgba(74,222,128,0.7)'}">{new Date() > new Date(season_info[0].season_end) ? 'Ended' : 'Live'}</div>
       </div>
     </div>
   </div>
 </div>
 
 <div class="rounded-xl border border-amber-200 bg-amber-50 shadow-sm p-4 mb-8 flex items-center gap-3">
-  <div class="text-amber-400 text-2xl">🏆</div>
+  <div class="text-amber-400 text-2xl">👑</div>
   <div class="text-xs font-semibold text-amber-600 uppercase tracking-widest flex-shrink-0">Season Leader</div>
   <div class="flex-1 h-px bg-amber-200"></div>
   <div class="text-sm font-bold text-amber-800">{leader[0]?.team_name}</div>


### PR DESCRIPTION
## Summary

- Season selection now derived from `max(season)` with completed matches — no longer depends on the `is_current_season` source flag
- Season badge dynamically shows **Live** (green) or **Ended** (slate) by comparing today's date against the last completed match date in that season
- Season Leader emoji changed from 🏆 to 👑 to avoid duplication with the Standings nav card

## Test plan

- [ ] Badge shows correct season (most recent with completed matches)
- [ ] Badge reads "Live" with green styling when today is within the active season window
- [ ] Badge reads "Ended" with gray styling when today is past the last match date
- [ ] Season Leader banner renders with 👑 and correct team/points
- [ ] KPIs (goals, matches, teams) reflect the correct max season

🤖 Generated with [Claude Code](https://claude.com/claude-code)