### PR TITLE
fix(dbt): disable fixtures freshness check during off-season

### DIFF
--- a/dbt/models/silver/_sources.yml
+++ b/dbt/models/silver/_sources.yml
@@ -20,6 +20,7 @@ sources:
       - name: sportmonks__referees
       - name: sportmonks__players
       - name: sportmonks__fixtures
+        freshness: null
       - name: sportmonks__standings
       - name: sportmonks__topscorers
       - name: sportmonks__stage_topscorers


### PR DESCRIPTION
## Summary
- Set `freshness: null` for `sportmonks__fixtures` in `_sources.yml`
- The Superliga season has ended so no new fixture data is being ingested, causing nightly false-positive `ERROR STALE` failures in the DQ tests step
- Remember to re-enable when the new season starts

## Test plan
- [ ] Confirm nightly pipeline passes DQ tests without the stale error

🤖 Generated with [Claude Code](https://claude.com/claude-code)