### PR TITLE
feat(league): add match log explorer table

### DIFF
--- a/dashboards/pages/league-analytics.md
+++ b/dashboards/pages/league-analytics.md
@@ -358,6 +358,39 @@ where ('All Teams' in ${inputs.team.value} OR team_name in ${inputs.team.value})
 order by team_name
 ```
 
+```sql match_log
+select
+    season,
+    match_date,
+    month_name,
+    day_name,
+    is_weekend,
+    kick_off_time,
+    period_of_day,
+    match_round_name,
+    match_round_type,
+    standings_type,
+    match_name,
+    score,
+    match_status,
+    max(case when team_side = 'Home' then formation end) as home_formation,
+    max(case when team_side = 'Away' then formation end) as away_formation,
+    max(case when team_side = 'Home' then coach_name end) as home_coach,
+    max(case when team_side = 'Away' then coach_name end) as away_coach,
+    referee_name,
+    referee_nationality,
+    stadium_name,
+    stadium_city,
+    stadium_surface
+from superligaen.mart_match_facts
+where season = '${inputs.season.value}'
+  and result in ('Win', 'Draw', 'Loss')
+group by season, match_date, month_name, day_name, is_weekend, kick_off_time, period_of_day,
+         match_round_name, match_round_type, standings_type, match_name, score, match_status,
+         referee_name, referee_nationality, stadium_name, stadium_city, stadium_surface
+order by match_date desc
+```
+
 ```sql match_schedule
 select
     day_name,
@@ -876,4 +909,35 @@ order by case period_of_day
 />
 
 </div>
+
+---
+
+## Match Log
+
+<p style="font-size:0.8125rem;color:#6b7280;margin:0 0 1rem 0;font-style:italic;">All matches for the selected season. Use the search box to drill into a specific team, time slot, day, or round.</p>
+
+<DataTable data={match_log} search=true rows=15>
+    <Column id=season              title="Season"           />
+    <Column id=match_date          title="Date"             />
+    <Column id=month_name          title="Month"            />
+    <Column id=day_name            title="Day"              />
+    <Column id=is_weekend          title="Weekend"          />
+    <Column id=kick_off_time       title="Kick-off"         />
+    <Column id=period_of_day       title="Time Slot"        />
+    <Column id=match_round_name    title="Round"            />
+    <Column id=match_round_type    title="Round Type"       />
+    <Column id=standings_type      title="Phase"            />
+    <Column id=match_name          title="Match"            wrap=true />
+    <Column id=score               title="Score"            align=center />
+    <Column id=match_status        title="Status"           />
+    <Column id=home_formation      title="Home Formation"   />
+    <Column id=away_formation      title="Away Formation"   />
+    <Column id=home_coach          title="Home Coach"       />
+    <Column id=away_coach          title="Away Coach"       />
+    <Column id=referee_name        title="Referee"          />
+    <Column id=referee_nationality title="Ref. Nationality" />
+    <Column id=stadium_name        title="Stadium"          />
+    <Column id=stadium_city        title="City"             />
+    <Column id=stadium_surface     title="Surface"          />
+</DataTable>
 

--- a/dashboards/pages/league-analytics.md
+++ b/dashboards/pages/league-analytics.md
@@ -359,7 +359,7 @@ order by team_name
 ```
 
 ```sql match_log
-select
+select distinct
     season,
     match_date,
     month_name,
@@ -367,28 +367,29 @@ select
     is_weekend,
     kick_off_time,
     period_of_day,
+    cast(match_round_number as integer) as match_round_number,
     match_round_name,
     match_round_type,
     standings_type,
     match_name,
     score,
     match_status,
-    max(case when team_side = 'Home' then formation end) as home_formation,
-    max(case when team_side = 'Away' then formation end) as away_formation,
-    max(case when team_side = 'Home' then coach_name end) as home_coach,
-    max(case when team_side = 'Away' then coach_name end) as away_coach,
+    team_name,
+    team_side,
+    result,
+    opponent_team_name,
+    formation,
+    coach_name,
     referee_name,
     referee_nationality,
     stadium_name,
     stadium_city,
-    stadium_surface
+    stadium_surface,
+    goals_scored
 from superligaen.mart_match_facts
 where season = '${inputs.season.value}'
   and result in ('Win', 'Draw', 'Loss')
-group by season, match_date, month_name, day_name, is_weekend, kick_off_time, period_of_day,
-         match_round_name, match_round_type, standings_type, match_name, score, match_status,
-         referee_name, referee_nationality, stadium_name, stadium_city, stadium_surface
-order by match_date desc
+order by match_date desc, team_name
 ```
 
 ```sql match_schedule
@@ -914,9 +915,9 @@ order by case period_of_day
 
 ## Match Log
 
-<p style="font-size:0.8125rem;color:#6b7280;margin:0 0 1rem 0;font-style:italic;">All matches for the selected season. Use the search box to drill into a specific team, time slot, day, or round.</p>
+<p style="font-size:0.8125rem;color:#6b7280;margin:0 0 1rem 0;font-style:italic;">Every team appearance for the selected season — one row per team per match. Search by anything: team, opponent, result, formation, coach, referee, stadium, time slot, day, round, etc.</p>
 
-<DataTable data={match_log} search=true rows=15>
+<DataTable data={match_log} search=true rows=6>
     <Column id=season              title="Season"           />
     <Column id=match_date          title="Date"             />
     <Column id=month_name          title="Month"            />
@@ -924,20 +925,24 @@ order by case period_of_day
     <Column id=is_weekend          title="Weekend"          />
     <Column id=kick_off_time       title="Kick-off"         />
     <Column id=period_of_day       title="Time Slot"        />
+    <Column id=match_round_number  title="Round #"          align=center />
     <Column id=match_round_name    title="Round"            />
     <Column id=match_round_type    title="Round Type"       />
     <Column id=standings_type      title="Phase"            />
     <Column id=match_name          title="Match"            wrap=true />
     <Column id=score               title="Score"            align=center />
     <Column id=match_status        title="Status"           />
-    <Column id=home_formation      title="Home Formation"   />
-    <Column id=away_formation      title="Away Formation"   />
-    <Column id=home_coach          title="Home Coach"       />
-    <Column id=away_coach          title="Away Coach"       />
+    <Column id=team_name           title="Team"             />
+    <Column id=team_side           title="Side"             />
+    <Column id=result              title="Result"           />
+    <Column id=opponent_team_name  title="Opponent"         />
+    <Column id=formation           title="Formation"        />
+    <Column id=coach_name          title="Coach"            />
     <Column id=referee_name        title="Referee"          />
     <Column id=referee_nationality title="Ref. Nationality" />
     <Column id=stadium_name        title="Stadium"          />
     <Column id=stadium_city        title="City"             />
     <Column id=stadium_surface     title="Surface"          />
+    <Column id=goals_scored        title="Goals"            align=center contentType=colorscale colorPalette={['white','#3b82f6']} />
 </DataTable>
 


### PR DESCRIPTION
## Summary

- Adds a searchable **Match Log** table at the bottom of the League Intelligence page
- One row per team per match, covering all dimensional attributes from `mart_match_facts` (25 columns + goals scored)
- Search by anything: team, opponent, result, formation, coach, referee, stadium, time slot, day, round, etc.
- 6 rows per page to keep the page compact

## Test plan

- [ ] Table renders correctly at the bottom of the league page
- [ ] Search filters across all columns (try "Morning", a team name, a formation)
- [ ] Goals scored colorscale renders correctly
- [ ] Pagination works

🤖 Generated with [Claude Code](https://claude.com/claude-code)