### PR TITLE
fix(dashboard): align missed description text in match-results

### DIFF
--- a/dashboards/pages/match-results.md
+++ b/dashboards/pages/match-results.md
@@ -102,7 +102,7 @@ from curr cross join prev
 </div>
 {/each}
 
-<p class="text-sm text-gray-500 mb-3">Click on a match to open the detailed analysis page.</p>
+<p style="font-size:0.75rem;color:#6b7280;margin:0 0 1rem 0;font-style:italic;">Click on a match to open the detailed analysis page.</p>
 
 <div class="block md:hidden">
 <DataTable data={results} rows=20>


### PR DESCRIPTION
## Summary
- One description line in `match-results.md` was using Tailwind classes (`text-sm text-gray-500 mb-3`) instead of the inline style established in #322, so it was missed in the previous pass
- Converted to the same `font-size:0.75rem; color:#6b7280; font-style:italic` standard

🤖 Generated with [Claude Code](https://claude.com/claude-code)