### PR TITLE
fix(mart): rewrite llm_round_discussions to use gold tables only

### DIFF
--- a/dashboards/pages/match-results.md
+++ b/dashboards/pages/match-results.md
@@ -140,13 +140,7 @@ from ${results}
 ```sql discussions
 select persona_name, sort_order, message
 from superligaen.llm_round_discussions
-where season      = '${inputs.season.value}'
-  and round_number = ${inputs.round.value ?? -1}
-  and match_name = case
-    when '${inputs.match.value ?? ''}' != ''
-    then split_part('${inputs.match.value ?? ''}', '|', 1)
-    else null
-  end
+where match_id = cast('${inputs.match.value ?? '0'}' as bigint)
 order by sort_order
 ```
 
@@ -289,14 +283,14 @@ order by sort_order
 
 ```sql match_options
 select
-    match_name || '|' || cast(match_date as varchar) as match_key,
+    cast(match_id as varchar)                        as match_key,
     match_short_name || '  (' || score || ')'        as match_label,
     match_date
 from superligaen.mart_match_facts
 where season = '${inputs.season.value}'
   and cast(match_round_number as integer) = ${inputs.round.value ?? -1}
   and result in ('Win', 'Draw', 'Loss')
-group by match_name, match_short_name, match_date, score
+group by match_id, match_short_name, match_date, score
 order by match_date desc
 ```
 
@@ -346,17 +340,7 @@ select
     max(case when team_side = 'Home' then red_cards end)                                        as home_rc,
     max(case when team_side = 'Away' then red_cards end)                                        as away_rc
 from superligaen.mart_match_facts
-where season = '${inputs.season.value}'
-  and match_name = case
-    when '${inputs.match.value ?? ''}' != ''
-    then split_part('${inputs.match.value ?? ''}', '|', 1)
-    else null
-  end
-  and cast(match_date as varchar) = case
-    when '${inputs.match.value ?? ''}' != ''
-    then split_part('${inputs.match.value ?? ''}', '|', 2)
-    else null
-  end
+where match_id = cast('${inputs.match.value ?? '0'}' as bigint)
 ```
 
 {#if mc.length > 0}
@@ -632,16 +616,7 @@ select
     errors_leading_to_shot,
     round(rating, 2) as rating
 from superligaen.mart_player_facts
-where match_name = case
-    when '${inputs.match.value ?? ''}' != ''
-    then split_part('${inputs.match.value ?? ''}', '|', 1)
-    else null
-  end
-  and cast(match_date as varchar) = case
-    when '${inputs.match.value ?? ''}' != ''
-    then split_part('${inputs.match.value ?? ''}', '|', 2)
-    else null
-  end
+where match_id = cast('${inputs.match.value ?? '0'}' as bigint)
   and result in ('Win', 'Draw', 'Loss')
   and appearance_type = 'Starter'
 order by team_side desc, position_group, position_name
@@ -710,16 +685,7 @@ select
     errors_leading_to_shot,
     round(rating, 2) as rating
 from superligaen.mart_player_facts
-where match_name = case
-    when '${inputs.match.value ?? ''}' != ''
-    then split_part('${inputs.match.value ?? ''}', '|', 1)
-    else null
-  end
-  and cast(match_date as varchar) = case
-    when '${inputs.match.value ?? ''}' != ''
-    then split_part('${inputs.match.value ?? ''}', '|', 2)
-    else null
-  end
+where match_id = cast('${inputs.match.value ?? '0'}' as bigint)
   and result in ('Win', 'Draw', 'Loss')
   and appearance_type = 'Substitute'
 order by team_side desc, position_group, position_name

--- a/dashboards/sources/superligaen/llm_round_discussions.sql
+++ b/dashboards/sources/superligaen/llm_round_discussions.sql
@@ -1,10 +1,20 @@
 select
-    s.season,
-    s.round_number,
-    s.match_name,
-    p.persona_name,
-    p.sort_order,
-    s.message
-from superligaen.silver.llm_match_discussions s
-join superligaen.gold.dim_persona             p on p.persona_name = s.persona_name
-order by s.season, s.round_number, s.match_name, p.sort_order
+    dd.date                as comment_date,
+    dm.match_id,
+    dm.match_round_type,
+    dm.match_round_number,
+    dm.match_round_name,
+    dm.match_type,
+    dm.match_name,
+    dm.match_short_name,
+    dm.match_result,
+    dm.kick_off_time,
+    dm.match_status,
+    dp.persona_name,
+    dp.sort_order,
+    f.message
+from superligaen.gold.fct_match_discussions f
+join superligaen.gold.dim_match             dm on dm.match_sk   = f.match_sk
+join superligaen.gold.dim_persona           dp on dp.persona_sk = f.persona_sk
+join superligaen.gold.dim_date              dd on dd.date_sk    = f.date_sk
+order by dd.date, dm.match_name, dp.sort_order


### PR DESCRIPTION
## Summary
- Replaces `silver.llm_match_discussions` join in the mart with `fct_match_discussions` + `dim_match` + `dim_persona` + `dim_date`
- Mart now exposes `comment_date`, all `dim_match` attributes, all `dim_persona` attributes (excluding `bio` and `season`), and `message`
- Simplifies `match-results.md` by using `match_id` as the match dropdown key, replacing all `split_part`/`CASE WHEN` filters in `discussions`, `mc`, `lineup`, and `subs` queries with a clean `match_id` equality filter

## Test plan
- [ ] Verify match-results page loads and season/round dropdowns populate correctly
- [ ] Verify match dropdown populates with correct matches for a given season/round
- [ ] Verify match comparison card (`mc`) loads correct stats for selected match
- [ ] Verify lineup and subs load for selected match
- [ ] Verify LLM discussions load per match with correct persona ordering

🤖 Generated with [Claude Code](https://claude.com/claude-code)