### PR TITLE
fix(match-analysis): use inputs.match.value not inputs.match?.value in SQL templates

### DIFF
--- a/dashboards/pages/match-results.md
+++ b/dashboards/pages/match-results.md
@@ -143,8 +143,8 @@ from superligaen.llm_round_discussions
 where season      = '${inputs.season.value}'
   and round_number = ${inputs.round.value ?? -1}
   and match_name = case
-    when '${inputs.match?.value ?? ''}' != ''
-    then split_part('${inputs.match?.value ?? ''}', '|', 1)
+    when '${inputs.match.value ?? ''}' != ''
+    then split_part('${inputs.match.value ?? ''}', '|', 1)
     else null
   end
 order by sort_order
@@ -348,13 +348,13 @@ select
 from superligaen.mart_match_facts
 where season = '${inputs.season.value}'
   and match_name = case
-    when '${inputs.match?.value ?? ''}' != ''
-    then split_part('${inputs.match?.value ?? ''}', '|', 1)
+    when '${inputs.match.value ?? ''}' != ''
+    then split_part('${inputs.match.value ?? ''}', '|', 1)
     else null
   end
   and cast(match_date as varchar) = case
-    when '${inputs.match?.value ?? ''}' != ''
-    then split_part('${inputs.match?.value ?? ''}', '|', 2)
+    when '${inputs.match.value ?? ''}' != ''
+    then split_part('${inputs.match.value ?? ''}', '|', 2)
     else null
   end
 ```
@@ -633,13 +633,13 @@ select
     round(rating, 2) as rating
 from superligaen.mart_player_facts
 where match_name = case
-    when '${inputs.match?.value ?? ''}' != ''
-    then split_part('${inputs.match?.value ?? ''}', '|', 1)
+    when '${inputs.match.value ?? ''}' != ''
+    then split_part('${inputs.match.value ?? ''}', '|', 1)
     else null
   end
   and cast(match_date as varchar) = case
-    when '${inputs.match?.value ?? ''}' != ''
-    then split_part('${inputs.match?.value ?? ''}', '|', 2)
+    when '${inputs.match.value ?? ''}' != ''
+    then split_part('${inputs.match.value ?? ''}', '|', 2)
     else null
   end
   and result in ('Win', 'Draw', 'Loss')
@@ -711,13 +711,13 @@ select
     round(rating, 2) as rating
 from superligaen.mart_player_facts
 where match_name = case
-    when '${inputs.match?.value ?? ''}' != ''
-    then split_part('${inputs.match?.value ?? ''}', '|', 1)
+    when '${inputs.match.value ?? ''}' != ''
+    then split_part('${inputs.match.value ?? ''}', '|', 1)
     else null
   end
   and cast(match_date as varchar) = case
-    when '${inputs.match?.value ?? ''}' != ''
-    then split_part('${inputs.match?.value ?? ''}', '|', 2)
+    when '${inputs.match.value ?? ''}' != ''
+    then split_part('${inputs.match.value ?? ''}', '|', 2)
     else null
   end
   and result in ('Win', 'Draw', 'Loss')


### PR DESCRIPTION
## Summary
- Root cause: Evidence.dev's dependency tracker scans SQL templates for `inputs.X.value` patterns to decide which queries to re-run when inputs change
- All match-related queries used `inputs.match?.value` (optional chaining) — the `?.` breaks the tracker's regex, so `mc`/`lineup`/`subs`/`discussions` were never marked as dependent on `inputs.match`
- Result: on page load these queries ran once with an empty match value, returned 0 rows, and **never re-ran** even after the dropdown set `inputs.match.value` — hence the permanent "Loading match data..." on production
- On localhost the dev server re-runs all queries on every render cycle, masking the bug

## Fix
Replace `inputs.match?.value` → `inputs.match.value` in all SQL templates (14 occurrences). The `?? ''` null-coalescing guard already handles the undefined case.

## Test plan
- [ ] Visit match-results page on Vercel after deploy
- [ ] Match Analysis loads automatically without user interaction
- [ ] Lineup section loads
- [ ] Switching rounds/seasons/matches updates the analysis

🤖 Generated with [Claude Code](https://claude.com/claude-code)