### PR TITLE
fix(ingestion): retry 5xx errors and log failures to MotherDuck

### DIFF
--- a/ingestion/groq/generate_round_discussions.py
+++ b/ingestion/groq/generate_round_discussions.py
@@ -43,11 +43,12 @@ CREATE TABLE IF NOT EXISTS {db}.bronze.groq__llm_match_discussions (
 META_CREATE_SQL = """
 CREATE SCHEMA IF NOT EXISTS {db}.meta;
 CREATE TABLE IF NOT EXISTS {db}.meta.ingestion_run_log (
-    pipeline     VARCHAR,
-    mode         VARCHAR,
-    status       VARCHAR,
-    started_at   TIMESTAMP,
-    completed_at TIMESTAMP
+    pipeline      VARCHAR,
+    mode          VARCHAR,
+    status        VARCHAR,
+    started_at    TIMESTAMP,
+    completed_at  TIMESTAMP,
+    error_message VARCHAR
 )
 """
 
@@ -412,41 +413,49 @@ def main() -> None:
     started_at = datetime.now(timezone.utc).replace(tzinfo=None)
     now = started_at
 
-    if args.all_rounds:
-        if args.force:
-            con.execute(
-                f"DELETE FROM {args.db}.bronze.groq__llm_match_discussions WHERE season = ?",
-                [args.season],
-            )
-            log.info(f"--force: deleted all bronze rows for season {args.season}")
+    try:
+        if args.all_rounds:
+            if args.force:
+                con.execute(
+                    f"DELETE FROM {args.db}.bronze.groq__llm_match_discussions WHERE season = ?",
+                    [args.season],
+                )
+                log.info(f"--force: deleted all bronze rows for season {args.season}")
 
-        rounds = [
-            r[0] for r in con.execute(ALL_ROUNDS_SQL.format(db=args.db), [args.season]).fetchall()
-        ]
-        if not rounds:
-            log.error(f"No completed rounds found for season {args.season}")
-            return
-        log.info(f"Processing {len(rounds)} rounds for season {args.season}")
-        for round_number in rounds:
-            process_round(con, client, personas, args.db, args.season, round_number, False, now)
-
-    else:
-        round_number = args.round
-        if round_number is None:
-            result = con.execute(LATEST_ROUND_SQL.format(db=args.db), [args.season]).fetchone()
-            round_number = result[0] if result else None
-            if round_number is None:
+            rounds = [
+                r[0] for r in con.execute(ALL_ROUNDS_SQL.format(db=args.db), [args.season]).fetchall()
+            ]
+            if not rounds:
                 log.error(f"No completed rounds found for season {args.season}")
                 return
-            log.info(f"Auto-detected latest round: {round_number}")
+            log.info(f"Processing {len(rounds)} rounds for season {args.season}")
+            for round_number in rounds:
+                process_round(con, client, personas, args.db, args.season, round_number, False, now)
 
-        process_round(con, client, personas, args.db, args.season, round_number, args.force, now)
+        else:
+            round_number = args.round
+            if round_number is None:
+                result = con.execute(LATEST_ROUND_SQL.format(db=args.db), [args.season]).fetchone()
+                round_number = result[0] if result else None
+                if round_number is None:
+                    log.error(f"No completed rounds found for season {args.season}")
+                    return
+                log.info(f"Auto-detected latest round: {round_number}")
 
-    con.execute(
-        f"INSERT INTO {args.db}.meta.ingestion_run_log VALUES (?, ?, ?, ?, ?)",
-        ["groq", "incremental", "success", started_at, datetime.now(timezone.utc).replace(tzinfo=None)],
-    )
-    con.close()
+            process_round(con, client, personas, args.db, args.season, round_number, args.force, now)
+
+        con.execute(
+            f"INSERT INTO {args.db}.meta.ingestion_run_log VALUES (?, ?, ?, ?, ?, ?)",
+            ["groq", "incremental", "success", started_at, datetime.now(timezone.utc).replace(tzinfo=None), None],
+        )
+    except Exception as exc:
+        con.execute(
+            f"INSERT INTO {args.db}.meta.ingestion_run_log VALUES (?, ?, ?, ?, ?, ?)",
+            ["groq", "incremental", "failure", started_at, datetime.now(timezone.utc).replace(tzinfo=None), str(exc)],
+        )
+        raise
+    finally:
+        con.close()
 
 
 if __name__ == "__main__":

--- a/ingestion/sportmonks/api.py
+++ b/ingestion/sportmonks/api.py
@@ -33,6 +33,11 @@ def get(path: str, params: dict = None, base: str = API_BASE) -> dict:
             log.warning("Request error (attempt %d/%d): %s", attempt + 1, MAX_RETRIES, exc)
             time.sleep(min(5 * 2 ** attempt, 120))
             continue
+        if r.status_code >= 500:
+            wait = min(10 * 2 ** attempt, 300)
+            log.warning("Server error %d — sleeping %ds (attempt %d/%d)", r.status_code, wait, attempt + 1, MAX_RETRIES)
+            time.sleep(wait)
+            continue
         if r.status_code == 429:
             # Use retry_after from the API response if present; otherwise fall back
             # to exponential backoff capped at 600 s

--- a/ingestion/sportmonks/db.py
+++ b/ingestion/sportmonks/db.py
@@ -41,11 +41,12 @@ def ensure_schema(conn: duckdb.DuckDBPyConnection) -> None:
     conn.execute("CREATE SCHEMA IF NOT EXISTS meta")
     conn.execute("""
         CREATE TABLE IF NOT EXISTS meta.ingestion_run_log (
-            pipeline     VARCHAR,
-            mode         VARCHAR,
-            status       VARCHAR,
-            started_at   TIMESTAMP,
-            completed_at TIMESTAMP
+            pipeline      VARCHAR,
+            mode          VARCHAR,
+            status        VARCHAR,
+            started_at    TIMESTAMP,
+            completed_at  TIMESTAMP,
+            error_message VARCHAR
         )
     """)
     for table in ALL_TABLES:

--- a/ingestion/sportmonks/run.py
+++ b/ingestion/sportmonks/run.py
@@ -88,12 +88,20 @@ def main() -> None:
     conn = connect(args.db)
     ensure_schema(conn)
     started_at = datetime.now(timezone.utc).replace(tzinfo=None)
-    engine.run(conn, mode=args.mode, tables=tables)
-    conn.execute(
-        "INSERT INTO meta.ingestion_run_log VALUES (?, ?, ?, ?, ?)",
-        ["sportmonks", args.mode, "success", started_at, datetime.now(timezone.utc).replace(tzinfo=None)],
-    )
-    conn.close()
+    try:
+        engine.run(conn, mode=args.mode, tables=tables)
+        conn.execute(
+            "INSERT INTO meta.ingestion_run_log VALUES (?, ?, ?, ?, ?, ?)",
+            ["sportmonks", args.mode, "success", started_at, datetime.now(timezone.utc).replace(tzinfo=None), None],
+        )
+    except Exception as exc:
+        conn.execute(
+            "INSERT INTO meta.ingestion_run_log VALUES (?, ?, ?, ?, ?, ?)",
+            ["sportmonks", args.mode, "failure", started_at, datetime.now(timezone.utc).replace(tzinfo=None), str(exc)],
+        )
+        raise
+    finally:
+        conn.close()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Sportmonks API 5xx responses (e.g. 503 Service Unavailable) now retry with exponential backoff — up to 8 attempts, starting at 10s, capped at 300s — instead of crashing the pipeline immediately
- Added `error_message VARCHAR` column to `meta.ingestion_run_log` (applied to live MotherDuck table and both schema creation scripts)
- Both the sportmonks and groq pipelines now write a `failure` row with the exception message on total failure, then re-raise so GitHub Actions still marks the job red

## Context

Last night's pipeline failed because the Sportmonks API returned a 503 on page 5 of the `/players` endpoint. The retry logic already handled 429s and connection errors but had no handling for 5xx — it called `raise_for_status()` immediately.

## Test plan

- [ ] Nightly pipeline runs successfully tonight
- [ ] `SELECT * FROM superligaen.meta.ingestion_run_log ORDER BY started_at DESC LIMIT 5` shows a success row with `error_message = NULL`

🤖 Generated with [Claude Code](https://claude.com/claude-code)