### PR TITLE
fix: workflow YAML parse error causing un-triggerable actions

### DIFF
--- a/.github/workflows/discussions.yml
+++ b/.github/workflows/discussions.yml
@@ -45,13 +45,7 @@ jobs:
           if [ -n "${{ github.event.inputs.season }}" ]; then
             SEASON="${{ github.event.inputs.season }}"
           else
-            SEASON=$(python - <<'EOF'
-import duckdb, os
-con = duckdb.connect(f"md:{os.environ['DB']}?motherduck_token={os.environ['MOTHERDUCK_TOKEN']}")
-row = con.execute(f"SELECT season FROM {os.environ['DB']}.gold.dim_date WHERE is_current_season ORDER BY date DESC LIMIT 1").fetchone()
-print(row[0] if row else "")
-EOF
-            )
+            SEASON=$(python -c "import duckdb,os; con=duckdb.connect('md:'+os.environ['DB']+'?motherduck_token='+os.environ['MOTHERDUCK_TOKEN']); row=con.execute('SELECT season FROM '+os.environ['DB']+'.gold.dim_date WHERE is_current_season ORDER BY date DESC LIMIT 1').fetchone(); print(row[0] if row else '')")
           fi
           if [ -z "$SEASON" ]; then echo "No current season found" && exit 1; fi
           echo "Generating discussions for season: $SEASON"

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -221,13 +221,7 @@ jobs:
       - name: Generate discussions for latest round
         run: |
           DB="${{ github.event.inputs.target_db || 'superligaen' }}"
-          SEASON=$(python - <<'EOF'
-import duckdb, os
-con = duckdb.connect(f"md:{os.environ['DB']}?motherduck_token={os.environ['MOTHERDUCK_TOKEN']}")
-row = con.execute(f"SELECT season FROM {os.environ['DB']}.gold.dim_date WHERE is_current_season ORDER BY date DESC LIMIT 1").fetchone()
-print(row[0] if row else "")
-EOF
-          )
+          SEASON=$(python -c "import duckdb,os; con=duckdb.connect('md:'+os.environ['DB']+'?motherduck_token='+os.environ['MOTHERDUCK_TOKEN']); row=con.execute('SELECT season FROM '+os.environ['DB']+'.gold.dim_date WHERE is_current_season ORDER BY date DESC LIMIT 1').fetchone(); print(row[0] if row else '')")
           if [ -z "$SEASON" ]; then echo "No current season found" && exit 1; fi
           echo "Generating discussions for season: $SEASON"
           EXTRA_ARGS=""


### PR DESCRIPTION
## Problem

`master.yml` and `discussions.yml` were showing as file paths in the GitHub Actions sidebar and couldn't be triggered. Root cause: both files contained a Python heredoc (`<<'EOF'`) whose content sat at column 0, which breaks GitHub's YAML parser — it can't read the `name:` field and falls back to the file path.

## Fix

Replaced the 6-line heredoc with an equivalent `python -c` one-liner that stays within the YAML literal block scalar's indentation.

## Test plan

- [ ] Merge and confirm both workflows appear as "Nightly pipeline" and "AI round discussions" in the Actions sidebar
- [ ] Trigger `discussions.yml` via workflow_dispatch to confirm it runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)