### PR TITLE
fix(match-analysis): use SQL subquery default, not JS input fallback

### DIFF
--- a/dashboards/pages/match-results.md
+++ b/dashboards/pages/match-results.md
@@ -142,7 +142,17 @@ select persona_name, sort_order, message, match_date
 from superligaen.llm_round_discussions
 where season      = '${inputs.season.value}'
   and round_number = ${inputs.round.value ?? -1}
-  and match_name   = split_part('${inputs.match?.value ?? match_options[0]?.match_key ?? ''}', '|', 1)
+  and match_name = case
+    when '${inputs.match?.value ?? ''}' != ''
+    then split_part('${inputs.match?.value ?? ''}', '|', 1)
+    else (
+      select match_name from superligaen.mart_match_facts
+      where season = '${inputs.season.value}'
+        and cast(match_round_number as integer) = ${inputs.round.value ?? -1}
+        and result in ('Win', 'Draw', 'Loss')
+      order by match_date desc limit 1
+    )
+  end
 order by sort_order
 ```
 
@@ -342,9 +352,20 @@ select
     max(case when team_side = 'Home' then red_cards end)                                        as home_rc,
     max(case when team_side = 'Away' then red_cards end)                                        as away_rc
 from superligaen.mart_match_facts
-where match_name            = split_part('${inputs.match?.value ?? match_options[0]?.match_key ?? ''}', '|', 1)
-  and cast(match_date as varchar) = split_part('${inputs.match?.value ?? match_options[0]?.match_key ?? ''}', '|', 2)
-  and season                = '${inputs.season.value}'
+where season = '${inputs.season.value}'
+  and cast(match_round_number as integer) = ${inputs.round.value ?? -1}
+  and result in ('Win', 'Draw', 'Loss')
+  and match_name = case
+    when '${inputs.match?.value ?? ''}' != ''
+    then split_part('${inputs.match?.value ?? ''}', '|', 1)
+    else (
+      select match_name from superligaen.mart_match_facts
+      where season = '${inputs.season.value}'
+        and cast(match_round_number as integer) = ${inputs.round.value ?? -1}
+        and result in ('Win', 'Draw', 'Loss')
+      order by match_date desc limit 1
+    )
+  end
 ```
 
 {#if mc.length > 0}
@@ -620,8 +641,28 @@ select
     errors_leading_to_shot,
     round(rating, 2) as rating
 from superligaen.mart_player_facts
-where match_name                 = split_part('${inputs.match?.value ?? match_options[0]?.match_key ?? ''}', '|', 1)
-  and cast(match_date as varchar) = split_part('${inputs.match?.value ?? match_options[0]?.match_key ?? ''}', '|', 2)
+where match_name = case
+    when '${inputs.match?.value ?? ''}' != ''
+    then split_part('${inputs.match?.value ?? ''}', '|', 1)
+    else (
+      select match_name from superligaen.mart_match_facts
+      where season = '${inputs.season.value}'
+        and cast(match_round_number as integer) = ${inputs.round.value ?? -1}
+        and result in ('Win', 'Draw', 'Loss')
+      order by match_date desc limit 1
+    )
+  end
+  and cast(match_date as varchar) = case
+    when '${inputs.match?.value ?? ''}' != ''
+    then split_part('${inputs.match?.value ?? ''}', '|', 2)
+    else (
+      select cast(match_date as varchar) from superligaen.mart_match_facts
+      where season = '${inputs.season.value}'
+        and cast(match_round_number as integer) = ${inputs.round.value ?? -1}
+        and result in ('Win', 'Draw', 'Loss')
+      order by match_date desc limit 1
+    )
+  end
   and result in ('Win', 'Draw', 'Loss')
   and appearance_type = 'Starter'
 order by team_side desc, position_group, position_name
@@ -690,8 +731,28 @@ select
     errors_leading_to_shot,
     round(rating, 2) as rating
 from superligaen.mart_player_facts
-where match_name                 = split_part('${inputs.match?.value ?? match_options[0]?.match_key ?? ''}', '|', 1)
-  and cast(match_date as varchar) = split_part('${inputs.match?.value ?? match_options[0]?.match_key ?? ''}', '|', 2)
+where match_name = case
+    when '${inputs.match?.value ?? ''}' != ''
+    then split_part('${inputs.match?.value ?? ''}', '|', 1)
+    else (
+      select match_name from superligaen.mart_match_facts
+      where season = '${inputs.season.value}'
+        and cast(match_round_number as integer) = ${inputs.round.value ?? -1}
+        and result in ('Win', 'Draw', 'Loss')
+      order by match_date desc limit 1
+    )
+  end
+  and cast(match_date as varchar) = case
+    when '${inputs.match?.value ?? ''}' != ''
+    then split_part('${inputs.match?.value ?? ''}', '|', 2)
+    else (
+      select cast(match_date as varchar) from superligaen.mart_match_facts
+      where season = '${inputs.season.value}'
+        and cast(match_round_number as integer) = ${inputs.round.value ?? -1}
+        and result in ('Win', 'Draw', 'Loss')
+      order by match_date desc limit 1
+    )
+  end
   and result in ('Win', 'Draw', 'Loss')
   and appearance_type = 'Substitute'
 order by team_side desc, position_group, position_name


### PR DESCRIPTION
## What was wrong
Evidence only re-runs a query when `inputs.*` values change. It does **not** react to other query result arrays changing inside SQL templates. The previous fix used `match_options[0]?.match_key` in the template strings — but that expression is evaluated once on page load while `match_options` is still an empty array, so `mc`, `lineup`, `subs`, and `discussions` all ran with an empty match key and never re-ran. This is why it worked on desktop (inputs persisted from URL/previous visit) but broke on mobile (fresh load, no prior state).

## Fix
Replace the JS fallback with a `CASE` expression inside the SQL itself:
- If `inputs.match.value` is set → filter to that specific match (user-selected)
- If not → a subquery picks the latest match for the round directly from the database

No dependency on Evidence's reactive input system for the default case.

## Test plan
- [ ] Open Match Results on mobile fresh — Match Analysis and Lineup load without touching any dropdown
- [ ] Change season or round — analysis updates to the first match of the new round automatically
- [ ] Select a different match from the dropdown — analysis updates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)