### PR TITLE
feat(dashboard): Fan Forum redesign with user comments

### DIFF
--- a/dashboards/pages/match-results.md
+++ b/dashboards/pages/match-results.md
@@ -6,6 +6,31 @@ title: Match Results
 
 <script>
   import MatchLineup from '../../components/MatchLineup.svelte';
+
+  let commentText = '';
+  let userComments = [];
+
+  $: matchKey = inputs?.season?.value && inputs?.round?.value && inputs?.match?.value
+    ? `fanforum_${inputs.season.value}_${inputs.round.value}_${inputs.match.value}`
+    : null;
+
+  $: if (typeof window !== 'undefined' && matchKey !== undefined) {
+    const stored = matchKey ? localStorage.getItem(matchKey) : null;
+    userComments = stored ? JSON.parse(stored) : [];
+    commentText = '';
+  }
+
+  function postComment() {
+    if (!commentText.trim() || !matchKey) return;
+    const entry = { text: commentText.trim(), time: new Date().toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }) };
+    userComments = [...userComments, entry];
+    localStorage.setItem(matchKey, JSON.stringify(userComments));
+    commentText = '';
+  }
+
+  function handleKeydown(e) {
+    if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) postComment();
+  }
 </script>
 
 ```sql seasons
@@ -628,14 +653,14 @@ order by team_side desc, position_group, position_name
 
 <div style="display:flex;align-items:baseline;gap:10px;margin-bottom:4px;">
   <h2 style="margin:0;">Fan Forum</h2>
-  <span style="font-size:0.8125rem;color:#6b7280;">{discussions.length} comments</span>
+  <span style="font-size:0.8125rem;color:#6b7280;">{discussions.length + userComments.length} comments</span>
 </div>
 
-<p style="font-size:0.8125rem;color:#6b7280;margin:0 0 20px;font-style:italic;">Four fans react to this match — grounded in the actual data, not always agreeing.</p>
+<p style="font-size:0.8125rem;color:#6b7280;margin:0 0 20px;font-style:italic;">Fan reactions to this match. Drop your take below.</p>
 
 <div style="display:flex;flex-direction:column;gap:0;margin-bottom:32px;border:1px solid #e5e7eb;border-radius:12px;overflow:hidden;">
-  {#each discussions as post, i}
-  <div style="display:flex;gap:12px;padding:16px 20px;background:white;{i < discussions.length - 1 ? 'border-bottom:1px solid #f3f4f6;' : ''}">
+  {#each discussions as post}
+  <div style="display:flex;gap:12px;padding:16px 20px;background:white;border-bottom:1px solid #f3f4f6;">
     <div style="flex-shrink:0;width:36px;height:36px;border-radius:50%;background:#f3f4f6;display:flex;align-items:center;justify-content:center;font-size:1.125rem;line-height:1;">
       {post.persona_icon}
     </div>
@@ -648,5 +673,45 @@ order by team_side desc, position_group, position_name
     </div>
   </div>
   {/each}
+
+  {#each userComments as comment}
+  <div style="display:flex;gap:12px;padding:16px 20px;background:white;border-bottom:1px solid #f3f4f6;">
+    <div style="flex-shrink:0;width:36px;height:36px;border-radius:50%;background:#dbeafe;display:flex;align-items:center;justify-content:center;font-size:1.125rem;line-height:1;">
+      👤
+    </div>
+    <div style="flex:1;min-width:0;">
+      <div style="display:flex;align-items:baseline;gap:8px;margin-bottom:6px;">
+        <span style="font-size:0.8125rem;font-weight:700;color:#111827;">You</span>
+        <span style="font-size:0.75rem;color:#9ca3af;">· {comment.time}</span>
+      </div>
+      <div style="font-size:0.875rem;color:#374151;line-height:1.6;">{comment.text}</div>
+    </div>
+  </div>
+  {/each}
+
+  <div style="display:flex;gap:12px;padding:16px 20px;background:#fafafa;">
+    <div style="flex-shrink:0;width:36px;height:36px;border-radius:50%;background:#dbeafe;display:flex;align-items:center;justify-content:center;font-size:1.125rem;line-height:1;">
+      👤
+    </div>
+    <div style="flex:1;min-width:0;">
+      <textarea
+        bind:value={commentText}
+        on:keydown={handleKeydown}
+        placeholder="Add a comment…"
+        rows="2"
+        style="width:100%;border:1px solid #e5e7eb;border-radius:8px;padding:8px 12px;font-size:0.875rem;color:#374151;resize:none;outline:none;font-family:inherit;background:white;box-sizing:border-box;"
+      ></textarea>
+      {#if commentText.trim()}
+      <div style="display:flex;justify-content:flex-end;margin-top:8px;">
+        <button
+          on:click={postComment}
+          style="background:#2563eb;color:white;border:none;border-radius:6px;padding:6px 16px;font-size:0.8125rem;font-weight:600;cursor:pointer;"
+        >
+          Post
+        </button>
+      </div>
+      {/if}
+    </div>
+  </div>
 </div>
 {/if}

--- a/dashboards/pages/match-results.md
+++ b/dashboards/pages/match-results.md
@@ -626,17 +626,26 @@ order by team_side desc, position_group, position_name
 
 ---
 
-## Fan Forum
+<div style="display:flex;align-items:baseline;gap:10px;margin-bottom:4px;">
+  <h2 style="margin:0;">Fan Forum</h2>
+  <span style="font-size:0.8125rem;color:#6b7280;">{discussions.length} comments</span>
+</div>
 
-<p style="font-size:0.8125rem;color:#6b7280;margin:-8px 0 16px;font-style:italic;">Four fans react to this match — grounded in the actual data, not always agreeing.</p>
+<p style="font-size:0.8125rem;color:#6b7280;margin:0 0 20px;font-style:italic;">Four fans react to this match — grounded in the actual data, not always agreeing.</p>
 
-<div class="space-y-4 mb-8">
-  {#each discussions as post}
-  <div style="background:white;border:1px solid #e5e7eb;border-radius:12px;padding:16px 20px;">
-    <div style="font-size:0.8125rem;font-weight:700;color:#111827;margin-bottom:8px;">
-      {post.persona_icon} {post.persona_name}
+<div style="display:flex;flex-direction:column;gap:0;margin-bottom:32px;border:1px solid #e5e7eb;border-radius:12px;overflow:hidden;">
+  {#each discussions as post, i}
+  <div style="display:flex;gap:12px;padding:16px 20px;background:white;{i < discussions.length - 1 ? 'border-bottom:1px solid #f3f4f6;' : ''}">
+    <div style="flex-shrink:0;width:36px;height:36px;border-radius:50%;background:#f3f4f6;display:flex;align-items:center;justify-content:center;font-size:1.125rem;line-height:1;">
+      {post.persona_icon}
     </div>
-    <div style="font-size:0.875rem;color:#374151;line-height:1.6;">{post.message}</div>
+    <div style="flex:1;min-width:0;">
+      <div style="display:flex;align-items:baseline;gap:8px;margin-bottom:6px;">
+        <span style="font-size:0.8125rem;font-weight:700;color:#111827;">{post.persona_name}</span>
+        <span style="font-size:0.75rem;color:#9ca3af;">· Match day</span>
+      </div>
+      <div style="font-size:0.875rem;color:#374151;line-height:1.6;">{post.message}</div>
+    </div>
   </div>
   {/each}
 </div>


### PR DESCRIPTION
## Summary
- Redesigned Fan Forum as a proper comment thread: avatar circles, name + timestamp layout, grouped card with dividers, and comment count in the heading
- Added localStorage-based user comment input — comments persist per match (keyed by season/round/match), reset when switching matches
- Updated section caption to "Fan reactions to this match. Drop your take below."

## Test plan
- [ ] Navigate to Match Results and scroll to Fan Forum — verify comment thread layout
- [ ] Type a comment and post it — verify it appears with "You" avatar and timestamp
- [ ] Refresh the page — verify your comment persists
- [ ] Switch to a different match — verify the input clears and previous comments load for that match
- [ ] Verify comment count in heading updates as you add comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)