### PR TITLE
chore(dashboards): drop redundant Group Stage filters from mart sources

### DIFF
--- a/dashboards/sources/superligaen/home/mart_home_summary.sql
+++ b/dashboards/sources/superligaen/home/mart_home_summary.sql
@@ -21,8 +21,7 @@ WITH matches AS (
     JOIN superligaen.gold.dim_match          m  ON m.match_sk        = f.match_sk
     JOIN superligaen.gold.dim_team           t  ON t.team_sk         = f.team_sk
     JOIN superligaen.gold.dim_match_result   r  ON r.match_result_sk = f.match_result_sk
-    WHERE m.match_type = 'Group Stage'
-      AND r.match_result IN ('Win', 'Draw', 'Loss')
+    WHERE r.match_result IN ('Win', 'Draw', 'Loss')
 ),
 latest_season AS (
     SELECT MAX(season) AS season FROM matches

--- a/dashboards/sources/superligaen/league-analytics/mart_match_facts.sql
+++ b/dashboards/sources/superligaen/league-analytics/mart_match_facts.sql
@@ -185,5 +185,4 @@ JOIN superligaen.gold.dim_formation      df  ON df.formation_sk     = f.formatio
 JOIN superligaen.gold.dim_time           dt  ON dt.time_sk          = f.time_sk
 LEFT JOIN player_agg                     pa  ON pa.match_sk         = f.match_sk
                                            AND pa.team_sk           = f.team_sk
-WHERE m.match_type = 'Group Stage'
-  AND d.season >= '2020/21'
+WHERE d.season >= '2020/21'

--- a/dashboards/sources/superligaen/league-analytics/mart_player_facts.sql
+++ b/dashboards/sources/superligaen/league-analytics/mart_player_facts.sql
@@ -126,5 +126,4 @@ JOIN superligaen.gold.dim_formation           df     ON df.formation_sk         
 JOIN superligaen.gold.dim_position            dpos   ON dpos.position_sk          = f.position_sk
 JOIN superligaen.gold.dim_coach               dc     ON dc.coach_sk               = f.coach_sk
 JOIN superligaen.gold.dim_time                dt     ON dt.time_sk                = f.time_sk
-WHERE m.match_type = 'Group Stage'
-  AND d.season >= '2020/21'
+WHERE d.season >= '2020/21'

--- a/dashboards/sources/superligaen/match-results/mart_match_results.sql
+++ b/dashboards/sources/superligaen/match-results/mart_match_results.sql
@@ -61,8 +61,7 @@ base AS (
     JOIN superligaen.gold.dim_referee        ref ON ref.referee_sk    = f.referee_sk
     LEFT JOIN player_agg                     pa  ON pa.match_sk       = f.match_sk
                                                AND pa.team_sk         = f.team_sk
-    WHERE m.match_type = 'Group Stage'
-      AND d.season >= '2020/21'
+    WHERE d.season >= '2020/21'
       AND r.match_result IN ('Win', 'Draw', 'Loss')
 )
 SELECT

--- a/dashboards/sources/superligaen/match-results/mart_round_potw.sql
+++ b/dashboards/sources/superligaen/match-results/mart_round_potw.sql
@@ -17,8 +17,7 @@ WITH base AS (
     JOIN superligaen.gold.dim_match_result         r      ON r.match_result_sk       = f.match_result_sk
     JOIN superligaen.gold.dim_appearance_type      at_dim ON at_dim.appearance_type_sk = f.appearance_type_sk
     JOIN superligaen.gold.dim_position             dpos   ON dpos.position_sk        = f.position_sk
-    WHERE m.match_type = 'Group Stage'
-      AND d.season >= '2020/21'
+    WHERE d.season >= '2020/21'
       AND r.match_result IN ('Win', 'Draw', 'Loss')
       AND f.rating IS NOT NULL
       AND f.minutes_played >= 30

--- a/dashboards/sources/superligaen/player-analytics/mart_player_season.sql
+++ b/dashboards/sources/superligaen/player-analytics/mart_player_season.sql
@@ -84,8 +84,7 @@ WITH base AS (
     JOIN superligaen.gold.dim_match_result         r      ON r.match_result_sk       = f.match_result_sk
     JOIN superligaen.gold.dim_appearance_type      at_dim ON at_dim.appearance_type_sk = f.appearance_type_sk
     JOIN superligaen.gold.dim_position             dpos   ON dpos.position_sk        = f.position_sk
-    WHERE m.match_type = 'Group Stage'
-      AND d.season >= '2020/21'
+    WHERE d.season >= '2020/21'
       AND r.match_result IN ('Win', 'Draw', 'Loss')
     GROUP BY
         d.season,

--- a/dashboards/sources/superligaen/referee-analytics/mart_referee_season.sql
+++ b/dashboards/sources/superligaen/referee-analytics/mart_referee_season.sql
@@ -28,8 +28,7 @@ JOIN superligaen.gold.dim_referee         ref ON ref.referee_sk    = f.referee_s
 JOIN superligaen.gold.dim_team_side       ts  ON ts.team_side_sk   = f.team_side_sk
 LEFT JOIN fouls_agg                       fa  ON fa.match_sk       = f.match_sk
                                             AND fa.team_sk         = f.team_sk
-WHERE m.match_type = 'Group Stage'
-  AND d.season >= '2020/21'
+WHERE d.season >= '2020/21'
   AND r.match_result IN ('Win', 'Draw', 'Loss')
 GROUP BY d.season, ref.referee_common_name
 ORDER BY d.season DESC, matches_managed DESC

--- a/dashboards/sources/superligaen/shared/mart_match_card.sql
+++ b/dashboards/sources/superligaen/shared/mart_match_card.sql
@@ -57,8 +57,7 @@ base AS (
     JOIN superligaen.gold.dim_referee        ref ON ref.referee_sk  = f.referee_sk
     LEFT JOIN player_agg                     pa  ON pa.match_sk     = f.match_sk
                                                AND pa.team_sk       = f.team_sk
-    WHERE m.match_type = 'Group Stage'
-      AND d.season >= '2020/21'
+    WHERE d.season >= '2020/21'
 )
 SELECT
     match_id,

--- a/dashboards/sources/superligaen/shared/mart_match_lineup.sql
+++ b/dashboards/sources/superligaen/shared/mart_match_lineup.sql
@@ -86,6 +86,5 @@ JOIN superligaen.gold.dim_team_side            ts     ON ts.team_side_sk        
 JOIN superligaen.gold.dim_appearance_type      at_dim ON at_dim.appearance_type_sk = f.appearance_type_sk
 JOIN superligaen.gold.dim_formation            df     ON df.formation_sk         = f.formation_sk
 JOIN superligaen.gold.dim_position             dpos   ON dpos.position_sk        = f.position_sk
-WHERE m.match_type = 'Group Stage'
-  AND d.season >= '2020/21'
+WHERE d.season >= '2020/21'
   AND at_dim.appearance_type IN ('Starter', 'Substitute')

--- a/dashboards/sources/superligaen/shared/mart_team_match.sql
+++ b/dashboards/sources/superligaen/shared/mart_team_match.sql
@@ -55,7 +55,6 @@ per_match AS (
     JOIN superligaen.gold.dim_time            dt  ON dt.time_sk          = f.time_sk
     LEFT JOIN player_agg                      pa  ON pa.match_sk         = f.match_sk
                                                AND pa.team_sk            = f.team_sk
-    WHERE m.match_type = 'Group Stage'
-      AND d.season >= '2020/21'
+    WHERE d.season >= '2020/21'
 )
 SELECT * FROM per_match

--- a/dashboards/sources/superligaen/stadium-analytics/mart_stadium_season.sql
+++ b/dashboards/sources/superligaen/stadium-analytics/mart_stadium_season.sql
@@ -69,8 +69,7 @@ LEFT JOIN (
     FROM superligaen.gold.fct_player_appearances GROUP BY match_sk, team_sk
 )                                         fouls ON fouls.match_sk  = f.match_sk
                                                AND fouls.team_sk   = f.team_sk
-WHERE m.match_type = 'Group Stage'
-  AND d.season >= '2020/21'
+WHERE d.season >= '2020/21'
   AND r.match_result IN ('Win', 'Draw', 'Loss')
   AND st.stadium_latitude  BETWEEN 54.5 AND 57.8
   AND st.stadium_longitude BETWEEN 7.5  AND 15.5

--- a/dashboards/sources/superligaen/stadium-analytics/mart_surface_season.sql
+++ b/dashboards/sources/superligaen/stadium-analytics/mart_surface_season.sql
@@ -45,8 +45,7 @@ LEFT JOIN player_agg                     pa  ON pa.match_sk       = f.match_sk
                                            AND pa.team_sk         = f.team_sk
 LEFT JOIN fouls_agg                      fouls ON fouls.match_sk  = f.match_sk
                                                AND fouls.team_sk  = f.team_sk
-WHERE m.match_type = 'Group Stage'
-  AND d.season >= '2020/21'
+WHERE d.season >= '2020/21'
   AND r.match_result IN ('Win', 'Draw', 'Loss')
   AND st.stadium_surface IS NOT NULL AND st.stadium_surface != ''
   AND st.stadium_latitude  BETWEEN 54.5 AND 57.8

--- a/dashboards/sources/superligaen/standings/mart_standings.sql
+++ b/dashboards/sources/superligaen/standings/mart_standings.sql
@@ -23,5 +23,4 @@ JOIN superligaen.gold.dim_date           d  ON d.date_sk         = f.date_sk
 JOIN superligaen.gold.dim_match          m  ON m.match_sk        = f.match_sk
 JOIN superligaen.gold.dim_team           t  ON t.team_sk         = f.team_sk
 JOIN superligaen.gold.dim_match_result   r  ON r.match_result_sk = f.match_result_sk
-WHERE m.match_type = 'Group Stage'
-  AND d.season >= '2020/21'
+WHERE d.season >= '2020/21'

--- a/dashboards/sources/superligaen/team-analytics/mart_team_season.sql
+++ b/dashboards/sources/superligaen/team-analytics/mart_team_season.sql
@@ -48,8 +48,7 @@ per_match AS (
     JOIN superligaen.gold.dim_coach           dc  ON dc.coach_sk       = f.coach_sk
     LEFT JOIN player_agg                      pa  ON pa.match_sk       = f.match_sk
                                                AND pa.team_sk          = f.team_sk
-    WHERE m.match_type = 'Group Stage'
-      AND d.season >= '2020/21'
+    WHERE d.season >= '2020/21'
 ),
 season_agg AS (
     SELECT

--- a/dashboards/sources/superligaen/upcoming-matches/mart_upcoming.sql
+++ b/dashboards/sources/superligaen/upcoming-matches/mart_upcoming.sql
@@ -23,8 +23,7 @@ WITH base AS (
     JOIN superligaen.gold.dim_match_result  r   ON r.match_result_sk  = f.match_result_sk
     JOIN superligaen.gold.dim_stadium       st  ON st.stadium_sk      = f.stadium_sk
     JOIN superligaen.gold.dim_referee       ref ON ref.referee_sk     = f.referee_sk
-    WHERE m.match_type = 'Group Stage'
-      AND r.match_result = 'Pending'
+    WHERE r.match_result = 'Pending'
     GROUP BY m.match_id, d.date, d.season, m.match_round_number, m.match_round_name,
              m.kick_off_time, st.stadium_name, ref.referee_common_name
 )


### PR DESCRIPTION
## Summary
Follow-up to #338: now that the gold layer contains only league matches, the `m.match_type = 'Group Stage'` predicates in the Evidence mart sources are no-ops. This removes them from all 15 mart queries.

`llm_round_discussions.sql` still selects the `match_type` column (not a filter), so it is untouched.

## Verification
Ran every modified query against prod (`superligaen.gold`) and compared row counts with the pre-change version from `main`: **all 15 identical** (e.g. `mart_standings` 2304, `mart_match_lineup` 35440, `mart_player_facts` 35440).

🤖 Generated with [Claude Code](https://claude.com/claude-code)