### PR TITLE
fix(silver): deduplicate persona entries within same LLM batch

### DIFF
--- a/dbt/models/silver/llm_match_discussions.sql
+++ b/dbt/models/silver/llm_match_discussions.sql
@@ -35,3 +35,4 @@ SELECT
     j.value->>'message'  AS message
 FROM valid r,
      json_each(r.cleaned_response::JSON) j
+QUALIFY ROW_NUMBER() OVER (PARTITION BY r.match_id, j.value->>'persona' ORDER BY r.generated_at DESC) = 1


### PR DESCRIPTION
## Problem
Nightly DQ test failed: \`unique_combination_of_columns\` on \`fct_match_discussions\` — 3 duplicate \`(match_sk, persona_sk)\` rows.

Root cause: Groq returned JSON arrays where the same persona name appeared twice (the 4th slot should have been Ecem, but the LLM reused Søren or Rasmus instead). The silver model's \`delete+insert\` unique key deduplicates across pipeline runs but not within the same batch.

## Fix
Added \`QUALIFY ROW_NUMBER() OVER (PARTITION BY match_id, persona_name ORDER BY generated_at DESC) = 1\` to the silver model so within-batch duplicates are dropped at query time.

## Cleanup done (both layers)
- Deleted 5 misattributed rows from \`silver.llm_match_discussions\`
- Deleted 3 misattributed rows from \`gold.fct_match_discussions\`

All deleted rows were Ecem/Maja-voiced messages incorrectly attributed to Søren or Rasmus. Both layers are now clean — DQ test will pass on the next nightly run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)