### PR TITLE
fix(source): simplify llm_round_discussions — query from silver directly

### DIFF
--- a/dashboards/pages/match-results.md
+++ b/dashboards/pages/match-results.md
@@ -138,7 +138,7 @@ from ${results}
 ```
 
 ```sql discussions
-select persona_name, sort_order, message, match_date
+select persona_name, sort_order, message
 from superligaen.llm_round_discussions
 where season      = '${inputs.season.value}'
   and round_number = ${inputs.round.value ?? -1}
@@ -795,7 +795,6 @@ order by team_side desc, position_group, position_name
     <div style="flex:1;min-width:0;">
       <div style="display:flex;align-items:baseline;gap:8px;margin-bottom:6px;">
         <span style="font-size:0.8125rem;font-weight:700;color:#111827;">{post.persona_name}</span>
-        <span style="font-size:0.75rem;color:#9ca3af;">· {daysAgo(post.match_date)}</span>
       </div>
       <div style="font-size:0.875rem;color:#374151;line-height:1.6;">{post.message}</div>
     </div>

--- a/dashboards/sources/superligaen/llm_round_discussions.sql
+++ b/dashboards/sources/superligaen/llm_round_discussions.sql
@@ -1,18 +1,10 @@
 select
-    d.season,
-    dm.match_round_number                                                    as round_number,
-    dm.match_name,
-    dp.persona_name,
-    dp.sort_order,
-    f.message,
-    d.date                                                                    as match_date
-from superligaen.gold.fct_match_discussions f
-join superligaen.gold.dim_persona           dp  on dp.persona_sk  = f.persona_sk
-join superligaen.gold.dim_match             dm  on dm.match_sk    = f.match_sk
-join (
-    select match_sk, min(date_sk) as date_sk
-    from superligaen.gold.fct_team_matches
-    group by match_sk
-)                                           ftm on ftm.match_sk   = f.match_sk
-join superligaen.gold.dim_date              d   on d.date_sk      = ftm.date_sk
-order by d.season, dm.match_round_number, dm.match_name, dp.sort_order
+    s.season,
+    s.round_number,
+    s.match_name,
+    p.persona_name,
+    p.sort_order,
+    s.message
+from superligaen.silver.llm_match_discussions s
+join superligaen.gold.dim_persona             p on p.persona_name = s.persona_name
+order by s.season, s.round_number, s.match_name, p.sort_order


### PR DESCRIPTION
## Summary
- Previous fix used a heavy `fct_team_matches` subquery to derive match date/season, which blocked Evidence from loading other page queries.
- New approach: query directly from `silver.llm_match_discussions` which already has `season`, `round_number`, and `match_name` — no complex joins needed.
- Removed `match_date` from the source and template (was only used for the "X days ago" label in fan forum posts).

## Test plan
- [ ] Verify match analysis and lineup load correctly on prod
- [ ] Verify fan forum shows AI discussions for matches with generated comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)