### PR TITLE
fix(match-analysis): show loading placeholder while lineup parquet downloads

### DIFF
--- a/dashboards/pages/match-analysis.md
+++ b/dashboards/pages/match-analysis.md
@@ -312,7 +312,7 @@ order by team_side desc, position_group, position_name
 
 <p style="font-size:13px;color:#6b7280;margin:-8px 0 16px;">Click on a player to see their stats for this match.</p>
 
-{#if mc.length > 0}
+{#if lineup.length > 0}
 <MatchLineup {lineup} {subs} home_team={mc[0]?.home_team} away_team={mc[0]?.away_team} score={mc[0]?.score} />
 {:else}
 <div class="rounded-xl border border-gray-200 bg-white p-6 mt-2 text-center text-gray-400 text-sm">


### PR DESCRIPTION
## Summary

- Guard the `MatchLineup` component with `{#if lineup.length > 0}` instead of `{#if mc.length > 0}`
- Previously: `mc` (58KB parquet) loaded fast → `MatchLineup` mounted with `lineup=[]` → its internal `{#if allPlayers.length > 0}` rendered nothing → user saw blank space
- Now: "Loading lineup…" placeholder stays visible until the 907KB `mart_match_lineup.parquet` finishes downloading and `lineup` populates

## Test plan

- [ ] Navigate from match-results to a match — lineup section shows "Loading lineup…" immediately, then renders the formation once the parquet downloads
- [ ] On cellular / slow connection — placeholder is always visible instead of a blank gap
- [ ] Head-to-Head stats and Fan Forum sections unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)