### PR TITLE
feat(league): add filter guidance hint below dropdowns

### DIFF
--- a/dashboards/pages/league-analytics.md
+++ b/dashboards/pages/league-analytics.md
@@ -47,6 +47,8 @@ select team_name from (
 
 <Dropdown data={teams} name=team value=team_name label=team_name multiple=true defaultValue={['All Teams']} />
 
+*Use the **Season** picker to switch between years. Use the **Team** filter to focus on one or more clubs — or keep 'All Teams' selected for full-league statistics. Both filters apply to every section on this page.*
+
 ```sql league_kpis
 with curr as (
     select


### PR DESCRIPTION
## Summary
- Adds a one-line italic hint below the Season and Team dropdowns on the League Intelligence page, explaining that both filters apply to every section
- Matches the guidance style already used on the Player Intelligence page (e.g. *"Season, team, and position filters all apply."*)

Closes #310

## Test plan
- [ ] Open League Intelligence page — hint appears below the dropdowns
- [ ] Text is readable and matches the italic style of other guidance lines on the page

🤖 Generated with [Claude Code](https://claude.com/claude-code)