### PR TITLE
feat(dashboards): redesign Upcoming Fixtures as matchday cards + match preview page

### DIFF
--- a/dashboards/pages/upcoming-match-analysis.md
+++ b/dashboards/pages/upcoming-match-analysis.md
@@ -113,7 +113,7 @@ limit 5
 {#if match_info.length > 0}
 
 <div class="rounded-2xl border border-gray-200 bg-gray-50 p-4 md:p-6 mb-6 text-center">
-  <div class="text-xs text-gray-400 uppercase tracking-widest mb-3">{match_info[0].round} &middot; {match_info[0].match_date} &middot; {match_info[0].kick_off_time} &middot; {match_info[0].stadium}</div>
+  <div class="text-xs text-gray-400 uppercase tracking-widest mb-3">{match_info[0].round} &middot; {match_info[0].match_date}</div>
   <div class="flex items-center justify-center gap-4 md:gap-6">
     <div class="flex-1 min-w-0 flex flex-col items-center">
       <img src={match_info[0].home_team_logo} alt="" class="h-12 w-12 md:h-16 md:w-16 object-contain mb-2" onerror="this.style.display='none'" />
@@ -127,6 +127,7 @@ limit 5
       <div class="text-xs text-red-400 font-semibold uppercase tracking-widest mt-1">Away</div>
     </div>
   </div>
+  <div class="text-xs text-gray-400 uppercase tracking-widest mt-3">{match_info[0].stadium} &middot; {match_info[0].kick_off_time}</div>
 </div>
 
 ---

--- a/dashboards/pages/upcoming-match-analysis.md
+++ b/dashboards/pages/upcoming-match-analysis.md
@@ -51,7 +51,18 @@ select
     mc.season,
     mc.match_date,
     mc.match_round_name                                                     as round,
+    cast(mc.match_round_number as int)                                      as round_no,
     mc.home_team_short || ' - ' || mc.away_team_short                       as match,
+    case
+        when mc.home_goals = mc.away_goals then '<span style="color:#9ca3af;font-weight:600;">Draw</span>'
+        when (case when mc.home_goals > mc.away_goals then mc.home_team else mc.away_team end) = mi.home_team
+            then '<span style="color:#2563eb;font-weight:600;">'
+                 || (case when mc.home_goals > mc.away_goals then mc.home_team_short else mc.away_team_short end)
+                 || '</span>'
+        else '<span style="color:#ef4444;font-weight:600;">'
+             || (case when mc.home_goals > mc.away_goals then mc.home_team_short else mc.away_team_short end)
+             || '</span>'
+    end                                                                     as winner,
     mc.score,
     (mc.home_goals + mc.away_goals)::int                                    as total_goals,
     (mc.home_sog   + mc.away_sog)::int                                      as total_shots_on_goal,
@@ -155,20 +166,22 @@ limit 5
 
 <div class="block md:hidden">
 <DataTable data={h2h} rows=20>
-    <Column id=match_date          title="Date"        />
+    <Column id=season              title="Season"      />
+    <Column id=round_no            title="Round"       align=center />
     <Column id=match               title="Match"       />
+    <Column id=winner              title="Winner"      contentType=html />
     <Column id=score               title="Score"       align=center />
     <Column id=total_goals         title="Goals"       contentType=colorscale colorPalette={['white','#22c55e']} align=center />
-    <Column id=total_big_chances   title="Big Ch."     contentType=colorscale colorPalette={['white','#f59e0b']} align=center />
+    <Column id=total_big_chances   title="Big Chances" contentType=colorscale colorPalette={['white','#f59e0b']} align=center />
     <Column id=total_shots_on_goal title="SoG"         contentType=bar colorPalette={['#6366f1']} />
 </DataTable>
 </div>
 <div class="hidden md:block">
 <DataTable data={h2h} rows=20>
     <Column id=season              title="Season"      />
-    <Column id=match_date          title="Date"        />
     <Column id=round               title="Round"       />
     <Column id=match               title="Match"       />
+    <Column id=winner              title="Winner"      contentType=html />
     <Column id=score               title="Score"       align=center />
     <Column id=total_goals         title="Goals"       contentType=colorscale colorPalette={['white','#22c55e']} align=center />
     <Column id=total_big_chances   title="Big Chances" contentType=colorscale colorPalette={['white','#f59e0b']} align=center />

--- a/dashboards/pages/upcoming-match-analysis.md
+++ b/dashboards/pages/upcoming-match-analysis.md
@@ -61,6 +61,7 @@ join ${match_info} mi
     on (mc.home_team = mi.home_team and mc.away_team = mi.away_team)
     or (mc.home_team = mi.away_team  and mc.away_team = mi.home_team)
 where mc.season in ${inputs.h2h_season.value}
+  and mc.home_goals is not null
 order by mc.match_date desc
 ```
 
@@ -76,6 +77,7 @@ join ${match_info} mi
     on (mc.home_team = mi.home_team and mc.away_team = mi.away_team)
     or (mc.home_team = mi.away_team  and mc.away_team = mi.home_team)
 where mc.season in ${inputs.h2h_season.value}
+  and mc.home_goals is not null
 ```
 
 ```sql home_form
@@ -136,13 +138,13 @@ limit 5
 <Dropdown data={h2h_seasons} name=h2h_season value=season label=season multiple=true selectAllByDefault=true order="season desc" />
 
 <div class="grid grid-cols-3 gap-4 mb-6">
-  <div class="rounded-xl border border-blue-200 bg-blue-50 p-4 text-center">
-    <div class="text-3xl font-black text-blue-600">{h2h_stats[0].team1_wins}</div>
-    <div class="text-xs text-blue-400 mt-1 font-semibold uppercase tracking-wide">{match_info[0].home_team_short} Wins</div>
+  <div class="rounded-xl border border-green-200 bg-green-50 p-4 text-center">
+    <div class="text-3xl font-black text-green-600">{h2h_stats[0].team1_wins}</div>
+    <div class="text-xs text-green-500 mt-1 font-semibold uppercase tracking-wide">{match_info[0].home_team_short} Wins</div>
   </div>
-  <div class="rounded-xl border border-gray-200 bg-gray-100 p-4 text-center">
-    <div class="text-3xl font-black text-gray-500">{h2h_stats[0].draws}</div>
-    <div class="text-xs text-gray-400 mt-1 font-semibold uppercase tracking-wide">Draws</div>
+  <div class="rounded-xl border border-yellow-200 bg-yellow-50 p-4 text-center">
+    <div class="text-3xl font-black text-yellow-500">{h2h_stats[0].draws}</div>
+    <div class="text-xs text-yellow-600 mt-1 font-semibold uppercase tracking-wide">Draws</div>
   </div>
   <div class="rounded-xl border border-red-200 bg-red-50 p-4 text-center">
     <div class="text-3xl font-black text-red-500">{h2h_stats[0].team2_wins}</div>

--- a/dashboards/pages/upcoming-match-analysis.md
+++ b/dashboards/pages/upcoming-match-analysis.md
@@ -139,13 +139,13 @@ limit 5
 <Dropdown data={h2h_seasons} name=h2h_season value=season label=season multiple=true selectAllByDefault=true order="season desc" />
 
 <div class="grid grid-cols-3 gap-4 mb-6">
-  <div class="rounded-xl border border-green-200 bg-green-50 p-4 text-center">
-    <div class="text-3xl font-black text-green-600">{h2h_stats[0].team1_wins}</div>
-    <div class="text-xs text-green-500 mt-1 font-semibold uppercase tracking-wide">{match_info[0].home_team_short} Wins</div>
+  <div class="rounded-xl border border-blue-200 bg-blue-50 p-4 text-center">
+    <div class="text-3xl font-black text-blue-600">{h2h_stats[0].team1_wins}</div>
+    <div class="text-xs text-blue-400 mt-1 font-semibold uppercase tracking-wide">{match_info[0].home_team_short} Wins</div>
   </div>
-  <div class="rounded-xl border border-yellow-200 bg-yellow-50 p-4 text-center">
-    <div class="text-3xl font-black text-yellow-500">{h2h_stats[0].draws}</div>
-    <div class="text-xs text-yellow-600 mt-1 font-semibold uppercase tracking-wide">Draws</div>
+  <div class="rounded-xl border border-gray-200 bg-gray-100 p-4 text-center">
+    <div class="text-3xl font-black text-gray-500">{h2h_stats[0].draws}</div>
+    <div class="text-xs text-gray-400 mt-1 font-semibold uppercase tracking-wide">Draws</div>
   </div>
   <div class="rounded-xl border border-red-200 bg-red-50 p-4 text-center">
     <div class="text-3xl font-black text-red-500">{h2h_stats[0].team2_wins}</div>

--- a/dashboards/pages/upcoming-match-analysis.md
+++ b/dashboards/pages/upcoming-match-analysis.md
@@ -101,6 +101,7 @@ select
 from superligaen.mart_team_match tm
 join ${match_info} mi on tm.team_name = mi.home_team
 where tm.result in ('Win', 'Draw', 'Loss')
+  and tm.match_date >= current_date - interval '6 months'
 order by tm.match_date desc
 limit 5
 ```
@@ -115,6 +116,7 @@ select
 from superligaen.mart_team_match tm
 join ${match_info} mi on tm.team_name = mi.away_team
 where tm.result in ('Win', 'Draw', 'Loss')
+  and tm.match_date >= current_date - interval '6 months'
 order by tm.match_date desc
 limit 5
 ```
@@ -191,9 +193,9 @@ limit 5
 
 ---
 
-### Form Guide — Last 5 Matches
+### Form Guide
 
-<p style="font-size:0.75rem;color:#6b7280;margin:0 0 1rem 0;font-style:italic;">Most recent five results for each side across all competitions in the current season.</p>
+<p style="font-size:0.75rem;color:#6b7280;margin:0 0 1rem 0;font-style:italic;">Most recent results for each side from the last 6 months.</p>
 
 <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
 
@@ -215,6 +217,8 @@ limit 5
           {/if}
         </div>
       </div>
+    {:else}
+      <div class="text-sm text-gray-400 py-2">Form guide not available</div>
     {/each}
   </div>
 </div>
@@ -237,6 +241,8 @@ limit 5
           {/if}
         </div>
       </div>
+    {:else}
+      <div class="text-sm text-gray-400 py-2">Form guide not available</div>
     {/each}
   </div>
 </div>

--- a/dashboards/pages/upcoming-match-analysis.md
+++ b/dashboards/pages/upcoming-match-analysis.md
@@ -1,0 +1,236 @@
+---
+sidebar: never
+hide_toc: true
+title: Match Preview
+---
+
+<script>
+  import { getInputContext } from '@evidence-dev/sdk/utils/svelte';
+
+  const pageInputs = getInputContext();
+
+  onMount(() => {
+    const sp = new URLSearchParams(window.location.search);
+    const m = sp.get('match');
+    if (!m) return;
+    pageInputs.update(($i) => ({
+      ...$i,
+      match: { value: m, label: m, rawValues: [{ value: m, label: m, selected: true }] }
+    }));
+  });
+</script>
+
+```sql match_info
+select
+    home_team,
+    away_team,
+    home_team_short,
+    away_team_short,
+    home_team_logo,
+    away_team_logo,
+    strftime(match_date, '%Y-%m-%d')  as match_date,
+    round,
+    kick_off_time,
+    stadium
+from superligaen.mart_upcoming
+where match_id = cast('${inputs.match.value}' as bigint)
+limit 1
+```
+
+```sql h2h_seasons
+select distinct mc.season
+from superligaen.mart_match_card mc
+join ${match_info} mi
+    on (mc.home_team = mi.home_team and mc.away_team = mi.away_team)
+    or (mc.home_team = mi.away_team  and mc.away_team = mi.home_team)
+order by mc.season desc
+```
+
+```sql h2h
+select
+    mc.season,
+    mc.match_date,
+    mc.match_round_name                                                     as round,
+    mc.home_team_short || ' - ' || mc.away_team_short                       as match,
+    mc.score,
+    (mc.home_goals + mc.away_goals)::int                                    as total_goals,
+    (mc.home_sog   + mc.away_sog)::int                                      as total_shots_on_goal,
+    (mc.home_big_chances + mc.away_big_chances)::int                        as total_big_chances
+from superligaen.mart_match_card mc
+join ${match_info} mi
+    on (mc.home_team = mi.home_team and mc.away_team = mi.away_team)
+    or (mc.home_team = mi.away_team  and mc.away_team = mi.home_team)
+where mc.season in ${inputs.h2h_season.value}
+order by mc.match_date desc
+```
+
+```sql h2h_stats
+select
+    sum(case when (mc.home_team = mi.home_team and mc.home_goals > mc.away_goals)
+              or  (mc.away_team = mi.home_team and mc.away_goals > mc.home_goals) then 1 else 0 end)  as team1_wins,
+    sum(case when mc.home_goals = mc.away_goals then 1 else 0 end)                                    as draws,
+    sum(case when (mc.home_team = mi.away_team  and mc.home_goals > mc.away_goals)
+              or  (mc.away_team = mi.away_team  and mc.away_goals > mc.home_goals) then 1 else 0 end) as team2_wins
+from superligaen.mart_match_card mc
+join ${match_info} mi
+    on (mc.home_team = mi.home_team and mc.away_team = mi.away_team)
+    or (mc.home_team = mi.away_team  and mc.away_team = mi.home_team)
+where mc.season in ${inputs.h2h_season.value}
+```
+
+```sql home_form
+select
+    strftime(tm.match_date, '%d %b')    as match_date,
+    tm.opponent_team_short_name         as opponent,
+    tm.goals_scored                     as gf,
+    tm.goals_conceded                   as ga,
+    tm.result
+from superligaen.mart_team_match tm
+join ${match_info} mi on tm.team_name = mi.home_team
+where tm.result in ('Win', 'Draw', 'Loss')
+order by tm.match_date desc
+limit 5
+```
+
+```sql away_form
+select
+    strftime(tm.match_date, '%d %b')    as match_date,
+    tm.opponent_team_short_name         as opponent,
+    tm.goals_scored                     as gf,
+    tm.goals_conceded                   as ga,
+    tm.result
+from superligaen.mart_team_match tm
+join ${match_info} mi on tm.team_name = mi.away_team
+where tm.result in ('Win', 'Draw', 'Loss')
+order by tm.match_date desc
+limit 5
+```
+
+<a href="/upcoming-matches" style="display:inline-flex;align-items:center;gap:6px;font-size:0.8125rem;font-weight:600;color:#6b7280;text-decoration:none;margin-bottom:16px;">← Upcoming Fixtures</a>
+
+{#if match_info.length > 0}
+
+<div class="rounded-2xl border border-gray-200 bg-gray-50 p-4 md:p-6 mb-6 text-center">
+  <div class="text-xs text-gray-400 uppercase tracking-widest mb-3">{match_info[0].round} &middot; {match_info[0].match_date} &middot; {match_info[0].kick_off_time} &middot; {match_info[0].stadium}</div>
+  <div class="flex items-center justify-center gap-4 md:gap-6">
+    <div class="flex-1 min-w-0 flex flex-col items-center">
+      <img src={match_info[0].home_team_logo} alt="" class="h-12 w-12 md:h-16 md:w-16 object-contain mb-2" onerror="this.style.display='none'" />
+      <div class="text-base md:text-xl font-bold text-gray-800 truncate w-full">{match_info[0].home_team_short}</div>
+      <div class="text-xs text-blue-400 font-semibold uppercase tracking-widest mt-1">Home</div>
+    </div>
+    <div class="text-xl md:text-2xl font-black text-gray-300 shrink-0">vs</div>
+    <div class="flex-1 min-w-0 flex flex-col items-center">
+      <img src={match_info[0].away_team_logo} alt="" class="h-12 w-12 md:h-16 md:w-16 object-contain mb-2" onerror="this.style.display='none'" />
+      <div class="text-base md:text-xl font-bold text-gray-800 truncate w-full">{match_info[0].away_team_short}</div>
+      <div class="text-xs text-red-400 font-semibold uppercase tracking-widest mt-1">Away</div>
+    </div>
+  </div>
+</div>
+
+---
+
+### Head-to-Head History
+
+<p style="font-size:0.75rem;color:#6b7280;margin:0 0 1rem 0;font-style:italic;">All previous meetings between these two clubs. Filter by season to narrow the comparison.</p>
+
+<Dropdown data={h2h_seasons} name=h2h_season value=season label=season multiple=true selectAllByDefault=true order="season desc" />
+
+<div class="grid grid-cols-3 gap-4 mb-6">
+  <div class="rounded-xl border border-blue-200 bg-blue-50 p-4 text-center">
+    <div class="text-3xl font-black text-blue-600">{h2h_stats[0].team1_wins}</div>
+    <div class="text-xs text-blue-400 mt-1 font-semibold uppercase tracking-wide">{match_info[0].home_team_short} Wins</div>
+  </div>
+  <div class="rounded-xl border border-gray-200 bg-gray-100 p-4 text-center">
+    <div class="text-3xl font-black text-gray-500">{h2h_stats[0].draws}</div>
+    <div class="text-xs text-gray-400 mt-1 font-semibold uppercase tracking-wide">Draws</div>
+  </div>
+  <div class="rounded-xl border border-red-200 bg-red-50 p-4 text-center">
+    <div class="text-3xl font-black text-red-500">{h2h_stats[0].team2_wins}</div>
+    <div class="text-xs text-red-400 mt-1 font-semibold uppercase tracking-wide">{match_info[0].away_team_short} Wins</div>
+  </div>
+</div>
+
+<div class="block md:hidden">
+<DataTable data={h2h} rows=20>
+    <Column id=match_date          title="Date"        />
+    <Column id=match               title="Match"       />
+    <Column id=score               title="Score"       align=center />
+    <Column id=total_goals         title="Goals"       contentType=colorscale colorPalette={['white','#22c55e']} align=center />
+    <Column id=total_big_chances   title="Big Ch."     contentType=colorscale colorPalette={['white','#f59e0b']} align=center />
+    <Column id=total_shots_on_goal title="SoG"         contentType=bar colorPalette={['#6366f1']} />
+</DataTable>
+</div>
+<div class="hidden md:block">
+<DataTable data={h2h} rows=20>
+    <Column id=season              title="Season"      />
+    <Column id=match_date          title="Date"        />
+    <Column id=round               title="Round"       />
+    <Column id=match               title="Match"       />
+    <Column id=score               title="Score"       align=center />
+    <Column id=total_goals         title="Goals"       contentType=colorscale colorPalette={['white','#22c55e']} align=center />
+    <Column id=total_big_chances   title="Big Chances" contentType=colorscale colorPalette={['white','#f59e0b']} align=center />
+    <Column id=total_shots_on_goal title="SoG"         contentType=bar colorPalette={['#6366f1']} />
+</DataTable>
+</div>
+
+---
+
+### Form Guide — Last 5 Matches
+
+<p style="font-size:0.75rem;color:#6b7280;margin:0 0 1rem 0;font-style:italic;">Most recent five results for each side across all competitions in the current season.</p>
+
+<div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+
+<div class="rounded-xl border border-gray-200 bg-gray-50 p-4">
+  <div class="text-base font-bold text-gray-700 mb-3">{match_info[0].home_team_short}</div>
+  <div class="flex flex-col gap-2">
+    {#each home_form as m}
+      <div class="flex items-center justify-between rounded-lg bg-white border border-gray-100 px-3 py-2">
+        <div class="text-xs text-gray-400 w-14 shrink-0">{m.match_date}</div>
+        <div class="text-xs text-gray-600 flex-1 px-2 truncate">vs {m.opponent}</div>
+        <div class="text-sm font-bold text-gray-700 w-12 text-center shrink-0">{m.gf}–{m.ga}</div>
+        <div class="w-8 text-center shrink-0">
+          {#if m.result === 'Win'}
+            <span class="inline-flex items-center justify-center w-6 h-5 text-xs font-bold rounded bg-green-500 text-white">W</span>
+          {:else if m.result === 'Draw'}
+            <span class="inline-flex items-center justify-center w-6 h-5 text-xs font-bold rounded bg-yellow-400 text-white">D</span>
+          {:else}
+            <span class="inline-flex items-center justify-center w-6 h-5 text-xs font-bold rounded bg-red-500 text-white">L</span>
+          {/if}
+        </div>
+      </div>
+    {/each}
+  </div>
+</div>
+
+<div class="rounded-xl border border-gray-200 bg-gray-50 p-4">
+  <div class="text-base font-bold text-gray-700 mb-3">{match_info[0].away_team_short}</div>
+  <div class="flex flex-col gap-2">
+    {#each away_form as m}
+      <div class="flex items-center justify-between rounded-lg bg-white border border-gray-100 px-3 py-2">
+        <div class="text-xs text-gray-400 w-14 shrink-0">{m.match_date}</div>
+        <div class="text-xs text-gray-600 flex-1 px-2 truncate">vs {m.opponent}</div>
+        <div class="text-sm font-bold text-gray-700 w-12 text-center shrink-0">{m.gf}–{m.ga}</div>
+        <div class="w-8 text-center shrink-0">
+          {#if m.result === 'Win'}
+            <span class="inline-flex items-center justify-center w-6 h-5 text-xs font-bold rounded bg-green-500 text-white">W</span>
+          {:else if m.result === 'Draw'}
+            <span class="inline-flex items-center justify-center w-6 h-5 text-xs font-bold rounded bg-yellow-400 text-white">D</span>
+          {:else}
+            <span class="inline-flex items-center justify-center w-6 h-5 text-xs font-bold rounded bg-red-500 text-white">L</span>
+          {/if}
+        </div>
+      </div>
+    {/each}
+  </div>
+</div>
+
+</div>
+
+{:else}
+
+<div class="rounded-xl border border-gray-200 bg-white p-6 mt-2 text-center text-gray-400 text-sm">
+  Loading match preview…
+</div>
+
+{/if}

--- a/dashboards/pages/upcoming-matches.md
+++ b/dashboards/pages/upcoming-matches.md
@@ -13,10 +13,10 @@ select distinct team_name from (
 ```
 
 ```sql rounds
-select distinct match_round_number as round_number, round
+select distinct cast(match_round_number as int) as round_number, round
 from superligaen.mart_upcoming
 where home_team is not null
-order by match_round_number asc
+order by round_number asc
 ```
 
 {#if teams.length > 0}
@@ -55,7 +55,17 @@ where home_team is not null
 order by match_date asc, kick_off_time asc
 ```
 
-## Upcoming Fixtures
+```sql round_title
+select string_agg(round_number::varchar, ', ' order by round_number) as label
+from (
+    select distinct cast(match_round_number as int) as round_number
+    from superligaen.mart_upcoming
+    where home_team is not null
+      and match_round_number in ${inputs.round.value}
+)
+```
+
+## Upcoming Fixtures — Round {round_title[0]?.label}
 
 {#each upcoming as m, i}
 {#if i === 0 || m.match_date !== upcoming[i-1].match_date}

--- a/dashboards/pages/upcoming-matches.md
+++ b/dashboards/pages/upcoming-matches.md
@@ -21,14 +21,14 @@ order by match_round_number asc
 
 {#if teams.length > 0}
 
-<p style="font-size:0.75rem;color:#6b7280;margin:0 0 1rem 0;font-style:italic;">Filter by team to see only relevant fixtures. Select a match in the section below to explore head-to-head history and recent form for both sides.</p>
+<p style="font-size:0.75rem;color:#6b7280;margin:0 0 1rem 0;font-style:italic;">Filter by team or round to narrow the fixtures. Click any match to open its preview — head-to-head history and recent form for both sides.</p>
 
 <Dropdown data={teams} name=team value=team_name label=team_name order="team_name asc" multiple=true selectAllByDefault=true />
 <Dropdown data={rounds} name=round value=round_number label=round_number title="Round" order="round_number asc" multiple=true defaultValue={rounds[0]?.round_number} />
 
 ```sql upcoming
 select
-    cast(match_id as varchar)                   as match_key,
+    cast(cast(match_id as bigint) as varchar)   as match_key,
     home_team || ' - ' || away_team             as match_name,
     round,
     match_round_number,
@@ -42,8 +42,6 @@ select
     strftime(match_date, '%Y-%m-%d')            as match_date,
     strftime(match_date, '%A %d %B')            as match_day,
     kick_off_time,
-    '<span style="color:#94a3b8;">' || stadium || '</span>'                  as stadium_muted,
-    '<span style="color:#94a3b8;">' || coalesce(referee, '—') || '</span>'  as referee_muted,
     stadium,
     referee,
     season
@@ -61,7 +59,8 @@ order by match_date asc, kick_off_time asc
 {#if i === 0 || m.match_date !== upcoming[i-1].match_date}
 <div class="text-xs font-bold text-gray-500 uppercase tracking-widest mt-6 mb-2">{m.match_day}</div>
 {/if}
-<div class="rounded-xl border border-gray-200 bg-white px-4 py-3 mb-3">
+<a href="/upcoming-match-analysis?match={m.match_key}" style="text-decoration:none;color:inherit;display:block;">
+<div class="rounded-xl border border-gray-200 bg-white px-4 py-3 mb-3 transition hover:shadow-md hover:border-gray-300 cursor-pointer">
   <div class="flex items-center gap-3">
     <div class="flex-1 flex items-center justify-end gap-2 min-w-0">
       <span class="font-semibold text-gray-800 truncate">{m.home_team}</span>
@@ -77,218 +76,8 @@ order by match_date asc, kick_off_time asc
   </div>
   <div class="text-[11px] text-gray-400 text-center mt-2 uppercase tracking-wide">{m.round} &middot; {m.stadium} &middot; {m.referee || 'TBD'}</div>
 </div>
+</a>
 {/each}
-
----
-
-## Match Analysis
-
-<p style="font-size:0.75rem;color:#6b7280;margin:0 0 1rem 0;font-style:italic;">Select a fixture to see the all-time head-to-head record between the two clubs and the last 5 results for each side going into the match.</p>
-
-<Dropdown data={upcoming} name=match value=match_key label=match_short_name order="match_date asc, kick_off_time asc" />
-
-```sql match_info
-select
-    home_team,
-    away_team,
-    home_team_short,
-    away_team_short,
-    home_team_logo,
-    away_team_logo,
-    match_date,
-    round,
-    kick_off_time,
-    stadium
-from ${upcoming}
-where match_key = '${inputs.match.value}'
-limit 1
-```
-
-```sql h2h_seasons
-select distinct mc.season
-from superligaen.mart_match_card mc
-join ${match_info} mi
-    on (mc.home_team = mi.home_team and mc.away_team = mi.away_team)
-    or (mc.home_team = mi.away_team  and mc.away_team = mi.home_team)
-order by mc.season desc
-```
-
-```sql h2h
-select
-    mc.season,
-    mc.match_date,
-    mc.match_round_name                                                     as round,
-    mc.home_team_short || ' - ' || mc.away_team_short                       as match,
-    mc.score,
-    (mc.home_goals + mc.away_goals)::int                                    as total_goals,
-    (mc.home_sog   + mc.away_sog)::int                                      as total_shots_on_goal,
-    (mc.home_big_chances + mc.away_big_chances)::int                        as total_big_chances
-from superligaen.mart_match_card mc
-join ${match_info} mi
-    on (mc.home_team = mi.home_team and mc.away_team = mi.away_team)
-    or (mc.home_team = mi.away_team  and mc.away_team = mi.home_team)
-where mc.season in ${inputs.h2h_season.value}
-order by mc.match_date desc
-```
-
-```sql h2h_stats
-select
-    sum(case when (mc.home_team = mi.home_team and mc.home_goals > mc.away_goals)
-              or  (mc.away_team = mi.home_team and mc.away_goals > mc.home_goals) then 1 else 0 end)  as team1_wins,
-    sum(case when mc.home_goals = mc.away_goals then 1 else 0 end)                                    as draws,
-    sum(case when (mc.home_team = mi.away_team  and mc.home_goals > mc.away_goals)
-              or  (mc.away_team = mi.away_team  and mc.away_goals > mc.home_goals) then 1 else 0 end) as team2_wins
-from superligaen.mart_match_card mc
-join ${match_info} mi
-    on (mc.home_team = mi.home_team and mc.away_team = mi.away_team)
-    or (mc.home_team = mi.away_team  and mc.away_team = mi.home_team)
-where mc.season in ${inputs.h2h_season.value}
-```
-
-```sql home_form
-select
-    strftime(tm.match_date, '%d %b')    as match_date,
-    tm.opponent_team_short_name         as opponent,
-    tm.goals_scored                     as gf,
-    tm.goals_conceded                   as ga,
-    tm.result
-from superligaen.mart_team_match tm
-join ${match_info} mi on tm.team_name = mi.home_team
-where tm.result in ('Win', 'Draw', 'Loss')
-order by tm.match_date desc
-limit 5
-```
-
-```sql away_form
-select
-    strftime(tm.match_date, '%d %b')    as match_date,
-    tm.opponent_team_short_name         as opponent,
-    tm.goals_scored                     as gf,
-    tm.goals_conceded                   as ga,
-    tm.result
-from superligaen.mart_team_match tm
-join ${match_info} mi on tm.team_name = mi.away_team
-where tm.result in ('Win', 'Draw', 'Loss')
-order by tm.match_date desc
-limit 5
-```
-
-<div class="rounded-2xl border border-gray-200 bg-gray-50 p-4 md:p-6 mb-6 text-center">
-  <div class="text-xs text-gray-400 uppercase tracking-widest mb-3">{match_info[0].round} &middot; {match_info[0].match_date} &middot; {match_info[0].kick_off_time} &middot; {match_info[0].stadium}</div>
-  <div class="flex items-center justify-center gap-4 md:gap-6">
-    <div class="flex-1 min-w-0 flex flex-col items-center">
-      <img src={match_info[0].home_team_logo} alt="" class="h-12 w-12 md:h-16 md:w-16 object-contain mb-2" onerror="this.style.display='none'" />
-      <div class="text-base md:text-xl font-bold text-gray-800 truncate w-full">{match_info[0].home_team_short}</div>
-      <div class="text-xs text-blue-400 font-semibold uppercase tracking-widest mt-1">Home</div>
-    </div>
-    <div class="text-xl md:text-2xl font-black text-gray-300 shrink-0">vs</div>
-    <div class="flex-1 min-w-0 flex flex-col items-center">
-      <img src={match_info[0].away_team_logo} alt="" class="h-12 w-12 md:h-16 md:w-16 object-contain mb-2" onerror="this.style.display='none'" />
-      <div class="text-base md:text-xl font-bold text-gray-800 truncate w-full">{match_info[0].away_team_short}</div>
-      <div class="text-xs text-red-400 font-semibold uppercase tracking-widest mt-1">Away</div>
-    </div>
-  </div>
-</div>
-
----
-
-### Head-to-Head History
-
-<p style="font-size:0.75rem;color:#6b7280;margin:0 0 1rem 0;font-style:italic;">All previous meetings between these two clubs. Filter by season to narrow the comparison.</p>
-
-<Dropdown data={h2h_seasons} name=h2h_season value=season label=season multiple=true selectAllByDefault=true order="season desc" />
-
-<div class="grid grid-cols-3 gap-4 mb-6">
-  <div class="rounded-xl border border-blue-200 bg-blue-50 p-4 text-center">
-    <div class="text-3xl font-black text-blue-600">{h2h_stats[0].team1_wins}</div>
-    <div class="text-xs text-blue-400 mt-1 font-semibold uppercase tracking-wide">{match_info[0].home_team_short} Wins</div>
-  </div>
-  <div class="rounded-xl border border-gray-200 bg-gray-100 p-4 text-center">
-    <div class="text-3xl font-black text-gray-500">{h2h_stats[0].draws}</div>
-    <div class="text-xs text-gray-400 mt-1 font-semibold uppercase tracking-wide">Draws</div>
-  </div>
-  <div class="rounded-xl border border-red-200 bg-red-50 p-4 text-center">
-    <div class="text-3xl font-black text-red-500">{h2h_stats[0].team2_wins}</div>
-    <div class="text-xs text-red-400 mt-1 font-semibold uppercase tracking-wide">{match_info[0].away_team_short} Wins</div>
-  </div>
-</div>
-
-<div class="block md:hidden">
-<DataTable data={h2h} rows=20>
-    <Column id=match_date          title="Date"        />
-    <Column id=match               title="Match"       />
-    <Column id=score               title="Score"       align=center />
-    <Column id=total_goals         title="Goals"       contentType=colorscale colorPalette={['white','#22c55e']} align=center />
-    <Column id=total_big_chances   title="Big Ch."     contentType=colorscale colorPalette={['white','#f59e0b']} align=center />
-    <Column id=total_shots_on_goal title="SoG"         contentType=bar colorPalette={['#6366f1']} />
-</DataTable>
-</div>
-<div class="hidden md:block">
-<DataTable data={h2h} rows=20>
-    <Column id=season              title="Season"      />
-    <Column id=match_date          title="Date"        />
-    <Column id=round               title="Round"       />
-    <Column id=match               title="Match"       />
-    <Column id=score               title="Score"       align=center />
-    <Column id=total_goals         title="Goals"       contentType=colorscale colorPalette={['white','#22c55e']} align=center />
-    <Column id=total_big_chances   title="Big Chances" contentType=colorscale colorPalette={['white','#f59e0b']} align=center />
-    <Column id=total_shots_on_goal title="SoG"         contentType=bar colorPalette={['#6366f1']} />
-</DataTable>
-</div>
-
----
-
-### Form Guide — Last 5 Matches
-
-<p style="font-size:0.75rem;color:#6b7280;margin:0 0 1rem 0;font-style:italic;">Most recent five results for each side across all competitions in the current season.</p>
-
-<div class="grid grid-cols-1 md:grid-cols-2 gap-6">
-
-<div class="rounded-xl border border-gray-200 bg-gray-50 p-4">
-  <div class="text-base font-bold text-gray-700 mb-3">{match_info[0].home_team_short}</div>
-  <div class="flex flex-col gap-2">
-    {#each home_form as m}
-      <div class="flex items-center justify-between rounded-lg bg-white border border-gray-100 px-3 py-2">
-        <div class="text-xs text-gray-400 w-14 shrink-0">{m.match_date}</div>
-        <div class="text-xs text-gray-600 flex-1 px-2 truncate">vs {m.opponent}</div>
-        <div class="text-sm font-bold text-gray-700 w-12 text-center shrink-0">{m.gf}–{m.ga}</div>
-        <div class="w-8 text-center shrink-0">
-          {#if m.result === 'Win'}
-            <span class="inline-flex items-center justify-center w-6 h-5 text-xs font-bold rounded bg-green-500 text-white">W</span>
-          {:else if m.result === 'Draw'}
-            <span class="inline-flex items-center justify-center w-6 h-5 text-xs font-bold rounded bg-yellow-400 text-white">D</span>
-          {:else}
-            <span class="inline-flex items-center justify-center w-6 h-5 text-xs font-bold rounded bg-red-500 text-white">L</span>
-          {/if}
-        </div>
-      </div>
-    {/each}
-  </div>
-</div>
-
-<div class="rounded-xl border border-gray-200 bg-gray-50 p-4">
-  <div class="text-base font-bold text-gray-700 mb-3">{match_info[0].away_team_short}</div>
-  <div class="flex flex-col gap-2">
-    {#each away_form as m}
-      <div class="flex items-center justify-between rounded-lg bg-white border border-gray-100 px-3 py-2">
-        <div class="text-xs text-gray-400 w-14 shrink-0">{m.match_date}</div>
-        <div class="text-xs text-gray-600 flex-1 px-2 truncate">vs {m.opponent}</div>
-        <div class="text-sm font-bold text-gray-700 w-12 text-center shrink-0">{m.gf}–{m.ga}</div>
-        <div class="w-8 text-center shrink-0">
-          {#if m.result === 'Win'}
-            <span class="inline-flex items-center justify-center w-6 h-5 text-xs font-bold rounded bg-green-500 text-white">W</span>
-          {:else if m.result === 'Draw'}
-            <span class="inline-flex items-center justify-center w-6 h-5 text-xs font-bold rounded bg-yellow-400 text-white">D</span>
-          {:else}
-            <span class="inline-flex items-center justify-center w-6 h-5 text-xs font-bold rounded bg-red-500 text-white">L</span>
-          {/if}
-        </div>
-      </div>
-    {/each}
-  </div>
-</div>
-
-</div>
 
 {:else}
 

--- a/dashboards/pages/upcoming-matches.md
+++ b/dashboards/pages/upcoming-matches.md
@@ -40,6 +40,7 @@ select
     home_team_logo,
     away_team_logo,
     strftime(match_date, '%Y-%m-%d')            as match_date,
+    strftime(match_date, '%A %d %B')            as match_day,
     kick_off_time,
     '<span style="color:#94a3b8;">' || stadium || '</span>'                  as stadium_muted,
     '<span style="color:#94a3b8;">' || coalesce(referee, '—') || '</span>'  as referee_muted,
@@ -56,14 +57,27 @@ order by match_date asc, kick_off_time asc
 
 ## Upcoming Fixtures
 
-<DataTable data={upcoming} rows=15>
-    <Column id=match_date         title="Date" />
-    <Column id=round title="Round" />
-    <Column id=match_name         title="Match"    wrap=true />
-    <Column id=kick_off_time title="Kick-Off" align=center />
-    <Column id=stadium_muted title="Stadium"  contentType=html />
-    <Column id=referee_muted title="Referee"  contentType=html />
-</DataTable>
+{#each upcoming as m, i}
+{#if i === 0 || m.match_date !== upcoming[i-1].match_date}
+<div class="text-xs font-bold text-gray-500 uppercase tracking-widest mt-6 mb-2">{m.match_day}</div>
+{/if}
+<div class="rounded-xl border border-gray-200 bg-white px-4 py-3 mb-3">
+  <div class="flex items-center gap-3">
+    <div class="flex-1 flex items-center justify-end gap-2 min-w-0">
+      <span class="font-semibold text-gray-800 truncate">{m.home_team}</span>
+      <img src={m.home_team_logo} alt="" class="h-8 w-8 object-contain shrink-0" onerror="this.style.display='none'" />
+    </div>
+    <div class="shrink-0 px-3 text-center">
+      <div class="text-base md:text-lg font-black text-gray-800 whitespace-nowrap">{m.kick_off_time}</div>
+    </div>
+    <div class="flex-1 flex items-center gap-2 min-w-0">
+      <img src={m.away_team_logo} alt="" class="h-8 w-8 object-contain shrink-0" onerror="this.style.display='none'" />
+      <span class="font-semibold text-gray-800 truncate">{m.away_team}</span>
+    </div>
+  </div>
+  <div class="text-[11px] text-gray-400 text-center mt-2 uppercase tracking-wide">{m.round} &middot; {m.stadium} &middot; {m.referee || 'TBD'}</div>
+</div>
+{/each}
 
 ---
 

--- a/dashboards/pages/upcoming-matches.md
+++ b/dashboards/pages/upcoming-matches.md
@@ -75,7 +75,8 @@ from (
 <div class="rounded-xl border border-gray-200 bg-white px-4 py-3 mb-3 transition hover:shadow-md hover:border-gray-300 cursor-pointer">
   <div class="flex items-center gap-3">
     <div class="flex-1 flex items-center justify-end gap-2 min-w-0">
-      <span class="font-semibold text-gray-800 truncate">{m.home_team}</span>
+      <span class="font-semibold text-gray-800 truncate md:hidden">{m.home_team_short}</span>
+      <span class="font-semibold text-gray-800 truncate hidden md:inline">{m.home_team}</span>
       <img src={m.home_team_logo} alt="" class="h-8 w-8 object-contain shrink-0" onerror="this.style.display='none'" />
     </div>
     <div class="shrink-0 px-3 text-center">
@@ -83,7 +84,8 @@ from (
     </div>
     <div class="flex-1 flex items-center gap-2 min-w-0">
       <img src={m.away_team_logo} alt="" class="h-8 w-8 object-contain shrink-0" onerror="this.style.display='none'" />
-      <span class="font-semibold text-gray-800 truncate">{m.away_team}</span>
+      <span class="font-semibold text-gray-800 truncate md:hidden">{m.away_team_short}</span>
+      <span class="font-semibold text-gray-800 truncate hidden md:inline">{m.away_team}</span>
     </div>
   </div>
   <div class="text-[11px] text-gray-400 text-center mt-2 uppercase tracking-wide">{m.stadium} &middot; {m.kick_off_time}</div>

--- a/dashboards/pages/upcoming-matches.md
+++ b/dashboards/pages/upcoming-matches.md
@@ -12,11 +12,19 @@ select distinct team_name from (
 ) order by team_name asc
 ```
 
+```sql rounds
+select distinct match_round_number as round_number, round
+from superligaen.mart_upcoming
+where home_team is not null
+order by match_round_number asc
+```
+
 {#if teams.length > 0}
 
 <p style="font-size:0.75rem;color:#6b7280;margin:0 0 1rem 0;font-style:italic;">Filter by team to see only relevant fixtures. Select a match in the section below to explore head-to-head history and recent form for both sides.</p>
 
 <Dropdown data={teams} name=team value=team_name label=team_name order="team_name asc" multiple=true selectAllByDefault=true />
+<Dropdown data={rounds} name=round value=round_number label=round_number title="Round" order="round_number asc" multiple=true defaultValue={rounds[0]?.round_number} />
 
 ```sql upcoming
 select
@@ -29,13 +37,18 @@ select
     home_team_short,
     away_team_short,
     match_short_name,
+    home_team_logo,
+    away_team_logo,
     strftime(match_date, '%Y-%m-%d')            as match_date,
     kick_off_time,
+    '<span style="color:#94a3b8;">' || stadium || '</span>'                  as stadium_muted,
+    '<span style="color:#94a3b8;">' || coalesce(referee, '—') || '</span>'  as referee_muted,
     stadium,
     referee,
     season
 from superligaen.mart_upcoming
 where home_team is not null
+  and match_round_number in ${inputs.round.value}
   and (home_team in ${inputs.team.value}
        or away_team in ${inputs.team.value})
 order by match_date asc, kick_off_time asc
@@ -43,26 +56,14 @@ order by match_date asc, kick_off_time asc
 
 ## Upcoming Fixtures
 
-<div class="block md:hidden">
-<DataTable data={upcoming} rows=10>
-    <Column id=match_date       title="Date"          />
-    <Column id=round            title="Round"         />
-    <Column id=match_short_name title="Match"         wrap=true />
-    <Column id=stadium          title="Stadium"       />
-    <Column id=kick_off_time    title="K/O"           />
-    <Column id=referee          title="Referee"       />
+<DataTable data={upcoming} rows=15>
+    <Column id=match_date         title="Date" />
+    <Column id=round title="Round" />
+    <Column id=match_name         title="Match"    wrap=true />
+    <Column id=kick_off_time title="Kick-Off" align=center />
+    <Column id=stadium_muted title="Stadium"  contentType=html />
+    <Column id=referee_muted title="Referee"  contentType=html />
 </DataTable>
-</div>
-<div class="hidden md:block">
-<DataTable data={upcoming} rows=10>
-    <Column id=match_date    title="Date"          />
-    <Column id=round         title="Round"         />
-    <Column id=match_name    title="Match"         wrap=true />
-    <Column id=stadium       title="Stadium"       />
-    <Column id=kick_off_time title="Kick-Off Time" />
-    <Column id=referee       title="Referee"       />
-</DataTable>
-</div>
 
 ---
 
@@ -78,6 +79,8 @@ select
     away_team,
     home_team_short,
     away_team_short,
+    home_team_logo,
+    away_team_logo,
     match_date,
     round,
     kick_off_time,
@@ -159,13 +162,15 @@ limit 5
 <div class="rounded-2xl border border-gray-200 bg-gray-50 p-4 md:p-6 mb-6 text-center">
   <div class="text-xs text-gray-400 uppercase tracking-widest mb-3">{match_info[0].round} &middot; {match_info[0].match_date} &middot; {match_info[0].kick_off_time} &middot; {match_info[0].stadium}</div>
   <div class="flex items-center justify-center gap-4 md:gap-6">
-    <div class="flex-1 min-w-0">
-      <div class="text-base md:text-xl font-bold text-gray-800 truncate">{match_info[0].home_team_short}</div>
+    <div class="flex-1 min-w-0 flex flex-col items-center">
+      <img src={match_info[0].home_team_logo} alt="" class="h-12 w-12 md:h-16 md:w-16 object-contain mb-2" onerror="this.style.display='none'" />
+      <div class="text-base md:text-xl font-bold text-gray-800 truncate w-full">{match_info[0].home_team_short}</div>
       <div class="text-xs text-blue-400 font-semibold uppercase tracking-widest mt-1">Home</div>
     </div>
     <div class="text-xl md:text-2xl font-black text-gray-300 shrink-0">vs</div>
-    <div class="flex-1 min-w-0">
-      <div class="text-base md:text-xl font-bold text-gray-800 truncate">{match_info[0].away_team_short}</div>
+    <div class="flex-1 min-w-0 flex flex-col items-center">
+      <img src={match_info[0].away_team_logo} alt="" class="h-12 w-12 md:h-16 md:w-16 object-contain mb-2" onerror="this.style.display='none'" />
+      <div class="text-base md:text-xl font-bold text-gray-800 truncate w-full">{match_info[0].away_team_short}</div>
       <div class="text-xs text-red-400 font-semibold uppercase tracking-widest mt-1">Away</div>
     </div>
   </div>

--- a/dashboards/pages/upcoming-matches.md
+++ b/dashboards/pages/upcoming-matches.md
@@ -24,7 +24,9 @@ order by match_round_number asc
 <p style="font-size:0.75rem;color:#6b7280;margin:0 0 1rem 0;font-style:italic;">Filter by team or round to narrow the fixtures. Click any match to open its preview — head-to-head history and recent form for both sides.</p>
 
 <Dropdown data={teams} name=team value=team_name label=team_name order="team_name asc" multiple=true selectAllByDefault=true />
+{#key rounds[0]?.round_number}
 <Dropdown data={rounds} name=round value=round_number label=round_number title="Round" order="round_number asc" multiple=true defaultValue={rounds[0]?.round_number} />
+{/key}
 
 ```sql upcoming
 select

--- a/dashboards/pages/upcoming-matches.md
+++ b/dashboards/pages/upcoming-matches.md
@@ -67,14 +67,14 @@ order by match_date asc, kick_off_time asc
       <img src={m.home_team_logo} alt="" class="h-8 w-8 object-contain shrink-0" onerror="this.style.display='none'" />
     </div>
     <div class="shrink-0 px-3 text-center">
-      <div class="text-base md:text-lg font-black text-gray-800 whitespace-nowrap">{m.kick_off_time}</div>
+      <div class="text-sm font-black text-gray-300">VS</div>
     </div>
     <div class="flex-1 flex items-center gap-2 min-w-0">
       <img src={m.away_team_logo} alt="" class="h-8 w-8 object-contain shrink-0" onerror="this.style.display='none'" />
       <span class="font-semibold text-gray-800 truncate">{m.away_team}</span>
     </div>
   </div>
-  <div class="text-[11px] text-gray-400 text-center mt-2 uppercase tracking-wide">{m.round} &middot; {m.stadium} &middot; {m.referee || 'TBD'}</div>
+  <div class="text-[11px] text-gray-400 text-center mt-2 uppercase tracking-wide">{m.stadium} &middot; {m.kick_off_time}</div>
 </div>
 </a>
 {/each}

--- a/dashboards/sources/superligaen/upcoming-matches/mart_upcoming.sql
+++ b/dashboards/sources/superligaen/upcoming-matches/mart_upcoming.sql
@@ -14,7 +14,9 @@ WITH base AS (
         MAX(CASE WHEN ts.team_side = 'Away' THEN t.team_short_name END)                        AS match_short_name,
         CASE WHEN st.stadium_name LIKE '%Unknown%' OR st.stadium_name LIKE '%Applicable%'
              THEN 'TBD' ELSE st.stadium_name END                                               AS stadium,
-        ref.referee_common_name                                                                 AS referee
+        ref.referee_common_name                                                                 AS referee,
+        MAX(CASE WHEN ts.team_side = 'Home' THEN t.team_logo END)                                AS home_team_logo,
+        MAX(CASE WHEN ts.team_side = 'Away' THEN t.team_logo END)                                AS away_team_logo
     FROM superligaen.gold.fct_team_matches  f
     JOIN superligaen.gold.dim_date          d   ON d.date_sk          = f.date_sk
     JOIN superligaen.gold.dim_match         m   ON m.match_sk         = f.match_sk
@@ -31,6 +33,6 @@ SELECT * FROM base
 UNION ALL
 -- sentinel row so parquet is never empty (filtered out in page queries via home_team IS NOT NULL)
 SELECT -1, date '1900-01-01', '0000-00', 0, '----', '00:00',
-       NULL, NULL, NULL, NULL, NULL, 'TBD', NULL
+       NULL, NULL, NULL, NULL, NULL, 'TBD', NULL, NULL, NULL
 WHERE NOT EXISTS (SELECT 1 FROM base)
 ORDER BY match_date ASC, kick_off_time ASC


### PR DESCRIPTION
## What

Full redesign of the **Upcoming Fixtures** page to match the current design system, plus a dedicated match-preview page.

### Fixtures page (`upcoming-matches.md`)
- Replaced the old flat table with **date-grouped matchday cards** (team names, VS, kickoff, stadium·time caption).
- Cards are **clickable**, linking to a new preview page.
- **Round-number filter** (multi-select, defaults to the nearest round) beside the team filter; selection is reflected in the section heading (`Round 1`, etc.).
- Mobile shows **short team names**; desktop shows full names.
- Fixed the round dropdown default not applying on mobile cold start (`{#key}` re-init).

### New preview page (`upcoming-match-analysis.md`)
- Hidden page (reached only by clicking a card), mirroring match-results → match-analysis. Reads the match id from the URL.
- **Match Preview header**: crests + round·date on top, stadium·time below.
- **Head-to-Head History**: completed matches only; win/draw tiles colored to match the header (home blue, draw gray, away red); a colorized **Winner** column; single table with round-number on mobile / round-name on desktop.
- **Form Guide**: last 6 months of completed matches per side, with a "Form guide not available" empty state.

### Data note
- `mart_upcoming` gains `home_team_logo` / `away_team_logo` (for the preview header crests).
- `match_id` / `match_round_number` are `DOUBLE` in source; cast to int where surfaced so ids/labels render cleanly (`19714016`, `Round 1`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)