### PR TITLE
fix(dbt): disable freshness check for topscorers during off-season

### DIFF
--- a/dbt/models/silver/_sources.yml
+++ b/dbt/models/silver/_sources.yml
@@ -23,7 +23,9 @@ sources:
         freshness: null
       - name: sportmonks__standings
       - name: sportmonks__topscorers
+        freshness: null
       - name: sportmonks__stage_topscorers
+        freshness: null
       - name: sportmonks__stage_statistics
       - name: sportmonks__round_statistics
       - name: sportmonks__rivals


### PR DESCRIPTION
## Summary

- `sportmonks__topscorers` and `sportmonks__stage_topscorers` were failing `dbt source freshness` with `ERROR STALE` (last ingested 2026-05-15, threshold 49h)
- Sportmonks returns 0 rows from the topscorer endpoints once the season ends — `insert_batch` short-circuits on empty input, so `_ingested_at` is never updated
- Other `season_based` tables (standings, stages, rounds, etc.) continue to return records from Sportmonks even off-season, which is why only topscorers failed
- Same root cause and fix as #327 (fixtures)

## Test plan

- [ ] Nightly pipeline passes DQ tests after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)