### PR TITLE
feat(fan-forum): dates, persona initials, and Danish persona overhaul

### DIFF
--- a/dashboards/pages/match-results.md
+++ b/dashboards/pages/match-results.md
@@ -44,7 +44,7 @@ title: Match Results
 
   function postComment() {
     if (!commentText.trim() || !matchKey) return;
-    const entry = { text: commentText.trim(), time: new Date().toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }) };
+    const entry = { text: commentText.trim(), time: new Date().toISOString().split('T')[0] };
     userComments = [...userComments, entry];
     localStorage.setItem(matchKey, JSON.stringify(userComments));
     commentText = '';
@@ -52,6 +52,19 @@ title: Match Results
 
   function handleKeydown(e) {
     if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) postComment();
+  }
+
+  function daysAgo(dateVal) {
+    if (!dateVal) return '';
+    const match = new Date(dateVal);
+    if (isNaN(match)) return '';
+    match.setHours(12, 0, 0, 0);
+    const today = new Date();
+    today.setHours(12, 0, 0, 0);
+    const diff = Math.round((today - match) / 86400000);
+    if (diff === 0) return 'Today';
+    if (diff === 1) return '1 day ago';
+    return `${diff} days ago`;
   }
 </script>
 
@@ -114,7 +127,7 @@ from ${results}
 ```
 
 ```sql discussions
-select persona_name, persona_icon, sort_order, message
+select persona_name, persona_icon, sort_order, message, match_date
 from superligaen.llm_round_discussions
 where season      = '${inputs.season.value}'
   and round_number = ${inputs.round.value}
@@ -689,7 +702,7 @@ order by team_side desc, position_group, position_name
     <div style="flex:1;min-width:0;">
       <div style="display:flex;align-items:baseline;gap:8px;margin-bottom:6px;">
         <span style="font-size:0.8125rem;font-weight:700;color:#111827;">{post.persona_name}</span>
-        <span style="font-size:0.75rem;color:#9ca3af;">· Match day</span>
+        <span style="font-size:0.75rem;color:#9ca3af;">· {daysAgo(post.match_date)}</span>
       </div>
       <div style="font-size:0.875rem;color:#374151;line-height:1.6;">{post.message}</div>
     </div>
@@ -704,7 +717,7 @@ order by team_side desc, position_group, position_name
     <div style="flex:1;min-width:0;">
       <div style="display:flex;align-items:baseline;gap:8px;margin-bottom:6px;">
         <span style="font-size:0.8125rem;font-weight:700;color:#111827;">You</span>
-        <span style="font-size:0.75rem;color:#9ca3af;">· {comment.time}</span>
+        <span style="font-size:0.75rem;color:#9ca3af;">· {daysAgo(comment.time)}</span>
       </div>
       <div style="font-size:0.875rem;color:#374151;line-height:1.6;">{comment.text}</div>
     </div>

--- a/dashboards/pages/match-results.md
+++ b/dashboards/pages/match-results.md
@@ -54,6 +54,17 @@ title: Match Results
     if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) postComment();
   }
 
