### PR TITLE
fix(match-results): remove ?? '0' fallback to fix cold-start blank sections

### DIFF
--- a/dashboards/pages/match-results.md
+++ b/dashboards/pages/match-results.md
@@ -122,7 +122,7 @@ from ${results}
 ```sql discussions
 select persona_name, sort_order, message
 from superligaen.llm_round_discussions
-where match_id = cast('${inputs.match.value ?? '0'}' as bigint)
+where match_id = cast('${inputs.match.value}' as bigint)
 order by sort_order
 ```
 
@@ -215,7 +215,7 @@ order by match_date desc
 ```sql mc
 select *
 from superligaen.mart_match_results
-where match_id = cast('${inputs.match.value ?? '0'}' as bigint)
+where match_id = cast('${inputs.match.value}' as bigint)
 ```
 
 {#if mc.length > 0}
@@ -430,7 +430,7 @@ where match_id = cast('${inputs.match.value ?? '0'}' as bigint)
 ```sql lineup
 select *
 from superligaen.mart_match_lineup
-where match_id = cast('${inputs.match.value ?? '0'}' as bigint)
+where match_id = cast('${inputs.match.value}' as bigint)
   and result in ('Win', 'Draw', 'Loss')
   and appearance_type = 'Starter'
 order by team_side desc, position_group, position_name
@@ -439,7 +439,7 @@ order by team_side desc, position_group, position_name
 ```sql subs
 select *
 from superligaen.mart_match_lineup
-where match_id = cast('${inputs.match.value ?? '0'}' as bigint)
+where match_id = cast('${inputs.match.value}' as bigint)
   and result in ('Win', 'Draw', 'Loss')
   and appearance_type = 'Substitute'
 order by team_side desc, position_group, position_name


### PR DESCRIPTION
## Summary

- Removes `?? '0'` fallback from all 4 match-scoped queries in `match-results.md`: `mc`, `discussions`, `lineup`, `subs`
- The fallback bypassed Evidence.dev's input guard, causing all 4 queries to fire immediately on page load with `match_id=0`, returning empty results that were never re-run once `inputs.match.value` was properly set
- This explains why Match Analysis and Lineup sections showed "Loading…" forever on cold load, but worked fine when navigating from another page first (WASM warm + inputs resolved before queries ran)

## Test plan

- [ ] Open Match Results page cold (no prior navigation) — Match Analysis and Lineup should load after selecting a match
- [ ] Verify Fan Forum discussions also load correctly
- [ ] Confirm no regression on results table, round KPIs, or POTW section

🤖 Generated with [Claude Code](https://claude.com/claude-code)