### PR TITLE
fix(source): derive discussion season/date from match, not generated_at

### DIFF
--- a/dashboards/sources/superligaen/llm_round_discussions.sql
+++ b/dashboards/sources/superligaen/llm_round_discussions.sql
@@ -5,9 +5,14 @@ select
     dp.persona_name,
     dp.sort_order,
     f.message,
-    d.date                                                                      as match_date
+    d.date                                                                    as match_date
 from superligaen.gold.fct_match_discussions f
-join superligaen.gold.dim_persona           dp on dp.persona_sk = f.persona_sk
-join superligaen.gold.dim_match             dm on dm.match_sk   = f.match_sk
-join superligaen.gold.dim_date              d  on d.date_sk     = f.date_sk
+join superligaen.gold.dim_persona           dp  on dp.persona_sk  = f.persona_sk
+join superligaen.gold.dim_match             dm  on dm.match_sk    = f.match_sk
+join (
+    select match_sk, min(date_sk) as date_sk
+    from superligaen.gold.fct_team_matches
+    group by match_sk
+)                                           ftm on ftm.match_sk   = f.match_sk
+join superligaen.gold.dim_date              d   on d.date_sk      = ftm.date_sk
 order by d.season, dm.match_round_number, dm.match_name, dp.sort_order


### PR DESCRIPTION
## Summary
- `llm_round_discussions` was joining `dim_date` via `fct_match_discussions.date_sk`, which is derived from `generated_at` (the time the LLM ran) — not the actual match date. This caused `season` to return `null` for all discussions, breaking the season filter in the dashboard.
- Fixed by joining `fct_team_matches` on `match_sk` to get the correct match `date_sk`, then joining `dim_date` on that.

## Test plan
- [ ] Verify fan forum shows AI discussions on prod for matches with generated comments
- [ ] Verify season and match date display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)