### PR TITLE
feat(gold): include only league matches in the gold layer

### DIFF
--- a/dbt/models/gold/dims/dim_match.sql
+++ b/dbt/models/gold/dims/dim_match.sql
@@ -5,7 +5,6 @@
         unique_key='match_id',
         merge_update_columns=['match_round_type', 'match_round_number', 'match_round_name', 'match_type', 'match_name', 'match_short_name', 'match_result', 'kick_off_time', 'match_status'],
         post_hook=[
-            "DELETE FROM {{ this }} WHERE match_id IN (SELECT f.id FROM {{ ref('fixtures') }} f JOIN {{ ref('stages') }} sg ON sg.id = f.stage_id WHERE sg.type_developer_name != 'GROUP_STAGE')",
             "DELETE FROM {{ this }} WHERE match_sk IN (-1, -2)",
             "INSERT INTO {{ this }} SELECT * FROM (VALUES (-1, NULL::INTEGER, 'Unknown Match Round Type', NULL::INTEGER, 'Unknown Match Round Name', 'Unknown Match Type', 'Unknown Match', 'Unknown Match', 'Unknown Match Result', 'Unknown', 'Unknown Match Status'), (-2, NULL::INTEGER, 'Not Applicable Match Round Type', NULL::INTEGER, 'Not Applicable Match Round Name', 'Not Applicable Match Type', 'Not Applicable Match', 'Not Applicable Match', 'Not Applicable Match Result', 'Not Applicable', 'Not Applicable Match Status')) t(match_sk, match_id, match_round_type, match_round_number, match_round_name, match_type, match_name, match_short_name, match_result, kick_off_time, match_status)"
         ]

--- a/dbt/models/gold/dims/dim_match.sql
+++ b/dbt/models/gold/dims/dim_match.sql
@@ -5,6 +5,7 @@
         unique_key='match_id',
         merge_update_columns=['match_round_type', 'match_round_number', 'match_round_name', 'match_type', 'match_name', 'match_short_name', 'match_result', 'kick_off_time', 'match_status'],
         post_hook=[
+            "DELETE FROM {{ this }} WHERE match_id IN (SELECT f.id FROM {{ ref('fixtures') }} f JOIN {{ ref('stages') }} sg ON sg.id = f.stage_id WHERE sg.type_developer_name != 'GROUP_STAGE')",
             "DELETE FROM {{ this }} WHERE match_sk IN (-1, -2)",
             "INSERT INTO {{ this }} SELECT * FROM (VALUES (-1, NULL::INTEGER, 'Unknown Match Round Type', NULL::INTEGER, 'Unknown Match Round Name', 'Unknown Match Type', 'Unknown Match', 'Unknown Match', 'Unknown Match Result', 'Unknown', 'Unknown Match Status'), (-2, NULL::INTEGER, 'Not Applicable Match Round Type', NULL::INTEGER, 'Not Applicable Match Round Name', 'Not Applicable Match Type', 'Not Applicable Match', 'Not Applicable Match', 'Not Applicable Match Result', 'Not Applicable', 'Not Applicable Match Status')) t(match_sk, match_id, match_round_type, match_round_number, match_round_name, match_type, match_name, match_short_name, match_result, kick_off_time, match_status)"
         ]
@@ -72,12 +73,15 @@ src AS (
                                                                                  AS kick_off_time,
         f.state_name                                                             AS match_status
     FROM {{ ref('fixtures') }} f
-    LEFT JOIN {{ ref('stages') }}      sg  ON sg.id          = f.stage_id
+    JOIN {{ ref('stages') }}           sg  ON sg.id          = f.stage_id
     LEFT JOIN regular_season_max       rsm ON rsm.season_id  = f.season_id
     LEFT JOIN participants_pivot       pp  ON pp.fixture_id  = f.id
     LEFT JOIN scores_pivot             sp  ON sp.fixture_id  = f.id
     LEFT JOIN name_map                 nm_h ON nm_h.team_id = pp.home_team_id
     LEFT JOIN name_map                 nm_a ON nm_a.team_id = pp.away_team_id
+    -- League matches only: Regular Season, Championship Round, Relegation Round.
+    -- Excludes KNOCK_OUT stages (European cup play-offs, relegation play-offs).
+    WHERE sg.type_developer_name = 'GROUP_STAGE'
 )
 SELECT
     {% if is_incremental() %}

--- a/dbt/models/gold/fct_match_discussions.sql
+++ b/dbt/models/gold/fct_match_discussions.sql
@@ -1,7 +1,10 @@
 {{ config(
     materialized='incremental',
     incremental_strategy='delete+insert',
-    unique_key=['match_sk', 'persona_sk']
+    unique_key=['match_sk', 'persona_sk'],
+    post_hook=[
+        "DELETE FROM {{ this }} WHERE match_sk > 0 AND match_sk NOT IN (SELECT match_sk FROM {{ ref('dim_match') }})"
+    ]
 ) }}
 
 SELECT

--- a/dbt/models/gold/fct_match_discussions.sql
+++ b/dbt/models/gold/fct_match_discussions.sql
@@ -1,10 +1,7 @@
 {{ config(
     materialized='incremental',
     incremental_strategy='delete+insert',
-    unique_key=['match_sk', 'persona_sk'],
-    post_hook=[
-        "DELETE FROM {{ this }} WHERE match_sk > 0 AND match_sk NOT IN (SELECT match_sk FROM {{ ref('dim_match') }})"
-    ]
+    unique_key=['match_sk', 'persona_sk']
 ) }}
 
 SELECT

