### PR TITLE
fix(dashboard): standardise description text size across all pages

### DIFF
--- a/dashboards/pages/league-analytics.md
+++ b/dashboards/pages/league-analytics.md
@@ -41,7 +41,7 @@ select team_name from (
 ) order by ord, team_name
 ```
 
-*Select a season and optionally filter to specific teams. All sections below — KPIs, awards, standings, radar, and match log — update to the selection.*
+<p style="font-size:0.75rem;color:#6b7280;margin:0 0 1rem 0;font-style:italic;">Select a season and optionally filter to specific teams. All sections below — KPIs, awards, standings, radar, and match log — update to the selection.</p>
 
 {#key seasons[0]?.season}
 <Dropdown data={seasons} name=season value=season label=season order="season desc" defaultValue={seasons[0]?.season} />
@@ -430,7 +430,7 @@ order by case period_of_day
 
 ## League Intelligence — {inputs.season.value}
 
-*Top-line KPIs for the selected season, each compared against the previous season. Applies to the team filter if set.*
+<p style="font-size:0.75rem;color:#6b7280;margin:0 0 1rem 0;font-style:italic;">Top-line KPIs for the selected season, each compared against the previous season. Applies to the team filter if set.</p>
 
 {#each league_kpis as k}
 <div class="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
@@ -514,7 +514,7 @@ order by case period_of_day
 
 ## Season Awards
 
-*Top scorer, top assister, and best-rated player for the selected season (minimum 5 appearances). Runner-up cards are stacked below each winner.*
+<p style="font-size:0.75rem;color:#6b7280;margin:0 0 1rem 0;font-style:italic;">Top scorer, top assister, and best-rated player for the selected season (minimum 5 appearances). Runner-up cards are stacked below each winner.</p>
 
 <div class="grid grid-cols-1 md:grid-cols-3 gap-6 mb-8">
 
@@ -683,7 +683,7 @@ order by case period_of_day
 
 ## Standings & Points Race
 
-*Cumulative points race round by round alongside the current league table. Hover a round on the line chart to see the full ranking.*
+<p style="font-size:0.75rem;color:#6b7280;margin:0 0 1rem 0;font-style:italic;">Cumulative points race round by round alongside the current league table. Hover a round on the line chart to see the full ranking.</p>
 
 <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-6 items-start">
 
@@ -736,8 +736,8 @@ order by case period_of_day
 <div style="display:grid;grid-template-columns:repeat(1,1fr);gap:0 1.5rem;margin-bottom:1.5rem;" class="md:two-col-radar">
 
 <!-- Explanations: order 1 & 5 on mobile, reset to DOM order on desktop -->
-<p style="order:1;font-size:0.8125rem;color:#6b7280;margin:1rem 0 0.5rem 0;font-style:italic;" class="md:order-reset">Where does each team sit on the attack vs defence spectrum? Teams to the right score more, teams lower down concede less. The bottom-right corner is where champions live.</p>
-<p style="order:5;font-size:0.8125rem;color:#6b7280;margin:1rem 0 0.5rem 0;font-style:italic;" class="md:order-reset">How does a team rank across six dimensions relative to the rest of the league? Each axis is a score from 0 to 100 — 100 means best in the league. Click a team in the legend to isolate it.</p>
+<p style="order:1;font-size:0.75rem;color:#6b7280;margin:1rem 0 0.5rem 0;font-style:italic;" class="md:order-reset">Where does each team sit on the attack vs defence spectrum? Teams to the right score more, teams lower down concede less. The bottom-right corner is where champions live.</p>
+<p style="order:5;font-size:0.75rem;color:#6b7280;margin:1rem 0 0.5rem 0;font-style:italic;" class="md:order-reset">How does a team rank across six dimensions relative to the rest of the league? Each axis is a score from 0 to 100 — 100 means best in the league. Click a team in the legend to isolate it.</p>
 
 <!-- Titles: order 2 & 6 on mobile, reset to DOM order on desktop -->
 <p style="order:2;font-size:0.875rem;font-weight:600;color:#374151;margin:0 0 0.5rem 0;" class="md:order-reset">Attack vs Defence — {inputs.season.value}</p>
@@ -802,7 +802,7 @@ order by case period_of_day
 
 ## Team Rankings by Domain
 
-*All teams ranked within each performance dimension. Sorted highest to lowest so the best and worst performers are immediately visible.*
+<p style="font-size:0.75rem;color:#6b7280;margin:0 0 1rem 0;font-style:italic;">All teams ranked within each performance dimension. Sorted highest to lowest so the best and worst performers are immediately visible.</p>
 
 <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-6">
 
@@ -889,7 +889,7 @@ order by case period_of_day
 
 ## Match Schedule
 
-<p style="font-size:0.8125rem;color:#6b7280;margin:0 0 1rem 0;font-style:italic;">When are Superligaen matches played? The left chart breaks down fixtures by day of week and time of day; the right shows whether kick-off time influences scoring. Time slots: Morning 05:00–10:59 · Afternoon 11:00–15:59 · Evening 16:00–20:59 · Night 21:00–04:59.</p>
+<p style="font-size:0.75rem;color:#6b7280;margin:0 0 1rem 0;font-style:italic;">When are Superligaen matches played? The left chart breaks down fixtures by day of week and time of day; the right shows whether kick-off time influences scoring. Time slots: Morning 05:00–10:59 · Afternoon 11:00–15:59 · Evening 16:00–20:59 · Night 21:00–04:59.</p>
 
 <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-6">
 
@@ -925,7 +925,7 @@ order by case period_of_day
 
 ## Match Log
 
-<p style="font-size:0.8125rem;color:#6b7280;margin:0 0 1rem 0;font-style:italic;">Every team appearance for the selected season — one row per team per match. Search by anything: team, opponent, result, formation, coach, referee, stadium, time slot, day, round, etc.</p>
+<p style="font-size:0.75rem;color:#6b7280;margin:0 0 1rem 0;font-style:italic;">Every team appearance for the selected season — one row per team per match. Search by anything: team, opponent, result, formation, coach, referee, stadium, time slot, day, round, etc.</p>
 
 <DataTable data={match_log} search=true rows=6>
     <Column id=season              title="Season"           />

--- a/dashboards/pages/match-analysis.md
+++ b/dashboards/pages/match-analysis.md
@@ -332,7 +332,7 @@ order by team_side desc, position_group, position_name
   {/if}
 </div>
 
-<p style="font-size:0.8125rem;color:#6b7280;margin:0 0 20px;font-style:italic;">Fan reactions to this match. Drop your take below.</p>
+<p style="font-size:0.75rem;color:#6b7280;margin:0 0 1rem 0;font-style:italic;">Fan reactions to this match. Drop your take below.</p>
 
 <div style="display:flex;flex-direction:column;gap:0;margin-bottom:32px;border:1px solid #e5e7eb;border-radius:12px;overflow:hidden;">
   {#each discussions as post}

--- a/dashboards/pages/match-results.md
+++ b/dashboards/pages/match-results.md
@@ -12,7 +12,7 @@ select season from (
 ) order by is_current desc, season desc
 ```
 
