### PR TITLE
feat(match-results): add 💥 emoji for woodwork hits in lineup

### DIFF
--- a/dashboards/components/MatchLineup.svelte
+++ b/dashboards/components/MatchLineup.svelte
@@ -153,6 +153,7 @@
     const parts = [];
     if (p.goals_scored > 0)           parts.push('⚽'.repeat(Math.min(p.goals_scored, 3)) + (p.goals_scored > 3 ? p.goals_scored : ''));
     if (p.assists > 0)                parts.push('🎯'.repeat(Math.min(p.assists, 2)) + (p.assists > 2 ? p.assists : ''));
+    if (p.woodwork_hits > 0)          parts.push('💥'.repeat(Math.min(p.woodwork_hits, 2)) + (p.woodwork_hits > 2 ? p.woodwork_hits : ''));
     if (p.own_goals > 0)              parts.push('🙈');
     if (p.penalty_missed > 0)         parts.push('❌');
     if (p.yellow_red_cards > 0)       parts.push('🟨🟥');


### PR DESCRIPTION
Closes #272

## Summary
- Adds `💥` emoji to the `emojiRow()` function in `MatchLineup.svelte` for players with `woodwork_hits > 0`
- Follows the same pattern as goals/assists: repeats up to 2 times, then shows the raw count for 3+
- No data-layer changes needed — `woodwork_hits` was already selected in the lineup SQL query

## Test plan
- [ ] Open a match where a player hit the woodwork and confirm `💥` appears next to their name in the lineup (both on the pitch and in the subs list)
- [ ] Confirm no emoji appears for players with 0 woodwork hits

🤖 Generated with [Claude Code](https://claude.ai/claude-code)