### PR TITLE
fix(fan-forum): prevent hallucinated names and always show forum

### DIFF
--- a/dashboards/pages/match-results.md
+++ b/dashboards/pages/match-results.md
@@ -775,13 +775,13 @@ order by team_side desc, position_group, position_name
 </div>
 {/if}
 
-{#if discussions.length > 0}
-
 ---
 
 <div style="display:flex;align-items:baseline;gap:10px;margin-bottom:4px;">
   <h2 style="margin:0;">Fan Forum</h2>
+  {#if discussions.length + userComments.length > 0}
   <span style="font-size:0.8125rem;color:#6b7280;">{discussions.length + userComments.length} comments</span>
+  {/if}
 </div>
 
 <p style="font-size:0.8125rem;color:#6b7280;margin:0 0 20px;font-style:italic;">Fan reactions to this match. Drop your take below.</p>
@@ -842,4 +842,3 @@ order by team_side desc, position_group, position_name
     </div>
   </div>
 </div>
-{/if}

--- a/scripts/generate_round_discussions.py
+++ b/scripts/generate_round_discussions.py
@@ -284,6 +284,7 @@ def build_prompt(match_context: str, personas: list[dict]) -> str:
         "- Each post must be 2-4 sentences, opinionated, and specific to this match.\n"
         "- They should reference each other to feel like a real conversation thread.\n"
         "- No generic football commentary — every sentence must be grounded in the match data.\n"
+        f"- When referring to other fans by name, use ONLY these exact names: {persona_order}. Never invent or use any other name.\n"
         "\n"
         f"PERSONAS:\n{persona_block}\n"
         "\n"


### PR DESCRIPTION
## Summary
- LLM was hallucinating persona names (e.g. "Lars") when generating fan forum comments — added an explicit prompt rule restricting name references to the exact persona names only
- Fan forum was hidden on mobile when no AI discussions existed — removed the `discussions.length > 0` guard so the forum and comment input are always visible; the comment count badge is hidden when there are nothing to show

## Test plan
- [ ] Verify fan forum renders on mobile even for matches without AI-generated discussions
- [ ] Verify newly generated discussions don't reference names outside the persona list

🤖 Generated with [Claude Code](https://claude.com/claude-code)