--- a/dbt/models/gold/fct_player_appearances.sql
+++ b/dbt/models/gold/fct_player_appearances.sql
@@ -2,10 +2,7 @@
     config(
         materialized='incremental',
         incremental_strategy='delete+insert',
-        unique_key=['match_sk', 'player_sk', 'team_sk'],
-        post_hook=[
-            "DELETE FROM {{ this }} WHERE match_sk > 0 AND match_sk NOT IN (SELECT match_sk FROM {{ ref('dim_match') }})"
-        ]
+        unique_key=['match_sk', 'player_sk', 'team_sk']
     )
 }}
 

--- a/dbt/models/gold/fct_player_appearances.sql
+++ b/dbt/models/gold/fct_player_appearances.sql
@@ -2,18 +2,24 @@
     config(
         materialized='incremental',
         incremental_strategy='delete+insert',
-        unique_key=['match_sk', 'player_sk', 'team_sk']
+        unique_key=['match_sk', 'player_sk', 'team_sk'],
+        post_hook=[
+            "DELETE FROM {{ this }} WHERE match_sk > 0 AND match_sk NOT IN (SELECT match_sk FROM {{ ref('dim_match') }})"
+        ]
     )
 }}
 
 WITH finished_fixtures AS (
     SELECT
-        id        AS fixture_id,
-        league_id,
-        venue_id,
-        starting_at
-    FROM {{ ref('fixtures') }}
-    WHERE state_developer_name IN ('FT', 'FT_PEN', 'AET')
+        f.id        AS fixture_id,
+        f.league_id,
+        f.venue_id,
+        f.starting_at
+    FROM {{ ref('fixtures') }} f
+    JOIN {{ ref('stages') }} sg ON sg.id = f.stage_id
+    WHERE f.state_developer_name IN ('FT', 'FT_PEN', 'AET')
+      -- League matches only: excludes KNOCK_OUT stages (European cup / relegation play-offs)
+      AND sg.type_developer_name = 'GROUP_STAGE'
 ),
 participants AS (
     SELECT fixture_id, team_id, location

--- a/dbt/models/gold/fct_team_matches.sql
+++ b/dbt/models/gold/fct_team_matches.sql
@@ -2,7 +2,10 @@
     config(
         materialized='incremental',
         incremental_strategy='delete+insert',
-        unique_key=['match_sk', 'team_side_sk']
+        unique_key=['match_sk', 'team_side_sk'],
+        post_hook=[
+            "DELETE FROM {{ this }} WHERE match_sk > 0 AND match_sk NOT IN (SELECT match_sk FROM {{ ref('dim_match') }})"
+        ]
     )
 }}
 
@@ -15,7 +18,9 @@ WITH all_fixtures AS (
         sg.type_developer_name AS stage_type,
         f.state_developer_name IN ('FT', 'FT_PEN', 'AET') AS is_finished
     FROM {{ ref('fixtures') }} f
-    LEFT JOIN {{ ref('stages') }} sg ON sg.id = f.stage_id
+    JOIN {{ ref('stages') }} sg ON sg.id = f.stage_id
+    -- League matches only: excludes KNOCK_OUT stages (European cup / relegation play-offs)
+    WHERE sg.type_developer_name = 'GROUP_STAGE'
 ),
 coaches AS (
     SELECT fixture_id, team_id, coach_id

--- a/dbt/models/gold/fct_team_matches.sql
+++ b/dbt/models/gold/fct_team_matches.sql
@@ -2,10 +2,7 @@
     config(
         materialized='incremental',
         incremental_strategy='delete+insert',
-        unique_key=['match_sk', 'team_side_sk'],
-        post_hook=[
-            "DELETE FROM {{ this }} WHERE match_sk > 0 AND match_sk NOT IN (SELECT match_sk FROM {{ ref('dim_match') }})"
-        ]
+        unique_key=['match_sk', 'team_side_sk']
     )
 }}
 


### PR DESCRIPTION
## Summary
The gold layer should contain **only Superliga league matches**. Knockout play-off fixtures (Europa League play-offs, Conference League play-offs, Relegation play-offs) are now excluded.

The split is clean in the source data: league stages (Regular Season, Championship Round, Relegation Round) are all `type_developer_name = 'GROUP_STAGE'`, while everything to exclude is `KNOCK_OUT` — 33 fixtures across all seasons.

## Changes
- **dim_match / fct_team_matches / fct_player_appearances**: join `stages` and keep only `type_developer_name = 'GROUP_STAGE'` fixtures.
- **fct_match_discussions**: unchanged — it inner-joins `dim_match`, so it follows automatically.

Already-materialized knockout rows will be removed by a **full refresh of the gold layer** after merge (tables are incremental, so the filter alone doesn't purge existing rows).

No dashboard changes needed — all marts already filter `m.match_type = 'Group Stage'`, so those filters simply become no-ops.

## Verification (MotherDuck `superligaen_dev`)
- `dbt run` + `dbt test` on the three models: 37 pass, 1 pre-existing warn (`assert_ht_goals_leq_ft_goals`, 6 league-match rows — unaffected by this change).
- After cleanup: 0 knockout rows in `dim_match`, 0 orphaned fact rows; `fct_team_matches` = 6568 = 3284 league matches × 2 sides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)