### PR TITLE
fix(silver): handle null MAX timestamp in llm_match_discussions incremental filter

### DIFF
--- a/dbt/models/silver/llm_match_discussions.sql
+++ b/dbt/models/silver/llm_match_discussions.sql
@@ -18,7 +18,7 @@ WITH raw AS (
         ) AS cleaned_response
     FROM {{ source('bronze', 'groq__llm_match_discussions') }}
     {% if is_incremental() %}
-    WHERE generated_at > (SELECT MAX(generated_at) FROM {{ this }})
+    WHERE generated_at > (SELECT COALESCE(MAX(generated_at), '1970-01-01'::TIMESTAMP) FROM {{ this }})
     {% endif %}
 )
 SELECT


### PR DESCRIPTION
## Summary

- The silver `llm_match_discussions` model uses `delete+insert` incremental strategy with `WHERE generated_at > (SELECT MAX(generated_at) FROM this)`
- When the table exists but is empty, `MAX(generated_at)` returns `NULL`, so the filter `generated_at > NULL` evaluates to NULL — silently excluding all bronze rows
- This caused both silver and gold `fct_match_discussions` to remain empty, making the Vercel build fail with *"File 'superligaen_llm_round_discussions.parquet' too small to be a Parquet file"*

## Fix

Wrapped the subquery with `COALESCE(..., '1970-01-01'::TIMESTAMP)` so an empty silver table falls back to epoch and picks up all rows on the next incremental run.

## Test plan

- [x] Verified bronze had 27 rows, silver and gold had 0
- [x] Ran `dbt run --select silver.llm_match_discussions gold.fct_match_discussions --target prod` — both now have 108 rows
- [ ] Trigger Vercel deploy to confirm the parquet error is resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)