### PR TITLE
fix(gold): explicitly cast starting_at as UTC before CET conversion

### DIFF
--- a/dbt/models/gold/dims/dim_match.sql
+++ b/dbt/models/gold/dims/dim_match.sql
@@ -66,9 +66,9 @@ src AS (
         CASE WHEN f.state_developer_name IN ('FT', 'FT_PEN', 'AET')
              THEN sp.goals_home::VARCHAR || ' - ' || sp.goals_away::VARCHAR
         END                                                                      AS match_result,
-        lpad(EXTRACT(hour   FROM f.starting_at::TIMESTAMPTZ AT TIME ZONE 'Europe/Copenhagen')::VARCHAR, 2, '0')
+        lpad(EXTRACT(hour   FROM (f.starting_at::TIMESTAMP AT TIME ZONE 'UTC') AT TIME ZONE 'Europe/Copenhagen')::VARCHAR, 2, '0')
             || ':'
-            || lpad(EXTRACT(minute FROM f.starting_at::TIMESTAMPTZ AT TIME ZONE 'Europe/Copenhagen')::VARCHAR, 2, '0')
+            || lpad(EXTRACT(minute FROM (f.starting_at::TIMESTAMP AT TIME ZONE 'UTC') AT TIME ZONE 'Europe/Copenhagen')::VARCHAR, 2, '0')
                                                                                  AS kick_off_time,
         f.state_name                                                             AS match_status
     FROM {{ ref('fixtures') }} f

--- a/dbt/models/gold/fct_player_appearances.sql
+++ b/dbt/models/gold/fct_player_appearances.sql
@@ -391,7 +391,7 @@ SELECT
     src.rating
 FROM src
 LEFT JOIN {{ ref('dim_date') }}          dd      ON dd.date              = src.starting_at::DATE
-LEFT JOIN {{ ref('dim_time') }}          dt_time ON dt_time.time_sk      = EXTRACT(hour FROM src.starting_at::TIMESTAMPTZ AT TIME ZONE 'Europe/Copenhagen')::INTEGER
+LEFT JOIN {{ ref('dim_time') }}          dt_time ON dt_time.time_sk      = EXTRACT(hour FROM (src.starting_at::TIMESTAMP AT TIME ZONE 'UTC') AT TIME ZONE 'Europe/Copenhagen')::INTEGER
 LEFT JOIN {{ ref('dim_match') }}         dm      ON dm.match_id          = src.fixture_id
 LEFT JOIN {{ ref('dim_player') }}        dp      ON dp.player_id         = src.player_id
 LEFT JOIN {{ ref('dim_team') }}          dteam   ON dteam.team_id        = src.team_id

--- a/dbt/models/gold/fct_team_matches.sql
+++ b/dbt/models/gold/fct_team_matches.sql
@@ -141,7 +141,7 @@ SELECT
     src.red_cards
 FROM src
 LEFT JOIN {{ ref('dim_date') }}          dd      ON dd.date              = src.starting_at::DATE
-LEFT JOIN {{ ref('dim_time') }}          dt_time ON dt_time.time_sk      = EXTRACT(hour FROM src.starting_at::TIMESTAMPTZ AT TIME ZONE 'Europe/Copenhagen')::INTEGER
+LEFT JOIN {{ ref('dim_time') }}          dt_time ON dt_time.time_sk      = EXTRACT(hour FROM (src.starting_at::TIMESTAMP AT TIME ZONE 'UTC') AT TIME ZONE 'Europe/Copenhagen')::INTEGER
 LEFT JOIN {{ ref('dim_team') }}          dteam   ON dteam.team_id        = src.team_id
 LEFT JOIN {{ ref('dim_opponent_team') }} dopp    ON dopp.opponent_team_id = src.opponent_team_id
 LEFT JOIN {{ ref('dim_league') }}        dl      ON dl.league_id         = src.league_id


### PR DESCRIPTION
## Summary

- The formula `starting_at::TIMESTAMPTZ AT TIME ZONE 'Europe/Copenhagen'` was session-timezone-dependent
- When the dbt/MotherDuck session timezone is `Europe/Copenhagen`, DuckDB interprets the naive timestamp as already being in local time, making the conversion a round-trip no-op — returning the UTC hour instead of the correct CET hour
- Fix: `(starting_at::TIMESTAMP AT TIME ZONE 'UTC') AT TIME ZONE 'Europe/Copenhagen'` explicitly declares the value as UTC first, making it deterministic regardless of session timezone

## Affected models

- `fct_team_matches` — `time_sk` was wrong for all matches
- `fct_player_appearances` — `time_sk` was wrong for all appearances
- `dim_match` — `kick_off_time` was potentially wrong depending on session timezone

## After merging

Trigger a **full refresh** of the gold layer so all historical rows are reprocessed with the correct CET hours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)