### PR TITLE
fix(match-analysis): replace ELSE scalar subqueries with null for WASM compatibility

### DIFF
--- a/dashboards/pages/match-results.md
+++ b/dashboards/pages/match-results.md
@@ -145,13 +145,7 @@ where season      = '${inputs.season.value}'
   and match_name = case
     when '${inputs.match?.value ?? ''}' != ''
     then split_part('${inputs.match?.value ?? ''}', '|', 1)
-    else (
-      select match_name from superligaen.mart_match_facts
-      where season = '${inputs.season.value}'
-        and cast(match_round_number as integer) = ${inputs.round.value ?? -1}
-        and result in ('Win', 'Draw', 'Loss')
-      order by match_date desc limit 1
-    )
+    else null
   end
 order by sort_order
 ```
@@ -356,24 +350,12 @@ where season = '${inputs.season.value}'
   and match_name = case
     when '${inputs.match?.value ?? ''}' != ''
     then split_part('${inputs.match?.value ?? ''}', '|', 1)
-    else (
-      select match_name from superligaen.mart_match_facts
-      where season = '${inputs.season.value}'
-        and cast(match_round_number as integer) = ${inputs.round.value ?? -1}
-        and result in ('Win', 'Draw', 'Loss')
-      order by match_date desc limit 1
-    )
+    else null
   end
   and cast(match_date as varchar) = case
     when '${inputs.match?.value ?? ''}' != ''
     then split_part('${inputs.match?.value ?? ''}', '|', 2)
-    else (
-      select cast(match_date as varchar) from superligaen.mart_match_facts
-      where season = '${inputs.season.value}'
-        and cast(match_round_number as integer) = ${inputs.round.value ?? -1}
-        and result in ('Win', 'Draw', 'Loss')
-      order by match_date desc limit 1
-    )
+    else null
   end
 ```
 
@@ -653,24 +635,12 @@ from superligaen.mart_player_facts
 where match_name = case
     when '${inputs.match?.value ?? ''}' != ''
     then split_part('${inputs.match?.value ?? ''}', '|', 1)
-    else (
-      select match_name from superligaen.mart_match_facts
-      where season = '${inputs.season.value}'
-        and cast(match_round_number as integer) = ${inputs.round.value ?? -1}
-        and result in ('Win', 'Draw', 'Loss')
-      order by match_date desc limit 1
-    )
+    else null
   end
   and cast(match_date as varchar) = case
     when '${inputs.match?.value ?? ''}' != ''
     then split_part('${inputs.match?.value ?? ''}', '|', 2)
-    else (
-      select cast(match_date as varchar) from superligaen.mart_match_facts
-      where season = '${inputs.season.value}'
-        and cast(match_round_number as integer) = ${inputs.round.value ?? -1}
-        and result in ('Win', 'Draw', 'Loss')
-      order by match_date desc limit 1
-    )
+    else null
   end
   and result in ('Win', 'Draw', 'Loss')
   and appearance_type = 'Starter'
@@ -743,24 +713,12 @@ from superligaen.mart_player_facts
 where match_name = case
     when '${inputs.match?.value ?? ''}' != ''
     then split_part('${inputs.match?.value ?? ''}', '|', 1)
-    else (
-      select match_name from superligaen.mart_match_facts
-      where season = '${inputs.season.value}'
-        and cast(match_round_number as integer) = ${inputs.round.value ?? -1}
-        and result in ('Win', 'Draw', 'Loss')
-      order by match_date desc limit 1
-    )
+    else null
   end
   and cast(match_date as varchar) = case
     when '${inputs.match?.value ?? ''}' != ''
     then split_part('${inputs.match?.value ?? ''}', '|', 2)
-    else (
-      select cast(match_date as varchar) from superligaen.mart_match_facts
-      where season = '${inputs.season.value}'
-        and cast(match_round_number as integer) = ${inputs.round.value ?? -1}
-        and result in ('Win', 'Draw', 'Loss')
-      order by match_date desc limit 1
-    )
+    else null
   end
   and result in ('Win', 'Draw', 'Loss')
   and appearance_type = 'Substitute'


### PR DESCRIPTION
## Summary
- DuckDB WASM (browser, production) fails silently on scalar subqueries inside `CASE ELSE` expressions
- On initial page load `inputs.match.value` is empty, hitting the ELSE branch, permanently locking `mc`/`lineup`/`subs`/`discussions` in a loading state
- Replace all 7 ELSE scalar subqueries with `null` — queries return 0 rows gracefully until the dropdown sets the match input, then re-run via the THEN branch

## Test plan
- [ ] Visit match-results page on the published Vercel URL
- [ ] Confirm Match Analysis loads after the dropdown populates
- [ ] Confirm Lineup section loads
- [ ] Confirm switching rounds/matches updates the analysis correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)