### PR TITLE
chore(ingestion): extend incremental fixtures window to +60 days

### DIFF
--- a/ingestion/sportmonks/config.py
+++ b/ingestion/sportmonks/config.py
@@ -13,7 +13,7 @@ API_CALL_DELAY    = 0.3  # seconds between every API request; rate limit is per 
                          # (~3000/hour per entity), so 0.3s is well within budget.
                          # Retry/backoff in api.py handles any 429s gracefully.
 INCREMENTAL_DAYS_BACK    = int(os.environ.get("INCREMENTAL_DAYS_BACK", 7))
-INCREMENTAL_DAYS_FORWARD = 30
+INCREMENTAL_DAYS_FORWARD = 60
 
 _PROJECT_ROOT   = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
 DEFAULT_DB_PATH = os.path.join(_PROJECT_ROOT, "superligaen_dev.duckdb")

--- a/ingestion/sportmonks/engine.py
+++ b/ingestion/sportmonks/engine.py
@@ -16,7 +16,7 @@ The only behavioural difference between modes is scope for seasonal / date entri
   full        → seasonal entries cover ALL in-scope seasons;
                 date_based iterates 90-day chunks across every season's range
   incremental → seasonal entries cover CURRENT season only;
-                date_based uses a rolling ±3 / +30 day window around today
+                date_based uses a rolling -7 / +60 day window around today
 
 Strategy handlers
 -----------------
@@ -406,7 +406,7 @@ def run(conn, mode: str = "incremental", tables: set = None) -> None:
     mode "full"        — all seasons iterated for seasonal tables;
                          full season-range chunks for fixtures
     mode "incremental" — current season only for seasonal tables;
-                         rolling ±3 / +30 day window for fixtures
+                         rolling -7 / +60 day window for fixtures
     tables             — optional set of table names to restrict the run to;
                          if None, all manifest entries for the given mode are run
     """

--- a/ingestion/sportmonks/run.py
+++ b/ingestion/sportmonks/run.py
@@ -24,7 +24,7 @@ each table's delete strategy in ENDPOINT_MANIFEST:
   incremental   Daily refresh (default).
                   global tables   → full truncate + reload  (same as full)
                   seasonal tables → current season only deleted + reloaded
-                  fixtures        → rolling window: last 3 days + next 30 days
+                  fixtures        → rolling window: last 7 days + next 60 days
 
 The entire pipeline is driven by ENDPOINT_MANIFEST in config.py.
 To add, remove, or adjust an endpoint — edit the manifest, not this file.


### PR DESCRIPTION
## What

Widen the forward-looking rolling window for `date_based` fixtures from **+30 → +60 days** (`INCREMENTAL_DAYS_FORWARD` in `ingestion/sportmonks/config.py`), so more upcoming matches are pre-loaded on each incremental run.

## Why

Pre-loads the next two months of scheduled fixtures instead of one, giving the dashboard a longer forward horizon. The change is effectively free: +60 still fits inside a single 90-day API chunk, so it stays **one API call per run**, and the `delete+insert` window keeps it idempotent. No MotherDuck burden beyond a slightly wider date range.

## Also

Corrected stale docstrings in `engine.py` / `run.py` that described the window as "±3 / +30" — the back-window has actually been 7 days, so they now read "-7 / +60".

🤖 Generated with [Claude Code](https://claude.com/claude-code)