### PR TITLE
fix(dashboard): consistent time-of-day colors across schedule charts

### DIFF
--- a/dashboards/pages/league-analytics.md
+++ b/dashboards/pages/league-analytics.md
@@ -901,7 +901,7 @@ order by case period_of_day
     title="Matches by Day & Time of Day"
     xAxisTitle="Day"
     yAxisTitle="Matches"
-    colorPalette={['#fbbf24','#3b82f6','#10b981','#f97316','#6366f1']}
+    colorPalette={['#fbbf24','#3b82f6','#6366f1','#f97316','#10b981']}
     type=stacked
     sort=false
     echartsOptions={{xAxis: {data: ['Monday','Tuesday','Wednesday','Thursday','Friday','Saturday','Sunday']}}}
@@ -915,10 +915,16 @@ order by case period_of_day
     title="Goals per Match by Time of Day"
     xAxisTitle="Time of Day"
     yAxisTitle="Goals / Match"
-    colorPalette={['#fbbf24','#3b82f6','#10b981','#f97316','#6366f1']}
     legend=false
     sort=false
-    echartsOptions={{xAxis: {data: ['Morning', 'Noon', 'Afternoon', 'Evening', 'Night']}}}
+    echartsOptions={{
+      xAxis: {data: ['Morning', 'Noon', 'Afternoon', 'Evening', 'Night']},
+      series: goals_by_slot.map(row => ({
+        itemStyle: {
+          color: ({Morning:'#10b981', Noon:'#f97316', Afternoon:'#fbbf24', Evening:'#3b82f6', Night:'#6366f1'})[row.period_of_day]
+        }
+      }))
+    }}
 />
 
 </div>


### PR DESCRIPTION
## Summary
- Both the stacked bar (Matches by Day) and the bar chart (Goals per Match by Time of Day) now use identical colors per time slot
- Replaced the fragile `colorPalette` approach on the right chart with per-series `itemStyle` overrides keyed by slot name — robust regardless of which slots have data in a given season
- Fixed semantically odd Night=green → **Night=indigo**, warm-to-cool progression now reads naturally

## Color mapping
| Slot | Color |
|---|---|
| Afternoon | #fbbf24 yellow |
| Evening | #3b82f6 blue |
| Night | #6366f1 indigo |
| Noon | #f97316 orange |

## Test plan
- [ ] Both charts show identical colors for each time slot
- [ ] Filtering to different seasons doesn't break color assignment

🤖 Generated with [Claude Code](https://claude.com/claude-code)