-*Select a season and round to browse all matches. Click any match in the table to open the full match analysis page.*
+<p style="font-size:0.75rem;color:#6b7280;margin:0 0 1rem 0;font-style:italic;">Select a season and round to browse all matches. Click any match in the table to open the full match analysis page.</p>
 
 {#key seasons[0]?.season}
 <Dropdown data={seasons} name=season value=season label=season order="season desc" defaultValue={seasons[0]?.season} />
@@ -144,7 +144,7 @@ order by sort_order
 {#if potw.length > 0}
 ## Players of the Week
 
-*Standout performers from this round — one player recognised per category based on the highest single-match stat.*
+<p style="font-size:0.75rem;color:#6b7280;margin:0 0 1rem 0;font-style:italic;">Standout performers from this round — one player recognised per category based on the highest single-match stat.</p>
 
 <div class="grid grid-cols-3 md:grid-cols-6 gap-3 mb-6">
   {#each potw as p}

--- a/dashboards/pages/player-analytics.md
+++ b/dashboards/pages/player-analytics.md
@@ -599,7 +599,7 @@ where season = '${inputs.season.value}'
 
 ## Top Players
 
-*Top 3 players with at least 5 appearances in the selected season, ranked by the chosen measure. Season, team, and position filters all apply.*
+<p style="font-size:0.75rem;color:#6b7280;margin:0 0 1rem 0;font-style:italic;">Top 3 players with at least 5 appearances in the selected season, ranked by the chosen measure. Season, team, and position filters all apply.</p>
 
 <Dropdown data={podium_measures} name=podium_measure value=value label=label defaultValue="goals" title="Measure" />
 
@@ -653,7 +653,7 @@ where season = '${inputs.season.value}'
 
 ## Player Deep Dive
 
-*Select a player from the dropdown to explore their profile, season stats, player characteristics, performance timeline, and match log.*
+<p style="font-size:0.75rem;color:#6b7280;margin:0 0 1rem 0;font-style:italic;">Select a player from the dropdown to explore their profile, season stats, player characteristics, performance timeline, and match log.</p>
 
 {#key players_in_team[0]?.player_name}
 <Dropdown data={players_in_team} name=player value=player_name label=player_name defaultValue={players_in_team[0]?.player_name} />
@@ -755,7 +755,7 @@ where season = '${inputs.season.value}'
 
 ## Player Characteristics
 
-*Composite percentile score among all players with 450+ minutes in {inputs.season.value}. Each axis combines multiple rate metrics weighted by their importance to that dimension. Higher = better relative to the league.*
+<p style="font-size:0.75rem;color:#6b7280;margin:0 0 1rem 0;font-style:italic;">Composite percentile score among all players with 450+ minutes in {inputs.season.value}. Each axis combines multiple rate metrics weighted by their importance to that dimension. Higher = better relative to the league.</p>
 
 {#each league_context as lc}
 <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-6 items-center">
@@ -821,7 +821,7 @@ where season = '${inputs.season.value}'
 
 ## Performance Timeline
 
-*Select a measure to see how it evolved across rounds. Rating is always shown as the secondary axis.*
+<p style="font-size:0.75rem;color:#6b7280;margin:0 0 1rem 0;font-style:italic;">Select a measure to see how it evolved across rounds. Rating is always shown as the secondary axis.</p>
 
 ```sql timeline_measures
 select * from (values
@@ -917,7 +917,7 @@ select * from (values
 
 ## Match Log
 
-*Use the selectors below to add or remove columns per domain.*
+<p style="font-size:0.75rem;color:#6b7280;margin:0 0 1rem 0;font-style:italic;">Use the selectors below to add or remove columns per domain.</p>
 
 ```sql other_measures
 select * from (values

--- a/dashboards/pages/referee-analytics.md
+++ b/dashboards/pages/referee-analytics.md
@@ -24,7 +24,7 @@ from superligaen.mart_referee_season
 order by season desc
 ```
 
-*Select a season to explore referee discipline patterns — league averages, strictness rankings, home/away bias, and individual referee deep dives.*
+<p style="font-size:0.75rem;color:#6b7280;margin:0 0 1rem 0;font-style:italic;">Select a season to explore referee discipline patterns — league averages, strictness rankings, home/away bias, and individual referee deep dives.</p>
 
 {#key seasons[0]?.season}
 <Dropdown data={seasons} name=season value=season label=season order="season desc" defaultValue={seasons[0]?.season} />
@@ -108,7 +108,7 @@ from ${referee_trends}
 
 ### League Discipline Snapshot
 
-*Season-wide averages across all referees — active officials, yellow and red card rates, and average fouls per match.*
+<p style="font-size:0.75rem;color:#6b7280;margin:0 0 1rem 0;font-style:italic;">Season-wide averages across all referees — active officials, yellow and red card rates, and average fouls per match.</p>
 
 <div class="grid grid-cols-2 md:grid-cols-4 gap-4 mb-8">
   <div class="rounded-xl border border-gray-200 bg-white shadow-sm p-4 text-center">
@@ -129,7 +129,7 @@ from ${referee_trends}
 
 ## Strictest vs Most Lenient Referees
 
-*Top 3 referees by yellow cards per match at each extreme — who runs the tightest game and who lets the most go.*
+<p style="font-size:0.75rem;color:#6b7280;margin:0 0 1rem 0;font-style:italic;">Top 3 referees by yellow cards per match at each extreme — who runs the tightest game and who lets the most go.</p>
 
 <div class="grid grid-cols-1 md:grid-cols-2 gap-8 mb-8">
 
@@ -177,7 +177,7 @@ from ${referee_trends}
 
 ## Season Leaderboard
 
-*All referees ranked by matches managed. Includes cards, fouls, severity index, and home/away yellow card split.*
+<p style="font-size:0.75rem;color:#6b7280;margin:0 0 1rem 0;font-style:italic;">All referees ranked by matches managed. Includes cards, fouls, severity index, and home/away yellow card split.</p>
 
 <DataTable data={season_stats} rows=20>
     <Column id=referee_name          title="Referee"              wrap=true />
@@ -195,7 +195,7 @@ from ${referee_trends}
 
 ## Home / Away Bias
 
-*A neutral referee should book home and away teams equally. Values near 50% = balanced. Above 50% = more cards to home team.*
+<p style="font-size:0.75rem;color:#6b7280;margin:0 0 1rem 0;font-style:italic;">A neutral referee should book home and away teams equally. Values near 50% = balanced. Above 50% = more cards to home team.</p>
 
 <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-6">
 
@@ -228,7 +228,7 @@ from ${referee_trends}
 
 ## Cards & Fouls per Match
 
-*Per-match averages for every referee. Sorted highest to lowest so outliers are immediately visible.*
+<p style="font-size:0.75rem;color:#6b7280;margin:0 0 1rem 0;font-style:italic;">Per-match averages for every referee. Sorted highest to lowest so outliers are immediately visible.</p>
 
 <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-6">
 
@@ -258,7 +258,7 @@ from ${referee_trends}
 
 ## Referee Deep Dive
 
-*Select a referee to see their personal profile, team exposure, match log, and how their card rates compare to the league average across all seasons.*
+<p style="font-size:0.75rem;color:#6b7280;margin:0 0 1rem 0;font-style:italic;">Select a referee to see their personal profile, team exposure, match log, and how their card rates compare to the league average across all seasons.</p>
 
 {#key season_stats[0]?.referee_name}
 <Dropdown data={season_stats} name=referee value=referee_name label=referee_name defaultValue={season_stats[0]?.referee_name} />
@@ -371,7 +371,7 @@ where referee_name = '${inputs.referee.value}'
 
 ## Historical Discipline Trends
 
-*Season-by-season league averages (grey) overlaid with the selected referee's own trend line — spot referees who have become stricter or more lenient over time.*
+<p style="font-size:0.75rem;color:#6b7280;margin:0 0 1rem 0;font-style:italic;">Season-by-season league averages (grey) overlaid with the selected referee's own trend line — spot referees who have become stricter or more lenient over time.</p>
 
 <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-6">
 

--- a/dashboards/pages/stadium-analytics.md
+++ b/dashboards/pages/stadium-analytics.md
@@ -10,7 +10,7 @@ from superligaen.mart_stadium_season
 order by season desc
 ```
 
-*Select a season to explore stadium and surface data — fortress rankings, home win rates, and how grass vs. artificial turf affects the way the game is played.*
+<p style="font-size:0.75rem;color:#6b7280;margin:0 0 1rem 0;font-style:italic;">Select a season to explore stadium and surface data — fortress rankings, home win rates, and how grass vs. artificial turf affects the way the game is played.</p>
 
 {#key season_options[0]?.season}
 <Dropdown data={season_options} name=season value=season label=season order="season desc" defaultValue={season_options[0]?.season} />
@@ -72,7 +72,7 @@ where season = '${inputs.season.value}'
 
 ## Stadium Map
 
-*Bubble size = total goals scored. Color = playing surface type.*
+<p style="font-size:0.75rem;color:#6b7280;margin:0 0 1rem 0;font-style:italic;">Bubble size = total goals scored. Color = playing surface type.</p>
 
 <BubbleMap
     data={stadium_stats}
@@ -93,7 +93,7 @@ where season = '${inputs.season.value}'
 
 ## Top 3 Fortress Stadiums
 
-*The three venues where the home side wins most often — home win %, wins, and total home matches played.*
+<p style="font-size:0.75rem;color:#6b7280;margin:0 0 1rem 0;font-style:italic;">The three venues where the home side wins most often — home win %, wins, and total home matches played.</p>
 
 <div class="grid grid-cols-1 md:grid-cols-3 gap-6 mb-8">
   {#each fortress_podium as s, i}
@@ -132,7 +132,7 @@ where season = '${inputs.season.value}'
 
 ## Full Fortress Ranking
 
-*Home record at each stadium. A true fortress keeps opponents at bay.*
+<p style="font-size:0.75rem;color:#6b7280;margin:0 0 1rem 0;font-style:italic;">Home record at each stadium. A true fortress keeps opponents at bay.</p>
 
 <BarChart
     data={fortress_ranking}
@@ -177,7 +177,7 @@ where season = '${inputs.season.value}'
 
 ## Surface Analysis: Grass vs Artificial Turf
 
-*How does the playing surface shape the way football is played?*
+<p style="font-size:0.75rem;color:#6b7280;margin:0 0 1rem 0;font-style:italic;">How does the playing surface shape the way football is played?</p>
 
 <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-6">
 

--- a/dashboards/pages/team-analytics.md
+++ b/dashboards/pages/team-analytics.md
@@ -31,7 +31,7 @@ where season = '${inputs.season.value}'
 order by team_name
 ```
 
-*Select a season and team to explore their full season profile — KPIs vs. the previous year, goals timeline, home/away splits, formation breakdowns, and the complete match log.*
+<p style="font-size:0.75rem;color:#6b7280;margin:0 0 1rem 0;font-style:italic;">Select a season and team to explore their full season profile — KPIs vs. the previous year, goals timeline, home/away splits, formation breakdowns, and the complete match log.</p>
 
 {#key seasons[0]?.season}
 <Dropdown data={seasons} name=season value=season label=season order="season desc" defaultValue={seasons[0]?.season} />
@@ -271,7 +271,7 @@ end
 
 ## Team Intelligence
 
-*Season summary for the selected team — points, goal difference, last 5 results, and head-to-head record against each opponent.*
+<p style="font-size:0.75rem;color:#6b7280;margin:0 0 1rem 0;font-style:italic;">Season summary for the selected team — points, goal difference, last 5 results, and head-to-head record against each opponent.</p>
 
 {#each team_header as h}
 <div class="rounded-2xl bg-gradient-to-br from-gray-900 via-gray-800 to-gray-900 p-6 md:p-8 mb-6 shadow-xl">
@@ -315,7 +315,7 @@ end
 
 ## Season Overview
 
-*Key performance indicators for the selected season, each compared against the previous season to show whether the team has improved or declined.*
+<p style="font-size:0.75rem;color:#6b7280;margin:0 0 1rem 0;font-style:italic;">Key performance indicators for the selected season, each compared against the previous season to show whether the team has improved or declined.</p>
 
 {#each team_kpis as k}
 <div class="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
@@ -407,7 +407,7 @@ end
 
 ## Goals per Round
 
-*Goals scored and conceded per match across the season. Hover a round to see the opponent.*
+<p style="font-size:0.75rem;color:#6b7280;margin:0 0 1rem 0;font-style:italic;">Goals scored and conceded per match across the season. Hover a round to see the opponent.</p>
 
 <LineChart
     data={goals_per_round}
@@ -423,7 +423,7 @@ end
 
 ## Goals against Opponent
 
-*Total goals scored and conceded against each opponent across all meetings in the selected season.*
+<p style="font-size:0.75rem;color:#6b7280;margin:0 0 1rem 0;font-style:italic;">Total goals scored and conceded against each opponent across all meetings in the selected season.</p>
 
 <BarChart
     data={goals_vs_opponent}
@@ -443,7 +443,7 @@ end
 
 ## Home vs Away
 
-*Results, goals, possession, and pass accuracy split by home and away fixtures.*
+<p style="font-size:0.75rem;color:#6b7280;margin:0 0 1rem 0;font-style:italic;">Results, goals, possession, and pass accuracy split by home and away fixtures.</p>
 
 <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-6">
 
@@ -493,7 +493,7 @@ end
 
 ## Formation
 
-*Win/draw/loss record and goals per match broken down by the formation used in each game.*
+<p style="font-size:0.75rem;color:#6b7280;margin:0 0 1rem 0;font-style:italic;">Win/draw/loss record and goals per match broken down by the formation used in each game.</p>
 
 <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-6">
 
@@ -524,7 +524,7 @@ end
 
 ## When We Play Best
 
-*Results split by day of the week and time of day to reveal any scheduling patterns in performance.*
+<p style="font-size:0.75rem;color:#6b7280;margin:0 0 1rem 0;font-style:italic;">Results split by day of the week and time of day to reveal any scheduling patterns in performance.</p>
 
 <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-6">
 
@@ -554,7 +554,7 @@ end
 
 ## Match Log
 
-*Full match-by-match record for the selected team and season, including possession, pass accuracy, shots on goal, and shot conversion.*
+<p style="font-size:0.75rem;color:#6b7280;margin:0 0 1rem 0;font-style:italic;">Full match-by-match record for the selected team and season, including possession, pass accuracy, shots on goal, and shot conversion.</p>
 
 <div class="hidden md:block">
 <DataTable data={match_results} rows=20 search=true downloadable=true>

--- a/dashboards/pages/upcoming-matches.md
+++ b/dashboards/pages/upcoming-matches.md
@@ -14,7 +14,7 @@ select distinct team_name from (
 
 {#if teams.length > 0}
 
-*Filter by team to see only relevant fixtures. Select a match in the section below to explore head-to-head history and recent form for both sides.*
+<p style="font-size:0.75rem;color:#6b7280;margin:0 0 1rem 0;font-style:italic;">Filter by team to see only relevant fixtures. Select a match in the section below to explore head-to-head history and recent form for both sides.</p>
 
 <Dropdown data={teams} name=team value=team_name label=team_name order="team_name asc" multiple=true selectAllByDefault=true />
 
@@ -68,7 +68,7 @@ order by match_date asc, kick_off_time asc
 
 ## Match Analysis
 
-*Select a fixture to see the all-time head-to-head record between the two clubs and the last 5 results for each side going into the match.*
+<p style="font-size:0.75rem;color:#6b7280;margin:0 0 1rem 0;font-style:italic;">Select a fixture to see the all-time head-to-head record between the two clubs and the last 5 results for each side going into the match.</p>
 
 <Dropdown data={upcoming} name=match value=match_key label=match_short_name order="match_date asc, kick_off_time asc" />
 
@@ -175,7 +175,7 @@ limit 5
 
 ### Head-to-Head History
 
-*All previous meetings between these two clubs. Filter by season to narrow the comparison.*
+<p style="font-size:0.75rem;color:#6b7280;margin:0 0 1rem 0;font-style:italic;">All previous meetings between these two clubs. Filter by season to narrow the comparison.</p>
 
 <Dropdown data={h2h_seasons} name=h2h_season value=season label=season multiple=true selectAllByDefault=true order="season desc" />
 
@@ -221,7 +221,7 @@ limit 5
 
 ### Form Guide — Last 5 Matches
 
-*Most recent five results for each side across all competitions in the current season.*
+<p style="font-size:0.75rem;color:#6b7280;margin:0 0 1rem 0;font-style:italic;">Most recent five results for each side across all competitions in the current season.</p>
 
 <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
 


### PR DESCRIPTION
## Summary
- Converted all section/chart description texts from markdown `*italic*` to explicit `<p>` tags with `font-size:0.75rem; color:#6b7280; font-style:italic` across all 8 dashboard pages
- Fixed remaining `<p>` tags that were still at `0.8125rem` (league-analytics × 2, match-analysis × 1)
- Ensures consistent visual hierarchy on every page: page title → section title → chart title → description

## Pages updated
league-analytics, team-analytics, player-analytics, referee-analytics, stadium-analytics, match-results, match-analysis, upcoming-matches

## Test plan
- [ ] Browse each dashboard page and confirm description texts are uniformly small/grey/italic
- [ ] Confirm no description text appears larger than chart or section titles

🤖 Generated with [Claude Code](https://claude.com/claude-code)