### PR TITLE
fix(match-analysis): remove outer round filter breaking mc on desktop

### DIFF
--- a/dashboards/pages/match-results.md
+++ b/dashboards/pages/match-results.md
@@ -353,13 +353,22 @@ select
     max(case when team_side = 'Away' then red_cards end)                                        as away_rc
 from superligaen.mart_match_facts
 where season = '${inputs.season.value}'
-  and cast(match_round_number as integer) = ${inputs.round.value ?? -1}
-  and result in ('Win', 'Draw', 'Loss')
   and match_name = case
     when '${inputs.match?.value ?? ''}' != ''
     then split_part('${inputs.match?.value ?? ''}', '|', 1)
     else (
       select match_name from superligaen.mart_match_facts
+      where season = '${inputs.season.value}'
+        and cast(match_round_number as integer) = ${inputs.round.value ?? -1}
+        and result in ('Win', 'Draw', 'Loss')
+      order by match_date desc limit 1
+    )
+  end
+  and cast(match_date as varchar) = case
+    when '${inputs.match?.value ?? ''}' != ''
+    then split_part('${inputs.match?.value ?? ''}', '|', 2)
+    else (
+      select cast(match_date as varchar) from superligaen.mart_match_facts
       where season = '${inputs.season.value}'
         and cast(match_round_number as integer) = ${inputs.round.value ?? -1}
         and result in ('Win', 'Draw', 'Loss')


### PR DESCRIPTION
## What broke
PR #291 added `cast(match_round_number as integer) = inputs.round.value ?? -1` to `mc`'s outer WHERE. On desktop, `inputs.round.value` is briefly undefined on initial load → resolves to -1 → 0 rows → Match Analysis never shows.

## Fix
- Remove the round and result filters from `mc`'s outer WHERE (they belong only inside the subquery that picks the default match)
- Add `match_date` CASE filter so `mc` pins to exactly one match when a selection is active

Desktop: filters by selected match (name + date). Mobile fresh load: subquery picks latest match for the round. Neither path goes through `inputs.round.value` in the outer WHERE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)