### PR TITLE
feat: dashboard UX improvements — semantic colors, chart enhancements & match schedule

### DIFF
--- a/dashboards/pages/league-analytics.md
+++ b/dashboards/pages/league-analytics.md
@@ -358,6 +358,38 @@ where ('All Teams' in ${inputs.team.value} OR team_name in ${inputs.team.value})
 order by team_name
 ```
 
+```sql match_schedule
+select
+    day_name,
+    period_of_day,
+    count(distinct match_id)::int as matches
+from superligaen.mart_match_facts
+where season = '${inputs.season.value}'
+  and ('All Teams' in ${inputs.team.value} OR team_name in ${inputs.team.value})
+  and result in ('Win', 'Draw', 'Loss')
+group by day_name, period_of_day
+order by case day_name
+    when 'Monday'    then 1 when 'Tuesday'  then 2 when 'Wednesday' then 3
+    when 'Thursday'  then 4 when 'Friday'   then 5 when 'Saturday'  then 6
+    when 'Sunday'    then 7 end,
+    case period_of_day
+    when 'Morning' then 1 when 'Noon' then 2 when 'Evening' then 3 when 'Night' then 4 else 5 end
+```
+
+```sql goals_by_slot
+select
+    period_of_day,
+    count(distinct match_id)::int                                              as matches,
+    round(sum(goals_scored)::double / count(distinct match_id), 2)             as goals_per_match
+from superligaen.mart_match_facts
+where season = '${inputs.season.value}'
+  and ('All Teams' in ${inputs.team.value} OR team_name in ${inputs.team.value})
+  and result in ('Win', 'Draw', 'Loss')
+group by period_of_day
+order by case period_of_day
+    when 'Morning' then 1 when 'Noon' then 2 when 'Evening' then 3 when 'Night' then 4 else 5 end
+```
+
 ---
 
 ## League Intelligence — {inputs.season.value}
@@ -805,6 +837,40 @@ order by team_name
     swapXY=true
     sort=true
     fmt='0.0%'
+/>
+
+</div>
+
+---
+
+## Match Schedule
+
+<div class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-6">
+
+<BarChart
+    data={match_schedule}
+    x=day_name
+    y=matches
+    series=period_of_day
+    title="Matches by Day & Time of Day"
+    xAxisTitle="Day"
+    yAxisTitle="Matches"
+    colorPalette={['#fbbf24','#3b82f6','#f97316','#6366f1']}
+    type=stacked
+    sort=false
+    echartsOptions={{xAxis: {data: ['Monday','Tuesday','Wednesday','Thursday','Friday','Saturday','Sunday']}, legend: {data: ['Morning','Noon','Evening','Night']}}}
+/>
+
+<BarChart
+    data={goals_by_slot}
+    x=period_of_day
+    y=goals_per_match
+    title="Goals per Match by Time of Day"
+    xAxisTitle="Time of Day"
+    yAxisTitle="Goals / Match"
+    colorPalette={['#fbbf24','#3b82f6','#f97316','#6366f1']}
+    sort=false
+    echartsOptions={{xAxis: {data: ['Morning', 'Noon', 'Evening', 'Night']}}}
 />
 
 </div>

--- a/dashboards/pages/league-analytics.md
+++ b/dashboards/pages/league-analytics.md
@@ -845,6 +845,8 @@ order by case period_of_day
 
 ## Match Schedule
 
+<p style="font-size:0.8125rem;color:#6b7280;margin:0 0 1rem 0;font-style:italic;">When are Superligaen matches played? The left chart breaks down fixtures by day of week and time of day; the right shows whether kick-off time influences scoring. Time slots: Morning 05:00–10:59 · Afternoon 11:00–15:59 · Evening 16:00–20:59 · Night 21:00–04:59.</p>
+
 <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-6">
 
 <BarChart
@@ -858,7 +860,7 @@ order by case period_of_day
     colorPalette={['#fbbf24','#3b82f6','#f97316','#6366f1']}
     type=stacked
     sort=false
-    echartsOptions={{xAxis: {data: ['Monday','Tuesday','Wednesday','Thursday','Friday','Saturday','Sunday']}, legend: {data: ['Morning','Noon','Evening','Night']}}}
+    echartsOptions={{xAxis: {data: ['Monday','Tuesday','Wednesday','Thursday','Friday','Saturday','Sunday']}}}
 />
 
 <BarChart

--- a/dashboards/pages/league-analytics.md
+++ b/dashboards/pages/league-analytics.md
@@ -736,7 +736,7 @@ order by team_name
     y=goals_pm
     title="Attacking — Goals per Match"
     yAxisTitle="Goals / Match"
-    colorPalette={['#22c55e']}
+    colorPalette={['#3b82f6']}
     swapXY=true
     sort=true
 />
@@ -747,7 +747,7 @@ order by team_name
     y=big_chances_pm
     title="Creativity — Big Chances Created per Match"
     yAxisTitle="Big Chances / Match"
-    colorPalette={['#f59e0b']}
+    colorPalette={['#06b6d4']}
     swapXY=true
     sort=true
 />
@@ -774,7 +774,7 @@ order by team_name
     y=conceded_pm
     title="Defending — Goals Conceded per Match"
     yAxisTitle="Goals Conceded / Match"
-    colorPalette={['#14b8a6']}
+    colorPalette={['#f97316']}
     swapXY=true
     sort=true
 />
@@ -789,7 +789,7 @@ order by team_name
     y=duel_win_pct
     title="Physicality — Duel Win %"
     yAxisTitle="Duel Win %"
-    colorPalette={['#f97316']}
+    colorPalette={['#14b8a6']}
     swapXY=true
     sort=true
     fmt='0.0%'
@@ -801,7 +801,7 @@ order by team_name
     y=win_pct
     title="Winning — Win Rate %"
     yAxisTitle="Win Rate %"
-    colorPalette={['#3b82f6']}
+    colorPalette={['#22c55e']}
     swapXY=true
     sort=true
     fmt='0.0%'

--- a/dashboards/pages/player-analytics.md
+++ b/dashboards/pages/player-analytics.md
@@ -570,7 +570,7 @@ select * from ranked where player_name = '${inputs.player.value}'
     <img src="{podium_players[1]?.team_logo}" alt="{podium_players[1]?.team_name}" style="height:1.375rem;width:1.375rem;object-fit:contain;margin-bottom:0.5rem;" onerror="this.style.display='none'" />
     <div style="background:#f1f5f9;border-radius:8px;padding:0.2rem 0.625rem 0.3rem;text-align:center;margin-bottom:0.625rem;">
       <div style="font-size:1.375rem;font-weight:900;color:#475569;line-height:1.15;">{podium_players[1]?.measure_value % 1 === 0 ? Math.round(podium_players[1].measure_value) : podium_players[1].measure_value}</div>
-      <div style="font-size:0.55rem;color:#94a3b8;text-transform:uppercase;letter-spacing:0.06em;white-space:nowrap;">{inputs.podium_measure.label}</div>
+      <div style="font-size:0.55rem;color:#94a3b8;text-transform:uppercase;letter-spacing:0.04em;word-break:break-word;line-height:1.3;">{inputs.podium_measure.label}</div>
     </div>
     <div style="width:100%;height:68px;background:linear-gradient(to bottom,#b0bec5,#90a4ae);border-radius:4px 4px 0 0;"></div>
   </div>
@@ -584,7 +584,7 @@ select * from ranked where player_name = '${inputs.player.value}'
     <img src="{podium_players[0]?.team_logo}" alt="{podium_players[0]?.team_name}" style="height:1.625rem;width:1.625rem;object-fit:contain;margin-bottom:0.5rem;" onerror="this.style.display='none'" />
     <div style="background:#fef9c3;border-radius:8px;padding:0.2rem 0.75rem 0.3rem;text-align:center;margin-bottom:0.625rem;">
       <div style="font-size:1.875rem;font-weight:900;color:#ca8a04;line-height:1.15;">{podium_players[0]?.measure_value % 1 === 0 ? Math.round(podium_players[0].measure_value) : podium_players[0].measure_value}</div>
-      <div style="font-size:0.6rem;color:#a16207;text-transform:uppercase;letter-spacing:0.06em;white-space:nowrap;">{inputs.podium_measure.label}</div>
+      <div style="font-size:0.6rem;color:#a16207;text-transform:uppercase;letter-spacing:0.04em;word-break:break-word;line-height:1.3;">{inputs.podium_measure.label}</div>
     </div>
     <div style="width:100%;height:100px;background:linear-gradient(to bottom,#fbbf24,#d97706);border-radius:4px 4px 0 0;"></div>
   </div>
@@ -598,7 +598,7 @@ select * from ranked where player_name = '${inputs.player.value}'
     <img src="{podium_players[2]?.team_logo}" alt="{podium_players[2]?.team_name}" style="height:1.25rem;width:1.25rem;object-fit:contain;margin-bottom:0.5rem;" onerror="this.style.display='none'" />
     <div style="background:#fdf4e7;border-radius:8px;padding:0.2rem 0.625rem 0.3rem;text-align:center;margin-bottom:0.625rem;">
       <div style="font-size:1.125rem;font-weight:900;color:#92400e;line-height:1.15;">{podium_players[2]?.measure_value % 1 === 0 ? Math.round(podium_players[2].measure_value) : podium_players[2].measure_value}</div>
-      <div style="font-size:0.55rem;color:#b45309;text-transform:uppercase;letter-spacing:0.06em;white-space:nowrap;">{inputs.podium_measure.label}</div>
+      <div style="font-size:0.55rem;color:#b45309;text-transform:uppercase;letter-spacing:0.04em;word-break:break-word;line-height:1.3;">{inputs.podium_measure.label}</div>
     </div>
     <div style="width:100%;height:44px;background:linear-gradient(to bottom,#cd7c2f,#a05c24);border-radius:4px 4px 0 0;"></div>
   </div>

--- a/dashboards/pages/player-analytics.md
+++ b/dashboards/pages/player-analytics.md
@@ -725,7 +725,7 @@ select * from ranked where player_name = '${inputs.player.value}'
     <div class="flex items-center gap-3">
       <div class="text-xs text-gray-500 w-28 shrink-0 text-right">Attacking</div>
       <div class="flex-1 bg-gray-100 rounded-full h-2.5">
-        <div class="h-2.5 rounded-full bg-amber-400" style="width:{lc.attacking_pct}%"></div>
+        <div class="h-2.5 rounded-full bg-blue-500" style="width:{lc.attacking_pct}%"></div>
       </div>
       <div class="text-xs font-bold text-gray-700 w-8 shrink-0 text-right">{lc.attacking_pct}</div>
     </div>
@@ -757,7 +757,7 @@ select * from ranked where player_name = '${inputs.player.value}'
     <div class="flex items-center gap-3">
       <div class="text-xs text-gray-500 w-28 shrink-0 text-right">Physicality</div>
       <div class="flex-1 bg-gray-100 rounded-full h-2.5">
-        <div class="h-2.5 rounded-full bg-orange-400" style="width:{lc.physicality_pct}%"></div>
+        <div class="h-2.5 rounded-full bg-amber-400" style="width:{lc.physicality_pct}%"></div>
       </div>
       <div class="text-xs font-bold text-gray-700 w-8 shrink-0 text-right">{lc.physicality_pct}</div>
     </div>
@@ -806,7 +806,7 @@ select * from (values
     xAxisTitle="Round"
     yAxisTitle="Goals"
     y2AxisTitle="Rating"
-    colorPalette={['#fbbf24','#94a3b8']}
+    colorPalette={['#3b82f6','#94a3b8']}
     y2Min=0
     y2Max=10
     echartsOptions={{yAxis: [{minInterval: 1}, {min: 0, max: 10}]}}
@@ -866,7 +866,7 @@ select * from (values
     xAxisTitle="Round"
     yAxisTitle="Duel Win %"
     y2AxisTitle="Rating"
-    colorPalette={['#fb923c','#94a3b8']}
+    colorPalette={['#f59e0b','#94a3b8']}
     y2Min=0
     y2Max=10
     echartsOptions={{yAxis: [{minInterval: 1}, {min: 0, max: 10}]}}
@@ -980,19 +980,19 @@ select * from (values
     <Column id=result_badge title="Result"   contentType=html align=center />
     <Column id=rating              title="Rating"         align=center contentType=colorscale colorPalette={['white','#8b5cf6']} />
     {#if inputs.atk.value?.includes('goals')}
-    <Column id=goals           title="Goals"       align=center contentType=colorscale colorPalette={['white','#fbbf24']} />
+    <Column id=goals           title="Goals"       align=center contentType=colorscale colorPalette={['white','#3b82f6']} />
     {/if}
     {#if inputs.atk.value?.includes('assists')}
-    <Column id=assists         title="Assists"     align=center contentType=colorscale colorPalette={['white','#fbbf24']} />
+    <Column id=assists         title="Assists"     align=center contentType=colorscale colorPalette={['white','#3b82f6']} />
     {/if}
     {#if inputs.atk.value?.includes('shots_on_target')}
-    <Column id=shots_on_target title="SoT"         align=center contentType=colorscale colorPalette={['white','#fbbf24']} />
+    <Column id=shots_on_target title="SoT"         align=center contentType=colorscale colorPalette={['white','#3b82f6']} />
     {/if}
     {#if inputs.atk.value?.includes('shot_conv')}
-    <Column id=shot_conv       title="Shot Conv %"  align=center contentType=colorscale colorPalette={['white','#fbbf24']} />
+    <Column id=shot_conv       title="Shot Conv %"  align=center contentType=colorscale colorPalette={['white','#3b82f6']} />
     {/if}
     {#if inputs.atk.value?.includes('woodwork_hits')}
-    <Column id=woodwork_hits   title="Woodwork"    align=center contentType=colorscale colorPalette={['white','#fbbf24']} />
+    <Column id=woodwork_hits   title="Woodwork"    align=center contentType=colorscale colorPalette={['white','#3b82f6']} />
     {/if}
     {#if inputs.cre.value?.includes('big_chances_created')}
     <Column id=big_chances_created title="Big Chances"    align=center contentType=colorscale colorPalette={['white','#38bdf8']} />
@@ -1144,19 +1144,19 @@ select * from (values
     <Column id=result_badge title="Result"   contentType=html align=center />
     <Column id=rating              title="Rating"         align=center contentType=colorscale colorPalette={['white','#8b5cf6']} />
     {#if inputs.atk.value?.includes('goals')}
-    <Column id=goals           title="Goals"       align=center contentType=colorscale colorPalette={['white','#fbbf24']} />
+    <Column id=goals           title="Goals"       align=center contentType=colorscale colorPalette={['white','#3b82f6']} />
     {/if}
     {#if inputs.atk.value?.includes('assists')}
-    <Column id=assists         title="Assists"     align=center contentType=colorscale colorPalette={['white','#fbbf24']} />
+    <Column id=assists         title="Assists"     align=center contentType=colorscale colorPalette={['white','#3b82f6']} />
     {/if}
     {#if inputs.atk.value?.includes('shots_on_target')}
-    <Column id=shots_on_target title="SoT"         align=center contentType=colorscale colorPalette={['white','#fbbf24']} />
+    <Column id=shots_on_target title="SoT"         align=center contentType=colorscale colorPalette={['white','#3b82f6']} />
     {/if}
     {#if inputs.atk.value?.includes('shot_conv')}
-    <Column id=shot_conv       title="Shot Conv %"  align=center contentType=colorscale colorPalette={['white','#fbbf24']} />
+    <Column id=shot_conv       title="Shot Conv %"  align=center contentType=colorscale colorPalette={['white','#3b82f6']} />
     {/if}
     {#if inputs.atk.value?.includes('woodwork_hits')}
-    <Column id=woodwork_hits   title="Woodwork"    align=center contentType=colorscale colorPalette={['white','#fbbf24']} />
+    <Column id=woodwork_hits   title="Woodwork"    align=center contentType=colorscale colorPalette={['white','#3b82f6']} />
     {/if}
     {#if inputs.cre.value?.includes('big_chances_created')}
     <Column id=big_chances_created title="Big Chances"    align=center contentType=colorscale colorPalette={['white','#38bdf8']} />

--- a/dashboards/pages/team-analytics.md
+++ b/dashboards/pages/team-analytics.md
@@ -488,6 +488,7 @@ end
     colorPalette={['#22c55e','#ef4444']}
     markers=true
     chartAreaHeight=280
+    echartsOptions={{series: [{markLine: {silent: true, symbol: ['none','none'], label: {show: false}, data: goals_per_round.map(r => ([{coord: [r.round, r.goals_scored]}, {coord: [r.round, r.goals_conceded], lineStyle: {color: r.goals_scored >= r.goals_conceded ? '#22c55e' : '#ef4444', width: 2, opacity: 0.5}}]))}}]}}
 />
 
 ## Goals by Opponent

--- a/dashboards/pages/team-analytics.md
+++ b/dashboards/pages/team-analytics.md
@@ -485,10 +485,10 @@ end
     y={['goals_scored','goals_conceded']}
     xAxisTitle="Round"
     yAxisTitle="Goals"
-    colorPalette={['#22c55e','#ef4444']}
+    colorPalette={['#3b82f6','#f97316']}
     markers=true
     chartAreaHeight=280
-    echartsOptions={{series: [{markLine: {silent: true, symbol: ['none','none'], label: {show: false}, data: goals_per_round.map(r => ([{coord: [r.round, r.goals_scored]}, {coord: [r.round, r.goals_conceded], lineStyle: {color: r.goals_scored >= r.goals_conceded ? '#22c55e' : '#ef4444', width: 2, opacity: 0.5}}]))}}]}}
+    echartsOptions={{series: [{markLine: {silent: true, symbol: ['none','none'], label: {show: false}, data: goals_per_round.map(r => ([{coord: [r.round, r.goals_scored]}, {coord: [r.round, r.goals_conceded], lineStyle: {color: r.goals_scored >= r.goals_conceded ? '#3b82f6' : '#f97316', width: 2, opacity: 0.5}}]))}}]}}
 />
 
 ## Goals by Opponent
@@ -499,7 +499,7 @@ end
     y={['goals_scored','goals_conceded']}
     type=grouped
     swapXY=true
-    colorPalette={['#22c55e','#ef4444']}
+    colorPalette={['#3b82f6','#f97316']}
     seriesOptions={{"barGap": "0%"}}
     xAxisTitle="Goals"
     yAxisTitle="Opponent"
@@ -528,7 +528,7 @@ end
     x=venue
     y={['goals_per_match','conceded_per_match']}
     title="Goals Scored vs Conceded per Match"
-    colorPalette={['#22c55e','#ef4444']}
+    colorPalette={['#3b82f6','#f97316']}
     type=grouped
     sort=false
 />
@@ -574,7 +574,7 @@ end
     x=formation
     y={['goals_per_match','conceded_per_match']}
     title="Goals per Match by Formation"
-    colorPalette={['#22c55e','#ef4444']}
+    colorPalette={['#3b82f6','#f97316']}
     type=grouped
     sort=false
 />
@@ -620,8 +620,8 @@ end
     <Column id=home_away     title="H/A"         align=center />
     <Column id=opponent      title="Opponent"    />
     <Column id=result_badge  title="Result"      contentType=html align=center />
-    <Column id=gf            title="GF"          align=center contentType=colorscale colorPalette={['white','#22c55e']} />
-    <Column id=ga            title="GA"          align=center contentType=colorscale colorPalette={['white','#ef4444']} />
+    <Column id=gf            title="GF"          align=center contentType=colorscale colorPalette={['white','#3b82f6']} />
+    <Column id=ga            title="GA"          align=center contentType=colorscale colorPalette={['white','#f97316']} />
     <Column id=possession    title="Poss %"      fmt='0.0"%"' contentType=colorscale colorPalette={['white','#8b5cf6']} />
     <Column id=pass_accuracy title="Pass Acc %"  fmt='0.0"%"' contentType=colorscale colorPalette={['white','#3b82f6']} />
     <Column id=shots_on_goal title="SoG"         align=center contentType=colorscale colorPalette={['white','#3b82f6']} />
@@ -634,8 +634,8 @@ end
     <Column id=match_date    title="Date"        />
     <Column id=opponent      title="Opponent"    />
     <Column id=result_badge  title="Result"      contentType=html align=center />
-    <Column id=gf            title="GF"          align=center contentType=colorscale colorPalette={['white','#22c55e']} />
-    <Column id=ga            title="GA"          align=center contentType=colorscale colorPalette={['white','#ef4444']} />
+    <Column id=gf            title="GF"          align=center contentType=colorscale colorPalette={['white','#3b82f6']} />
+    <Column id=ga            title="GA"          align=center contentType=colorscale colorPalette={['white','#f97316']} />
     <Column id=possession    title="Poss %"      fmt='0.0"%"' contentType=colorscale colorPalette={['white','#8b5cf6']} />
     <Column id=pass_accuracy title="Pass Acc %"  fmt='0.0"%"' contentType=colorscale colorPalette={['white','#3b82f6']} />
     <Column id=shots_on_goal title="SoG"         align=center contentType=colorscale colorPalette={['white','#3b82f6']} />


### PR DESCRIPTION
## Summary

- **Semantic color system** — green/red reserved strictly for Win/Loss results; goals scored now blue (`#3b82f6`), goals conceded orange (`#f97316`) across team, league, and player pages
- **Goals per Round chart** — added per-round connecting line segments between scored/conceded data points, colored blue when GF ≥ GA and orange otherwise
- **League domain charts** — 6 distinct colors so no two domains look similar
- **Player page** — progress bar colors aligned with timeline chart colors; podium measure label wraps on mobile instead of overflowing
- **Match Schedule section** — new section at the bottom of the league page with matches by day of week (stacked by time of day) and goals per match by time slot, with an intro explaining the time slot boundaries

## Test plan

- [ ] Team page: Goals per Round connecting lines visible and correctly colored
- [ ] Team page: No green/red outside of result-based charts
- [ ] League page: Domain chart bars are visually distinct colors
- [ ] League page: Match Schedule section renders with correct day/time ordering
- [ ] Player page: Progress bar colors match timeline chart colors
- [ ] Player page: Podium measure label wraps correctly on narrow screens

🤖 Generated with [Claude Code](https://claude.com/claude-code)