### PR TITLE
refactor: move Groq ingestion + add meta.ingestion_run_log

### DIFF
--- a/.github/workflows/discussions.yml
+++ b/.github/workflows/discussions.yml
@@ -56,7 +56,7 @@ jobs:
           if [ "${{ github.event.inputs.force }}" = "true" ]; then
             EXTRA_ARGS="$EXTRA_ARGS --force"
           fi
-          python scripts/generate_round_discussions.py --season "$SEASON" --db "$DB" $EXTRA_ARGS
+          python ingestion/groq/generate_round_discussions.py --season "$SEASON" --db "$DB" $EXTRA_ARGS
         env:
           MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
           GROQ_API_KEY:     ${{ secrets.GROQ_API_KEY }}

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -231,7 +231,7 @@ jobs:
           if [ "${{ github.event.inputs.force_discussions }}" = "true" ]; then
             EXTRA_ARGS="$EXTRA_ARGS --force"
           fi
-          python scripts/generate_round_discussions.py --season "$SEASON" --db "$DB" $EXTRA_ARGS
+          python ingestion/groq/generate_round_discussions.py --season "$SEASON" --db "$DB" $EXTRA_ARGS
         env:
           MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
           GROQ_API_KEY:     ${{ secrets.GROQ_API_KEY }}

--- a/dashboards/sources/superligaen/home/last_updated.sql
+++ b/dashboards/sources/superligaen/home/last_updated.sql
@@ -1,2 +1,3 @@
-select strftime(max(_ingested_at), '%d %b %Y %H:%M UTC') as last_updated
-from superligaen.bronze.sportmonks__fixtures
+select strftime(max(completed_at), '%d %b %Y %H:%M UTC') as last_updated
+from superligaen.meta.ingestion_run_log
+where status = 'success'

--- a/ingestion/groq/generate_round_discussions.py
+++ b/ingestion/groq/generate_round_discussions.py
@@ -40,6 +40,17 @@ CREATE TABLE IF NOT EXISTS {db}.bronze.groq__llm_match_discussions (
 )
 """
 
+META_CREATE_SQL = """
+CREATE SCHEMA IF NOT EXISTS {db}.meta;
+CREATE TABLE IF NOT EXISTS {db}.meta.ingestion_run_log (
+    pipeline     VARCHAR,
+    mode         VARCHAR,
+    status       VARCHAR,
+    started_at   TIMESTAMP,
+    completed_at TIMESTAMP
+)
+"""
+
 PLAYER_QUERY = """
 SELECT
     ts.team_side,
@@ -383,6 +394,9 @@ def main() -> None:
     con = duckdb.connect(f"md:{args.db}?motherduck_token={token}")
 
     con.execute(BRONZE_CREATE_SQL.format(db=args.db))
+    for stmt in META_CREATE_SQL.format(db=args.db).strip().split(";"):
+        if stmt.strip():
+            con.execute(stmt)
 
     personas = load_personas(con, args.db)
     if not personas:
@@ -391,7 +405,8 @@ def main() -> None:
     log.info(f"Loaded {len(personas)} personas: {[p['name'] for p in personas]}")
 
     client = Groq(api_key=os.environ["GROQ_API_KEY"])
-    now = datetime.now(timezone.utc).replace(tzinfo=None)
+    started_at = datetime.now(timezone.utc).replace(tzinfo=None)
+    now = started_at
 
     if args.all_rounds:
         if args.force:
@@ -423,6 +438,10 @@ def main() -> None:
 
         process_round(con, client, personas, args.db, args.season, round_number, args.force, now)
 
+    con.execute(
+        f"INSERT INTO {args.db}.meta.ingestion_run_log VALUES (?, ?, ?, ?, ?)",
+        ["groq", "incremental", "success", started_at, datetime.now(timezone.utc).replace(tzinfo=None)],
+    )
     con.close()
 
 

--- a/ingestion/groq/generate_round_discussions.py
+++ b/ingestion/groq/generate_round_discussions.py
@@ -7,9 +7,9 @@ once per match, and writes the raw API response to bronze.groq__llm_match_discus
 dbt then parses and models the bronze data into silver + gold.
 
 Usage:
-  python scripts/generate_round_discussions.py --season 2024/25 --round 26
-  python scripts/generate_round_discussions.py --season 2024/25  # auto-detects latest round
-  python scripts/generate_round_discussions.py --season 2024/25 --round 26 --db superligaen_dev
+  python ingestion/groq/generate_round_discussions.py --season 2024/25 --round 26
+  python ingestion/groq/generate_round_discussions.py --season 2024/25  # auto-detects latest round
+  python ingestion/groq/generate_round_discussions.py --season 2024/25 --round 26 --db superligaen_dev
 """
 
 import argparse

--- a/ingestion/sportmonks/db.py
+++ b/ingestion/sportmonks/db.py
@@ -36,8 +36,18 @@ def connect(db_path: str = None) -> duckdb.DuckDBPyConnection:
 
 
 def ensure_schema(conn: duckdb.DuckDBPyConnection) -> None:
-    """Create bronze schema and all tables; migrate old schemas gracefully."""
+    """Create bronze/meta schemas and all tables; migrate old schemas gracefully."""
     conn.execute("CREATE SCHEMA IF NOT EXISTS bronze")
+    conn.execute("CREATE SCHEMA IF NOT EXISTS meta")
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS meta.ingestion_run_log (
+            pipeline     VARCHAR,
+            mode         VARCHAR,
+            status       VARCHAR,
+            started_at   TIMESTAMP,
+            completed_at TIMESTAMP
+        )
+    """)
     for table in ALL_TABLES:
         conn.execute(f"""
             CREATE TABLE IF NOT EXISTS bronze.{table} (

--- a/ingestion/sportmonks/run.py
+++ b/ingestion/sportmonks/run.py
@@ -34,6 +34,7 @@ import argparse
 import logging
 import os
 import sys
+from datetime import datetime, timezone
 
 from dotenv import load_dotenv
 
@@ -86,7 +87,12 @@ def main() -> None:
     tables = set(args.tables.split(",")) if args.tables else None
     conn = connect(args.db)
     ensure_schema(conn)
+    started_at = datetime.now(timezone.utc).replace(tzinfo=None)
     engine.run(conn, mode=args.mode, tables=tables)
+    conn.execute(
+        "INSERT INTO meta.ingestion_run_log VALUES (?, ?, ?, ?, ?)",
+        ["sportmonks", args.mode, "success", started_at, datetime.now(timezone.utc).replace(tzinfo=None)],
+    )
     conn.close()
 
 


### PR DESCRIPTION
## Summary

- Moves `scripts/generate_round_discussions.py` → `ingestion/groq/generate_round_discussions.py` — Groq calls an external API and lands raw responses in bronze, same pattern as `ingestion/sportmonks/`
- Introduces a `meta` schema with `meta.ingestion_run_log` table; both Sportmonks and Groq pipelines write a row on successful completion
- Updates `last_updated.sql` to read `max(completed_at)` from `meta.ingestion_run_log` instead of proxying off `bronze.sportmonks__fixtures._ingested_at`

## Test plan

- [ ] Run nightly pipeline — verify a row appears in `meta.ingestion_run_log` for both `sportmonks` and `groq`
- [ ] Check dashboard home page shows correct last updated timestamp

🤖 Generated with [Claude Code](https://claude.com/claude-code)