### PR TITLE
fix(gold): align fct_match_discussions incremental logic with other fact tables

### DIFF
--- a/dbt/models/gold/fct_match_discussions.sql
+++ b/dbt/models/gold/fct_match_discussions.sql
@@ -13,8 +13,5 @@ FROM {{ ref('llm_match_discussions') }}  s
 JOIN {{ ref('dim_match') }}              dm ON dm.match_id    = s.match_id
 JOIN {{ ref('dim_persona') }}            dp ON dp.persona_name = s.persona_name
 {% if is_incremental() %}
-WHERE NOT EXISTS (
-    SELECT 1 FROM {{ this }} t
-    WHERE t.match_sk = dm.match_sk AND t.persona_sk = dp.persona_sk
-)
+WHERE {{ gold_incremental_filter() }}
 {% endif %}


### PR DESCRIPTION
## Summary
- Replaced custom `WHERE NOT EXISTS` guard in `fct_match_discussions` with the standard `gold_incremental_filter()` macro used by all other gold fact tables
- The old logic blocked regenerated discussions from propagating to gold — if a `(match_sk, persona_sk)` pair already existed, it was skipped entirely, even if the LLM had regenerated new content (e.g. after a persona rework)
- The new 7-day sliding window lets `delete+insert` correctly replace stale rows for any match whose discussions were regenerated within the lookback period

## Test plan
- [ ] Run `dbt run --select fct_match_discussions` and verify match 19686590 (FC Fredericia - Silkeborg IF) gets updated with the silver records generated on 2026-05-29
- [ ] Confirm row count for the match remains 5 (one per persona)

🤖 Generated with [Claude Code](https://claude.com/claude-code)