### PR TITLE
feat(ux): section guidance text & team-analytics polish (#310)

### DIFF
--- a/dashboards/pages/index.md
+++ b/dashboards/pages/index.md
@@ -93,7 +93,7 @@ select * from superligaen.mart_home_summary
   <div class="rounded-xl bg-blue-50 w-11 h-11 flex items-center justify-center text-xl flex-shrink-0 mr-4">⚽</div>
   <div class="flex-1 min-w-0">
     <div class="text-sm font-bold text-gray-800 group-hover:text-blue-600 transition-colors">Match Results</div>
-    <div class="text-gray-400 text-xs mt-0.5 leading-snug">Full match history, scorelines and analytics by round</div>
+    <div class="text-gray-400 text-xs mt-0.5 leading-snug">Scorelines, round KPIs &amp; players of the week</div>
   </div>
   <div class="shrink-0 text-gray-300 group-hover:text-blue-400 group-hover:translate-x-1 transition-all duration-200 ml-3">→</div>
 </a>
@@ -111,7 +111,7 @@ select * from superligaen.mart_home_summary
   <div class="rounded-xl bg-emerald-50 w-11 h-11 flex items-center justify-center text-xl flex-shrink-0 mr-4">📈</div>
   <div class="flex-1 min-w-0">
     <div class="text-sm font-bold text-gray-800 group-hover:text-emerald-600 transition-colors">League Intelligence</div>
-    <div class="text-gray-400 text-xs mt-0.5 leading-snug">Standings, points race, team radar &amp; discipline rankings</div>
+    <div class="text-gray-400 text-xs mt-0.5 leading-snug">Season KPIs, points race, team radar &amp; domain rankings</div>
   </div>
   <div class="shrink-0 text-gray-300 group-hover:text-emerald-400 group-hover:translate-x-1 transition-all duration-200 ml-3">→</div>
 </a>
@@ -120,7 +120,7 @@ select * from superligaen.mart_home_summary
   <div class="rounded-xl bg-sky-50 w-11 h-11 flex items-center justify-center text-xl flex-shrink-0 mr-4">👥</div>
   <div class="flex-1 min-w-0">
     <div class="text-sm font-bold text-gray-800 group-hover:text-sky-600 transition-colors">Team Intelligence</div>
-    <div class="text-gray-400 text-xs mt-0.5 leading-snug">Points race, match log, squad depth &amp; home/away splits</div>
+    <div class="text-gray-400 text-xs mt-0.5 leading-snug">Season KPIs, goals timeline, formation &amp; home/away splits</div>
   </div>
   <div class="shrink-0 text-gray-300 group-hover:text-sky-400 group-hover:translate-x-1 transition-all duration-200 ml-3">→</div>
 </a>

--- a/dashboards/pages/league-analytics.md
+++ b/dashboards/pages/league-analytics.md
@@ -41,6 +41,8 @@ select team_name from (
 ) order by ord, team_name
 ```
 
+*Select a season and optionally filter to specific teams. All sections below — KPIs, awards, standings, radar, and match log — update to the selection.*
+
 {#key seasons[0]?.season}
 <Dropdown data={seasons} name=season value=season label=season order="season desc" defaultValue={seasons[0]?.season} />
 {/key}
@@ -428,6 +430,8 @@ order by case period_of_day
 
 ## League Intelligence — {inputs.season.value}
 
+*Top-line KPIs for the selected season, each compared against the previous season. Applies to the team filter if set.*
+
 {#each league_kpis as k}
 <div class="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
 
@@ -509,6 +513,8 @@ order by case period_of_day
 ---
 
 ## Season Awards
+
+*Top scorer, top assister, and best-rated player for the selected season (minimum 5 appearances). Runner-up cards are stacked below each winner.*
 
 <div class="grid grid-cols-1 md:grid-cols-3 gap-6 mb-8">
 
@@ -677,6 +683,8 @@ order by case period_of_day
 
 ## Standings & Points Race
 
+*Cumulative points race round by round alongside the current league table. Hover a round on the line chart to see the full ranking.*
+
 <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-6 items-start">
 
 <div>
@@ -793,6 +801,8 @@ order by case period_of_day
 ---
 
 ## Team Rankings by Domain
+
+*All teams ranked within each performance dimension. Sorted highest to lowest so the best and worst performers are immediately visible.*
 
 <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-6">
 

--- a/dashboards/pages/match-results.md
+++ b/dashboards/pages/match-results.md
@@ -12,6 +12,8 @@ select season from (
 ) order by is_current desc, season desc
 ```
 
+*Select a season and round to browse all matches. Click any match in the table to open the full match analysis page.*
+
 {#key seasons[0]?.season}
 <Dropdown data={seasons} name=season value=season label=season order="season desc" defaultValue={seasons[0]?.season} />
 {/key}
@@ -141,6 +143,8 @@ order by sort_order
 
 {#if potw.length > 0}
 ## Players of the Week
+
+*Standout performers from this round — one player recognised per category based on the highest single-match stat.*
 
 <div class="grid grid-cols-3 md:grid-cols-6 gap-3 mb-6">
   {#each potw as p}

--- a/dashboards/pages/referee-analytics.md
+++ b/dashboards/pages/referee-analytics.md
@@ -24,6 +24,8 @@ from superligaen.mart_referee_season
 order by season desc
 ```
 
+*Select a season to explore referee discipline patterns — league averages, strictness rankings, home/away bias, and individual referee deep dives.*
+
 {#key seasons[0]?.season}
 <Dropdown data={seasons} name=season value=season label=season order="season desc" defaultValue={seasons[0]?.season} />
 {/key}
@@ -106,6 +108,8 @@ from ${referee_trends}
 
 ### League Discipline Snapshot
 
+*Season-wide averages across all referees — active officials, yellow and red card rates, and average fouls per match.*
+
 <div class="grid grid-cols-2 md:grid-cols-4 gap-4 mb-8">
   <div class="rounded-xl border border-gray-200 bg-white shadow-sm p-4 text-center">
     <BigValue data={season_kpis} value=total_referees title="Active Referees" />
@@ -124,6 +128,8 @@ from ${referee_trends}
 ---
 
 ## Strictest vs Most Lenient Referees
+
+*Top 3 referees by yellow cards per match at each extreme — who runs the tightest game and who lets the most go.*
 
 <div class="grid grid-cols-1 md:grid-cols-2 gap-8 mb-8">
 
@@ -170,6 +176,8 @@ from ${referee_trends}
 ---
 
 ## Season Leaderboard
+
+*All referees ranked by matches managed. Includes cards, fouls, severity index, and home/away yellow card split.*
 
 <DataTable data={season_stats} rows=20>
     <Column id=referee_name          title="Referee"              wrap=true />
@@ -220,6 +228,8 @@ from ${referee_trends}
 
 ## Cards & Fouls per Match
 
+*Per-match averages for every referee. Sorted highest to lowest so outliers are immediately visible.*
+
 <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-6">
 
 <BarChart
@@ -247,6 +257,8 @@ from ${referee_trends}
 ---
 
 ## Referee Deep Dive
+
+*Select a referee to see their personal profile, team exposure, match log, and how their card rates compare to the league average across all seasons.*
 
 {#key season_stats[0]?.referee_name}
 <Dropdown data={season_stats} name=referee value=referee_name label=referee_name defaultValue={season_stats[0]?.referee_name} />
@@ -358,6 +370,8 @@ where referee_name = '${inputs.referee.value}'
 ---
 
 ## Historical Discipline Trends
+
+*Season-by-season league averages (grey) overlaid with the selected referee's own trend line — spot referees who have become stricter or more lenient over time.*
 
 <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-6">
 

--- a/dashboards/pages/stadium-analytics.md
+++ b/dashboards/pages/stadium-analytics.md
@@ -10,6 +10,8 @@ from superligaen.mart_stadium_season
 order by season desc
 ```
 
+*Select a season to explore stadium and surface data — fortress rankings, home win rates, and how grass vs. artificial turf affects the way the game is played.*
+
 {#key season_options[0]?.season}
 <Dropdown data={season_options} name=season value=season label=season order="season desc" defaultValue={season_options[0]?.season} />
 {/key}
@@ -90,6 +92,8 @@ where season = '${inputs.season.value}'
 ---
 
 ## Top 3 Fortress Stadiums
+
+*The three venues where the home side wins most often — home win %, wins, and total home matches played.*
 
 <div class="grid grid-cols-1 md:grid-cols-3 gap-6 mb-8">
   {#each fortress_podium as s, i}

--- a/dashboards/pages/team-analytics.md
+++ b/dashboards/pages/team-analytics.md
@@ -31,6 +31,8 @@ where season = '${inputs.season.value}'
 order by team_name
 ```
 
+*Select a season and team to explore their full season profile — KPIs vs. the previous year, goals timeline, home/away splits, formation breakdowns, and the complete match log.*
+
 {#key seasons[0]?.season}
 <Dropdown data={seasons} name=season value=season label=season order="season desc" defaultValue={seasons[0]?.season} />
 {/key}
@@ -269,6 +271,8 @@ end
 
 ## Team Intelligence
 
+*Season summary for the selected team — points, goal difference, last 5 results, and head-to-head record against each opponent.*
+
 {#each team_header as h}
 <div class="rounded-2xl bg-gradient-to-br from-gray-900 via-gray-800 to-gray-900 p-6 md:p-8 mb-6 shadow-xl">
   <div class="flex flex-col md:flex-row items-center md:items-start gap-6">
@@ -310,6 +314,8 @@ end
 ---
 
 ## Season Overview
+
+*Key performance indicators for the selected season, each compared against the previous season to show whether the team has improved or declined.*
 
 {#each team_kpis as k}
 <div class="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
@@ -401,6 +407,8 @@ end
 
 ## Goals per Round
 
+*Goals scored and conceded per match across the season. Hover a round to see the opponent.*
+
 <LineChart
     data={goals_per_round}
     x=round
@@ -414,6 +422,8 @@ end
 />
 
 ## Goals by Opponent
+
+*Total goals scored and conceded against each opponent across all meetings in the selected season.*
 
 <BarChart
     data={goals_vs_opponent}
@@ -432,6 +442,8 @@ end
 ---
 
 ## Home vs Away
+
+*Results, goals, possession, and pass accuracy split by home and away fixtures.*
 
 <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-6">
 
@@ -479,6 +491,8 @@ end
 
 ## Formation
 
+*Win/draw/loss record and goals per match broken down by the formation used in each game.*
+
 <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-6">
 
 <BarChart
@@ -507,6 +521,8 @@ end
 
 ## When We Play Best
 
+*Results split by day of the week and time of day to reveal any scheduling patterns in performance.*
+
 <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-6">
 
 <BarChart
@@ -534,6 +550,8 @@ end
 ---
 
 ## Match Log
+
+*Full match-by-match record for the selected team and season, including possession, pass accuracy, shots on goal, and shot conversion.*
 
 <div class="hidden md:block">
 <DataTable data={match_results} rows=20 search=true downloadable=true>

--- a/dashboards/pages/team-analytics.md
+++ b/dashboards/pages/team-analytics.md
@@ -418,7 +418,7 @@ end
     colorPalette={['#3b82f6','#f97316']}
     markers=true
     chartAreaHeight=280
-    echartsOptions={{series: [{markLine: {silent: true, symbol: ['none','none'], label: {show: false}, data: goals_per_round.map(r => ([{coord: [r.round, r.goals_scored]}, {coord: [r.round, r.goals_conceded], lineStyle: {color: r.goals_scored >= r.goals_conceded ? '#3b82f6' : '#f97316', width: 2, opacity: 0.5}}]))}}]}}
+    echartsOptions={{tooltip: {formatter: (function() { const lu = {}; for (const r of goals_per_round) { lu[r.round] = {opponent: r.opponent, result: r.result}; } return function(params) { const round = params[0].value[0]; const info = lu[round] || {}; let out = '<span style="font-weight:600;">Round ' + round + '</span>'; if (info.opponent) out += '<br><span style="font-size:11px;color:#9ca3af;">vs ' + info.opponent + ' · ' + info.result + '</span>'; for (const p of params) { out += '<br>' + p.marker + ' ' + p.seriesName + ': <b>' + p.value[1] + '</b>'; } return out; }; })()}, series: [{markLine: {silent: true, symbol: ['none','none'], label: {show: false}, data: goals_per_round.map(r => ([{coord: [r.round, r.goals_scored]}, {coord: [r.round, r.goals_conceded], lineStyle: {color: r.goals_scored >= r.goals_conceded ? '#3b82f6' : '#f97316', width: 2, opacity: 0.5}}]))}}]}}
 />
 
 ## Goals against Opponent

--- a/dashboards/pages/team-analytics.md
+++ b/dashboards/pages/team-analytics.md
@@ -514,6 +514,7 @@ end
     title="Goals per Match by Formation"
     colorPalette={['#3b82f6','#f97316']}
     type=grouped
+    seriesOptions={{"barGap": "0%"}}
     sort=false
 />
 

--- a/dashboards/pages/team-analytics.md
+++ b/dashboards/pages/team-analytics.md
@@ -421,7 +421,7 @@ end
     echartsOptions={{series: [{markLine: {silent: true, symbol: ['none','none'], label: {show: false}, data: goals_per_round.map(r => ([{coord: [r.round, r.goals_scored]}, {coord: [r.round, r.goals_conceded], lineStyle: {color: r.goals_scored >= r.goals_conceded ? '#3b82f6' : '#f97316', width: 2, opacity: 0.5}}]))}}]}}
 />
 
-## Goals by Opponent
+## Goals against Opponent
 
 *Total goals scored and conceded against each opponent across all meetings in the selected season.*
 

--- a/dashboards/pages/team-analytics.md
+++ b/dashboards/pages/team-analytics.md
@@ -454,6 +454,7 @@ end
     title="W/D/L Split"
     colorPalette={['#22c55e','#eab308','#ef4444']}
     type=grouped
+    seriesOptions={{"barGap": "0%"}}
     sort=false
 />
 
@@ -464,6 +465,7 @@ end
     title="Goals Scored vs Conceded per Match"
     colorPalette={['#3b82f6','#f97316']}
     type=grouped
+    seriesOptions={{"barGap": "0%"}}
     sort=false
 />
 

--- a/dashboards/pages/upcoming-matches.md
+++ b/dashboards/pages/upcoming-matches.md
@@ -14,6 +14,8 @@ select distinct team_name from (
 
 {#if teams.length > 0}
 
+*Filter by team to see only relevant fixtures. Select a match in the section below to explore head-to-head history and recent form for both sides.*
+
 <Dropdown data={teams} name=team value=team_name label=team_name order="team_name asc" multiple=true selectAllByDefault=true />
 
 ```sql upcoming
@@ -65,6 +67,8 @@ order by match_date asc, kick_off_time asc
 ---
 
 ## Match Analysis
+
+*Select a fixture to see the all-time head-to-head record between the two clubs and the last 5 results for each side going into the match.*
 
 <Dropdown data={upcoming} name=match value=match_key label=match_short_name order="match_date asc, kick_off_time asc" />
 
@@ -171,6 +175,8 @@ limit 5
 
 ### Head-to-Head History
 
+*All previous meetings between these two clubs. Filter by season to narrow the comparison.*
+
 <Dropdown data={h2h_seasons} name=h2h_season value=season label=season multiple=true selectAllByDefault=true order="season desc" />
 
 <div class="grid grid-cols-3 gap-4 mb-6">
@@ -214,6 +220,8 @@ limit 5
 ---
 
 ### Form Guide — Last 5 Matches
+
+*Most recent five results for each side across all competitions in the current season.*
 
 <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
 


### PR DESCRIPTION
## Summary
- Adds italic intro text before dropdowns and section-level descriptions across all interactive pages (team, player, league, referee, stadium, match-results, upcoming-matches) so users understand what each filter controls and what each section shows
- Fixes two inaccurate nav card descriptions on the home page (League Intelligence had "discipline rankings"; Team Intelligence had "squad depth" — neither exists on those pages)
- Goals per Round tooltip now shows opponent and match result on hover
- Renamed "Goals by Opponent" → "Goals against Opponent"
- Removed bar gap (`barGap: 0%`) on Home vs Away and Formation grouped charts to match the Goals against Opponent chart style

Closes #310

## Test plan
- [ ] All pages: confirm intro text appears above dropdowns
- [ ] All pages: confirm each section has a brief italic description
- [ ] Team page — Goals per Round: hover a round and confirm opponent + result appears in tooltip
- [ ] Team page — Home vs Away & Formation: bars should be flush with no gap between series
- [ ] Home page: League Intelligence and Team Intelligence card descriptions are accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)