### PR TITLE
fix(dashboards): exclude empty seasons from season-scoped marts

### DIFF
--- a/dashboards/sources/superligaen/league-analytics/mart_match_facts.sql
+++ b/dashboards/sources/superligaen/league-analytics/mart_match_facts.sql
@@ -186,3 +186,4 @@ JOIN superligaen.gold.dim_time           dt  ON dt.time_sk          = f.time_sk
 LEFT JOIN player_agg                     pa  ON pa.match_sk         = f.match_sk
                                            AND pa.team_sk           = f.team_sk
 WHERE d.season >= '2020/21'
+  AND r.match_result IN ('Win', 'Draw', 'Loss')

--- a/dashboards/sources/superligaen/league-analytics/mart_player_facts.sql
+++ b/dashboards/sources/superligaen/league-analytics/mart_player_facts.sql
@@ -127,3 +127,4 @@ JOIN superligaen.gold.dim_position            dpos   ON dpos.position_sk        
 JOIN superligaen.gold.dim_coach               dc     ON dc.coach_sk               = f.coach_sk
 JOIN superligaen.gold.dim_time                dt     ON dt.time_sk                = f.time_sk
 WHERE d.season >= '2020/21'
+  AND r.match_result IN ('Win', 'Draw', 'Loss')

--- a/dashboards/sources/superligaen/shared/mart_team_match.sql
+++ b/dashboards/sources/superligaen/shared/mart_team_match.sql
@@ -56,5 +56,6 @@ per_match AS (
     LEFT JOIN player_agg                      pa  ON pa.match_sk         = f.match_sk
                                                AND pa.team_sk            = f.team_sk
     WHERE d.season >= '2020/21'
+      AND r.match_result IN ('Win', 'Draw', 'Loss')
 )
 SELECT * FROM per_match

--- a/dashboards/sources/superligaen/standings/mart_standings.sql
+++ b/dashboards/sources/superligaen/standings/mart_standings.sql
@@ -24,3 +24,4 @@ JOIN superligaen.gold.dim_match          m  ON m.match_sk        = f.match_sk
 JOIN superligaen.gold.dim_team           t  ON t.team_sk         = f.team_sk
 JOIN superligaen.gold.dim_match_result   r  ON r.match_result_sk = f.match_result_sk
 WHERE d.season >= '2020/21'
+  AND r.match_result IN ('Win', 'Draw', 'Loss')

--- a/dashboards/sources/superligaen/team-analytics/mart_team_season.sql
+++ b/dashboards/sources/superligaen/team-analytics/mart_team_season.sql
@@ -49,6 +49,7 @@ per_match AS (
     LEFT JOIN player_agg                      pa  ON pa.match_sk       = f.match_sk
                                                AND pa.team_sk          = f.team_sk
     WHERE d.season >= '2020/21'
+      AND r.match_result IN ('Win', 'Draw', 'Loss')
 ),
 season_agg AS (
     SELECT


### PR DESCRIPTION
## Problem

Every season dropdown is built from `SELECT DISTINCT season FROM <its mart>`, so a season shows up whenever its mart has any rows. The upcoming season has only scheduled fixtures (`match_result = 'Pending'`, zero completed), and standings / team / league pages were surfacing it as an **empty season with no data**.

`mart_match_results` already avoided this by applying a base filter `AND match_result IN ('Win','Draw','Loss')`, so pending-only seasons produce no rows. The other season-scoped marts only filtered `season >= '2020/21'`.

## Fix

Add the same base filter to the five marts that lacked it:

- `mart_standings`
- `mart_team_match`
- `mart_team_season`
- `mart_match_facts`
- `mart_player_facts`

A season now reappears automatically once it records its first completed match. `mart_upcoming` is intentionally left unfiltered (it should show scheduled fixtures), and the per-match `match_card`/`match_lineup` marts are unaffected (no season selector).

## Verification

Rebuilt sources against dev: standings/team/league/match-results now top out at the latest season **with** completed matches; `mart_standings` and `mart_team_match` each dropped exactly the pending team-match rows, `mart_team_season` dropped the 12 empty team rows, and `mart_upcoming` still shows its scheduled fixtures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)