### PR TITLE
fix(dashboard): align goals-by-slot bar colors with stacked chart

### DIFF
--- a/dashboards/pages/league-analytics.md
+++ b/dashboards/pages/league-analytics.md
@@ -911,10 +911,12 @@ order by case period_of_day
     data={goals_by_slot}
     x=period_of_day
     y=goals_per_match
+    series=period_of_day
     title="Goals per Match by Time of Day"
     xAxisTitle="Time of Day"
     yAxisTitle="Goals / Match"
     colorPalette={['#fbbf24','#3b82f6','#10b981','#f97316','#6366f1']}
+    legend=false
     sort=false
     echartsOptions={{xAxis: {data: ['Morning', 'Noon', 'Afternoon', 'Evening', 'Night']}}}
 />


### PR DESCRIPTION
## Summary

- Right chart (Goals per Match by Time of Day) was rendering all bars in a single color because it had no `series` dimension — Evidence only applies per-bar colors when a series is set
- Adding `series=period_of_day` gives each bar its own color using the same alphabetical assignment as the left stacked chart, so Afternoon=yellow, Evening=blue, etc. are consistent across both charts
- `legend=false` suppresses the redundant legend on the right chart

## Test plan

- [ ] Both Match Schedule charts show matching colors for each time slot

🤖 Generated with [Claude Code](https://claude.com/claude-code)