### PR TITLE
fix(silver): skip malformed LLM JSON in llm_match_discussions

### DIFF
--- a/dbt/models/silver/llm_match_discussions.sql
+++ b/dbt/models/silver/llm_match_discussions.sql
@@ -20,6 +20,10 @@ WITH raw AS (
     {% if is_incremental() %}
     WHERE generated_at > (SELECT COALESCE(MAX(generated_at), '1970-01-01'::TIMESTAMP) FROM {{ this }})
     {% endif %}
+),
+valid AS (
+    SELECT * FROM raw
+    WHERE TRY_CAST(cleaned_response AS JSON) IS NOT NULL
 )
 SELECT
     r.match_id,
@@ -29,5 +33,5 @@ SELECT
     r.generated_at,
     j.value->>'persona'  AS persona_name,
     j.value->>'message'  AS message
-FROM raw r,
+FROM valid r,
      json_each(r.cleaned_response::JSON) j


### PR DESCRIPTION
## Summary
- The `AI round discussions` workflow failed because Groq returned 2 malformed JSON responses (match_ids 19425661 and 19425684)
- One had a self-correction in plain text mid-JSON; the other had a stray `)` inside the array
- The hard cast `cleaned_response::JSON` in the dbt model crashed on these rows

## Fix
Added a `valid` CTE using `TRY_CAST` to filter out unparseable rows before the `json_each` call. Bad LLM outputs will now be silently skipped rather than failing the entire model run.

## Test plan
- [ ] Re-trigger `AI round discussions` workflow — should complete without error
- [ ] Verify the 2 bad match_ids (19425661, 19425684) are absent from `silver.llm_match_discussions`

🤖 Generated with [Claude Code](https://claude.com/claude-code)