### PR TITLE
feat(personas): reactivate Maja (woodwork only) and rework Ecem (referee philosophy)

### DIFF
--- a/dbt/models/gold/dims/dim_persona.sql
+++ b/dbt/models/gold/dims/dim_persona.sql
@@ -8,8 +8,8 @@ FROM (VALUES
      '68-year-old lifelong Danish football fan. Watched the Superliga since it began. Loves a game with lots of goals. Gets very happy when sees a game with 3 or more goals. Gets crumby when sees a game with 0 or 1 goal. Keeps short comments with full of emotions.'),
     (3, 'Rasmus',   3, true,
      'Passionate FC Nordsjælland fan. Always finds a way to bring it back to FCN — their style, their academy, what FCN would have done. If FCN are in this match he is fully emotionally invested. Gets euphoric when his team wins, inconsolable when they lose. Short, biased, unapologetic.'),
-    (4, 'Maja',     4, false,
-     'Lifelong FC København supporter. Measures every match against FCK''s standards — their pressing, their mentality, their winning culture. Openly rates FCK above everyone else. Gets smug when FCK win, gets cutting and dismissive when they don''t. Short comments, strong opinions.'),
-    (5, 'Ecem',     4, true,
-     'Football officiating obsessive. Never misses a card, penalty decision, or controversial offside call. Always has a sharp opinion on whether the referee was the story of the match — and whether the cards handed out were deserved. Focuses on how discipline and referee decisions shaped the result. Precise and opinionated.')
+    (4, 'Maja',     4, true,
+     'The woodwork obsessive. Nothing in football thrills her more than when the ball hits the post or crossbar — she finds it absolutely electric. She ONLY talks about woodwork hits in this match: how many there were, which team was unlucky, the drama and heartbreak of it. Gets genuinely euphoric over every single woodwork hit mentioned. If there were zero woodwork hits in this match, she simply says it was a good game and nothing more.'),
+    (5, 'Ecem',     5, true,
+     'Philosopher of the referee. Never mentions scores, player stats, or match data. Instead she reflects poetically on the referee of this specific match — she always mentions the referee by name. She marvels at the extraordinary responsibility they carry: standing alone in the centre of a stadium, controlling 22 players, making split-second decisions that shape history. She finds the role of a referee deeply fascinating as a human experience — the power, the pressure, the loneliness, the authority. Always thoughtful and philosophical, never statistical.')
 ) t(persona_sk, persona_name, sort_order, is_active, bio)

--- a/ingestion/groq/generate_round_discussions.py
+++ b/ingestion/groq/generate_round_discussions.py
@@ -107,7 +107,8 @@ WITH player_stats AS (
         team_sk,
         SUM(shots_total)         AS total_shots,
         SUM(shots_on_target)     AS shots_on_goal,
-        SUM(big_chances_created) AS big_chances
+        SUM(big_chances_created) AS big_chances,
+        SUM(woodwork_hits)       AS woodwork_hits
     FROM {db}.gold.fct_player_appearances
     GROUP BY match_sk, team_sk
 )
@@ -128,6 +129,7 @@ SELECT
     MAX(CASE WHEN ts.team_side = 'Home' THEN ps.total_shots      END)       AS home_shots,
     MAX(CASE WHEN ts.team_side = 'Home' THEN ps.shots_on_goal    END)       AS home_sog,
     MAX(CASE WHEN ts.team_side = 'Home' THEN ps.big_chances      END)       AS home_big_chances,
+    MAX(CASE WHEN ts.team_side = 'Home' THEN ps.woodwork_hits   END)       AS home_woodwork,
     MAX(CASE WHEN ts.team_side = 'Home' THEN f.corner_kicks     END)        AS home_corners,
     MAX(CASE WHEN ts.team_side = 'Home' THEN f.yellow_cards     END)        AS home_yc,
     MAX(CASE WHEN ts.team_side = 'Home' THEN f.red_cards        END)        AS home_rc,
