### PR TITLE
fix(dashboard): filter Team Rankings by team selection, sort conceded chart best-first

### DIFF
--- a/dashboards/pages/league-analytics.md
+++ b/dashboards/pages/league-analytics.md
@@ -259,8 +259,10 @@ select
     sum(case when result = 'Win' then 1 else 0 end)::double / count(distinct match_id)             as win_pct
 from superligaen.mart_match_facts
 where season = '${inputs.season.value}'
+  and ('All Teams' in ${inputs.team.value} OR team_name in ${inputs.team.value})
   and result in ('Win', 'Draw', 'Loss')
 group by team_name
+order by conceded_pm asc
 ```
 
 ```sql radar_data
@@ -390,6 +392,7 @@ select distinct
     goals_scored
 from superligaen.mart_match_facts
 where season = '${inputs.season.value}'
+  and ('All Teams' in ${inputs.team.value} OR team_name in ${inputs.team.value})
   and result in ('Win', 'Draw', 'Loss')
 order by match_date desc, team_name
 ```
@@ -802,7 +805,7 @@ order by case period_of_day
 
 ## Team Rankings by Domain
 
-<p style="font-size:0.75rem;color:#6b7280;margin:0 0 1rem 0;font-style:italic;">All teams ranked within each performance dimension. Sorted highest to lowest so the best and worst performers are immediately visible.</p>
+<p style="font-size:0.75rem;color:#6b7280;margin:0 0 1rem 0;font-style:italic;">All teams ranked within each performance dimension. Sorted best to worst so the strongest performers are always at the top — for goals conceded that means the tightest defence leads.</p>
 
 <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-6">
 
@@ -852,7 +855,7 @@ order by case period_of_day
     yAxisTitle="Goals Conceded / Match"
     colorPalette={['#f97316']}
     swapXY=true
-    sort=true
+    sort=false
 />
 
 </div>


### PR DESCRIPTION
## Summary
Fixes #337.

1. **Team Rankings by Domain now respond to the team dropdown.** The `team_domain_stats` query was missing the `('All Teams' in ${inputs.team.value} OR team_name in ${inputs.team.value})` predicate that every other query on the League page has.
2. **Match Log too.** Auditing the page for the same root cause showed `match_log` also ignored the team filter (the page intro explicitly promises the match log updates with the selection) — same fix applied. `team_landscape_bounds` is the only other unfiltered query and stays that way intentionally: it pins the scatter axes so they don't rescale.
3. **Goals Conceded chart now ranks best defence on top.** `team_domain_stats` orders by `conceded_pm asc` and the chart uses `sort=false` (Evidence preserves query order and renders the first row at the top for horizontal bars). The other five domain charts keep `sort=true` (descending), so they are unaffected by the query ordering.
4. Updated the section description to match the new sorting.

## Verification
- `npm run sources` + `npm run build:strict` both pass (strict mode fails on query errors).
- Sort behavior confirmed from Evidence component source: `sort=true` → descending by value; `sort=false` → query order preserved; `swapXY` sets `inverse: true` on the category axis so row 1 renders at top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)