+  const personaColors = {
+    'Lars':   { bg: '#dbeafe', text: '#1d4ed8' },
+    'Bent':   { bg: '#dcfce7', text: '#15803d' },
+    'Magnus': { bg: '#ede9fe', text: '#6d28d9' },
+    'Sofie':  { bg: '#fce7f3', text: '#be185d' },
+  };
+  function avatarStyle(name) {
+    const c = personaColors[name] ?? { bg: '#f3f4f6', text: '#374151' };
+    return `background:${c.bg};color:${c.text};`;
+  }
+
   function daysAgo(dateVal) {
     if (!dateVal) return '';
     const match = new Date(dateVal);
@@ -696,8 +707,8 @@ order by team_side desc, position_group, position_name
 <div style="display:flex;flex-direction:column;gap:0;margin-bottom:32px;border:1px solid #e5e7eb;border-radius:12px;overflow:hidden;">
   {#each discussions as post}
   <div style="display:flex;gap:12px;padding:16px 20px;background:white;border-bottom:1px solid #f3f4f6;">
-    <div style="flex-shrink:0;width:36px;height:36px;border-radius:50%;background:#f3f4f6;display:flex;align-items:center;justify-content:center;font-size:1.125rem;line-height:1;">
-      {post.persona_icon}
+    <div style="flex-shrink:0;width:36px;height:36px;border-radius:50%;display:flex;align-items:center;justify-content:center;font-size:0.8125rem;font-weight:700;{avatarStyle(post.persona_name)}">
+      {post.persona_name[0]}
     </div>
     <div style="flex:1;min-width:0;">
       <div style="display:flex;align-items:baseline;gap:8px;margin-bottom:6px;">

--- a/dashboards/pages/match-results.md
+++ b/dashboards/pages/match-results.md
@@ -138,7 +138,7 @@ from ${results}
 ```
 
 ```sql discussions
-select persona_name, persona_icon, sort_order, message, match_date
+select persona_name, sort_order, message, match_date
 from superligaen.llm_round_discussions
 where season      = '${inputs.season.value}'
   and round_number = ${inputs.round.value}

--- a/dashboards/pages/match-results.md
+++ b/dashboards/pages/match-results.md
@@ -55,10 +55,10 @@ title: Match Results
   }
 
   const personaColors = {
-    'Lars':   { bg: '#dbeafe', text: '#1d4ed8' },
-    'Bent':   { bg: '#dcfce7', text: '#15803d' },
-    'Magnus': { bg: '#ede9fe', text: '#6d28d9' },
-    'Sofie':  { bg: '#fce7f3', text: '#be185d' },
+    'Søren':   { bg: '#dbeafe', text: '#1d4ed8' },
+    'Flemming': { bg: '#dcfce7', text: '#15803d' },
+    'Rasmus':  { bg: '#ede9fe', text: '#6d28d9' },
+    'Maja':    { bg: '#fce7f3', text: '#be185d' },
   };
   function avatarStyle(name) {
     const c = personaColors[name] ?? { bg: '#f3f4f6', text: '#374151' };

--- a/dashboards/sources/superligaen/llm_round_discussions.sql
+++ b/dashboards/sources/superligaen/llm_round_discussions.sql
@@ -5,7 +5,8 @@ select
     dp.persona_name,
     dp.persona_icon,
     dp.sort_order,
-    f.message
+    f.message,
+    d.date                                                                      as match_date
 from superligaen.gold.fct_match_discussions f
 join superligaen.gold.dim_persona           dp on dp.persona_sk = f.persona_sk
 join superligaen.gold.dim_match             dm on dm.match_sk   = f.match_sk

--- a/dashboards/sources/superligaen/llm_round_discussions.sql
+++ b/dashboards/sources/superligaen/llm_round_discussions.sql
@@ -3,7 +3,6 @@ select
     dm.match_round_number                                                    as round_number,
     dm.match_name,
     dp.persona_name,
-    dp.persona_icon,
     dp.sort_order,
     f.message,
     d.date                                                                      as match_date

--- a/dbt/models/gold/dims/dim_persona.sql
+++ b/dbt/models/gold/dims/dim_persona.sql
@@ -2,12 +2,12 @@
 
 SELECT *
 FROM (VALUES
-    (1, 'Søren',   '📊', 1,
+    (1, 'Søren',   '📊', 2,
      'Data analyst in his early 30s. Trusts only the numbers — shots, possession, big chances, pass accuracy, cards. Never calls a win ''lucky'' when the stats back it up. Precise, occasionally smug, always grounded in the actual data.'),
-    (2, 'Flemming', '⚽', 2,
-     '68-year-old lifelong Danish football fan. Watched the Superliga since it began. Distrusts statistics — thinks you learn everything by watching the game. Values hard work, direct play, and results. Blunt and opinionated, occasionally refers to ''the old days'' but always grounds his point in what happened in this match.'),
+    (2, 'Flemming', '⚽', 1,
+     '68-year-old lifelong Danish football fan. Watched the Superliga since it began. Loves a game with lots of goals. Gets very happy when sees a game with 3 or more goals. Gets crumby when sees a game with 0 or 1 goal. Keeps short comments with full of emotions.'),
     (3, 'Rasmus',  '🔴', 3,
-     'Passionate FC Nordsjælland fan. Even when FCN aren''t playing he relates the match back to FCN — comparing styles, youth development, what FCN would have done differently. Knowledgeable but openly biased. If FCN are in this match he is extremely emotionally invested — elated or devastated.'),
+     'Passionate FC Nordsjælland fan. Always finds a way to bring it back to FCN — their style, their academy, what FCN would have done. If FCN are in this match he is fully emotionally invested. Gets euphoric when his team wins, inconsolable when they lose. Short, biased, unapologetic.'),
     (4, 'Maja',    '🎙️', 4,
-     'Former professional player, now a TV pundit. Focuses on tactics: formations, pressing triggers, transitions, individual positioning. Calm but incisive. Pushes back on Søren when stats miss the tactical story, and on Flemming when old-school thinking misses something structural about the game.')
+     'Lifelong FC København supporter. Measures every match against FCK''s standards — their pressing, their mentality, their winning culture. Openly rates FCK above everyone else. Gets smug when FCK win, gets cutting and dismissive when they don''t. Short comments, strong opinions.')
 ) t(persona_sk, persona_name, persona_icon, sort_order, bio)

--- a/dbt/models/gold/dims/dim_persona.sql
+++ b/dbt/models/gold/dims/dim_persona.sql
@@ -2,12 +2,12 @@
 
 SELECT *
 FROM (VALUES
-    (1, 'Lars',   '📊', 1,
+    (1, 'Søren',   '📊', 1,
      'Data analyst in his early 30s. Trusts only the numbers — shots, possession, big chances, pass accuracy, cards. Never calls a win ''lucky'' when the stats back it up. Precise, occasionally smug, always grounded in the actual data.'),
-    (2, 'Bent',   '⚽', 2,
+    (2, 'Flemming', '⚽', 2,
      '68-year-old lifelong Danish football fan. Watched the Superliga since it began. Distrusts statistics — thinks you learn everything by watching the game. Values hard work, direct play, and results. Blunt and opinionated, occasionally refers to ''the old days'' but always grounds his point in what happened in this match.'),
-    (3, 'Magnus', '🔴', 3,
+    (3, 'Rasmus',  '🔴', 3,
      'Passionate FC Nordsjælland fan. Even when FCN aren''t playing he relates the match back to FCN — comparing styles, youth development, what FCN would have done differently. Knowledgeable but openly biased. If FCN are in this match he is extremely emotionally invested — elated or devastated.'),
-    (4, 'Sofie',  '🎙️', 4,
-     'Former professional player, now a TV pundit. Focuses on tactics: formations, pressing triggers, transitions, individual positioning. Calm but incisive. Pushes back on Lars when stats miss the tactical story, and on Bent when old-school thinking misses something structural about the game.')
+    (4, 'Maja',    '🎙️', 4,
+     'Former professional player, now a TV pundit. Focuses on tactics: formations, pressing triggers, transitions, individual positioning. Calm but incisive. Pushes back on Søren when stats miss the tactical story, and on Flemming when old-school thinking misses something structural about the game.')
 ) t(persona_sk, persona_name, persona_icon, sort_order, bio)

--- a/dbt/models/gold/dims/dim_persona.sql
+++ b/dbt/models/gold/dims/dim_persona.sql
@@ -2,12 +2,12 @@
 
 SELECT *
 FROM (VALUES
-    (1, 'Søren',   '📊', 2,
+    (1, 'Søren',   2,
      'Data analyst in his early 30s. Trusts only the numbers — shots, possession, big chances, pass accuracy, cards. Never calls a win ''lucky'' when the stats back it up. Precise, occasionally smug, always grounded in the actual data.'),
-    (2, 'Flemming', '⚽', 1,
+    (2, 'Flemming', 1,
      '68-year-old lifelong Danish football fan. Watched the Superliga since it began. Loves a game with lots of goals. Gets very happy when sees a game with 3 or more goals. Gets crumby when sees a game with 0 or 1 goal. Keeps short comments with full of emotions.'),
-    (3, 'Rasmus',  '🔴', 3,
+    (3, 'Rasmus',  3,
      'Passionate FC Nordsjælland fan. Always finds a way to bring it back to FCN — their style, their academy, what FCN would have done. If FCN are in this match he is fully emotionally invested. Gets euphoric when his team wins, inconsolable when they lose. Short, biased, unapologetic.'),
-    (4, 'Maja',    '🎙️', 4,
+    (4, 'Maja',    4,
      'Lifelong FC København supporter. Measures every match against FCK''s standards — their pressing, their mentality, their winning culture. Openly rates FCK above everyone else. Gets smug when FCK win, gets cutting and dismissive when they don''t. Short comments, strong opinions.')
-) t(persona_sk, persona_name, persona_icon, sort_order, bio)
+) t(persona_sk, persona_name, sort_order, bio)

--- a/dbt/models/gold/fct_match_discussions.sql
+++ b/dbt/models/gold/fct_match_discussions.sql
@@ -4,19 +4,14 @@
     unique_key=['match_sk', 'persona_sk']
 ) }}
 
-WITH match_dates AS (
-    SELECT DISTINCT match_sk, date_sk
-    FROM {{ ref('fct_team_matches') }}
-)
 SELECT
     dm.match_sk,
     dp.persona_sk,
-    md.date_sk,
+    (year(s.generated_at) * 10000 + month(s.generated_at) * 100 + day(s.generated_at))::INTEGER AS date_sk,
     s.message
 FROM {{ ref('llm_match_discussions') }}  s
 JOIN {{ ref('dim_match') }}              dm ON dm.match_id    = s.match_id
 JOIN {{ ref('dim_persona') }}            dp ON dp.persona_name = s.persona_name
-JOIN match_dates                         md ON md.match_sk    = dm.match_sk
 {% if is_incremental() %}
 WHERE NOT EXISTS (
     SELECT 1 FROM {{ this }} t


### PR DESCRIPTION
## Summary
- **Relative dates**: Fan Forum now shows "X days ago" / "Today" instead of "Match day". Date comes from `generated_at` (ingestion date) via `dim_date` join in `fct_match_discussions`. User comments store today's date and age the same way.
- **Persona avatars**: Replaced emoji icons with colored initials (first letter of name in a color-coded circle). Initial is derived dynamically from `persona_name`; color is mapped per name.
- **Danish personas**: Renamed Lars → Søren, Bent → Flemming, Magnus → Rasmus, Sofie → Maja.
- **New characteristics**: Flemming (emotional goals fan), Rasmus (FCN fan, short & biased), Maja (rewritten as FCK fan — smug when FCK win, cutting when they don't).
- **Cleanup**: Removed unused `persona_icon` column from `dim_persona`, source SQL, and discussions query.

## Note
Existing generated discussions reference old persona names and will need to be regenerated after this merges.

## Test plan
- [ ] Fan Forum shows "X days ago" on AI posts
- [ ] User comment posted today shows "Today"
- [ ] Persona initials render with correct colors (S=blue, F=green, R=purple, M=pink)
- [ ] dbt rebuild of `dim_persona` succeeds without `persona_icon`
- [ ] Evidence source reload picks up `match_date` on discussions

🤖 Generated with [Claude Code](https://claude.com/claude-code)