@@ -140,6 +142,7 @@ SELECT
     MAX(CASE WHEN ts.team_side = 'Away' THEN ps.total_shots      END)       AS away_shots,
     MAX(CASE WHEN ts.team_side = 'Away' THEN ps.shots_on_goal    END)       AS away_sog,
     MAX(CASE WHEN ts.team_side = 'Away' THEN ps.big_chances      END)       AS away_big_chances,
+    MAX(CASE WHEN ts.team_side = 'Away' THEN ps.woodwork_hits   END)       AS away_woodwork,
     MAX(CASE WHEN ts.team_side = 'Away' THEN f.corner_kicks     END)        AS away_corners,
     MAX(CASE WHEN ts.team_side = 'Away' THEN f.yellow_cards     END)        AS away_yc,
     MAX(CASE WHEN ts.team_side = 'Away' THEN f.red_cards        END)        AS away_rc,
@@ -271,11 +274,11 @@ def build_match_context(row: dict, player_context: str) -> str:
         f"Phase: {row['phase']}  |  Venue: {row['stadium']}  |  Referee: {row['referee']}\n"
         f"\n"
         f"HOME — {row['home_team']} [{row['home_formation']}] (Coach: {row['home_coach']})\n"
-        f"  Goals: {row['home_goals']}  |  Shots: {row['home_shots']} (on target: {row['home_sog']})  |  Big chances: {row['home_big_chances']}\n"
+        f"  Goals: {row['home_goals']}  |  Shots: {row['home_shots']} (on target: {row['home_sog']})  |  Big chances: {row['home_big_chances']}  |  Woodwork hits: {row['home_woodwork'] or 0}\n"
         f"  Possession: {row['home_possession']}%  |  Corners: {row['home_corners']}  |  YC: {row['home_yc']}  |  RC: {row['home_rc']}\n"
         f"\n"
         f"AWAY — {row['away_team']} [{row['away_formation']}] (Coach: {row['away_coach']})\n"
-        f"  Goals: {row['away_goals']}  |  Shots: {row['away_shots']} (on target: {row['away_sog']})  |  Big chances: {row['away_big_chances']}\n"
+        f"  Goals: {row['away_goals']}  |  Shots: {row['away_shots']} (on target: {row['away_sog']})  |  Big chances: {row['away_big_chances']}  |  Woodwork hits: {row['away_woodwork'] or 0}\n"
         f"  Possession: {row['away_possession']}%  |  Corners: {row['away_corners']}  |  YC: {row['away_yc']}  |  RC: {row['away_rc']}\n"
         f"\n"
         f"{player_context}"
@@ -296,6 +299,7 @@ def build_prompt(match_context: str, personas: list[dict]) -> str:
         "- Each post must be 2-4 sentences, opinionated, and specific to this match.\n"
         "- They should reference each other to feel like a real conversation thread.\n"
         "- No generic football commentary — every sentence must be grounded in the match data.\n"
+        "- Each persona's bio is law. If a persona's bio restricts them to a specific topic (e.g. only woodwork hits) or forbids them from mentioning stats, follow that strictly — even if it means ignoring other match events.\n"
         f"- When referring to other fans by name, use ONLY these exact names: {persona_order}. Never invent or use any other name.\n"
         "\n"
         f"PERSONAS:\n{persona_block}\n"


### PR DESCRIPTION
## Summary
- **Maja** reactivated (`is_active = true`, `sort_order = 4`) with a new bio: only ever talks about woodwork hits — gets euphoric if any occurred, says "good game" and nothing more if none
- **Ecem** bio rewritten (`sort_order = 5`): drops all data/stats commentary; instead philosophically reflects on the referee by name — the power, responsibility, and fascination of controlling a match from the centre
- **Groq script**: `woodwork_hits` added to the `player_stats` CTE and surfaced as `home_woodwork` / `away_woodwork` in the match context so Maja has real data to react to
- **Prompt rule added**: "Each persona's bio is law" — enforces persona-specific topic restrictions even when they conflict with the general stats-only rule

## After merging
Run `dbt seed` (not needed — dim_persona is a model, not a seed) then `dbt run --select gold.dim_persona` to push the updated persona table to prod, then re-run the Groq script for any rounds you want refreshed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)