### PR TITLE
feat(ingestion): add sportmonks transfers bronze endpoint

### DIFF
--- a/ingestion/sportmonks/config.py
+++ b/ingestion/sportmonks/config.py
@@ -288,6 +288,21 @@ ENDPOINT_MANIFEST = [
         "includes": "team;rival",
         "modes":    ["full", "incremental"],
     },
+    {
+        # Incoming + outgoing transfers per in-scope team. The endpoint returns
+        # both directions; derive direction downstream by comparing
+        # from_team_id / to_team_id against the team. The counterparty club
+        # (fromTeam/toTeam) is frequently foreign and NOT in bronze teams, so
+        # the embedded objects are the only source for its name/logo/country.
+        # Fee `amount` (EUR) is populated only for a subset of permanent moves
+        # from ~2025 onward; loans / free transfers / end-of-loan have none.
+        "table":    "sportmonks__transfers",
+        "path":     "/transfers/teams/{team_id}",
+        "strategy": "team_based",
+        "delete":   "global",
+        "includes": "player;fromTeam;toTeam;type;position;detailedPosition",
+        "modes":    ["full", "incremental"],
+    },
 
     # ══════════════════════════════════════════════════════════════════════════
     # FOOTBALL API — Fixtures  (date-window; 90-day chunks or rolling window)


### PR DESCRIPTION
## What
Adds transfer ingestion to the SportMonks bronze layer via a single manifest entry — a new `bronze.sportmonks__transfers` table fed by `/transfers/teams/{team_id}` for every in-scope team.

```python
{
    "table":    "sportmonks__transfers",
    "path":     "/transfers/teams/{team_id}",
    "strategy": "team_based",
    "delete":   "global",
    "includes": "player;fromTeam;toTeam;type;position;detailedPosition",
    "modes":    ["full", "incremental"],
}
```

## Why this shape
- **`team_based` + `delete: global`** → the existing strategy already iterates all historical team IDs (current load ∪ everything in `bronze.sportmonks__teams`), so every run fully refreshes transfers for all ~24 in-scope clubs regardless of mode. No backfill step needed — the next scheduled incremental run populates full history.
- **Endpoint returns both directions** (incoming + outgoing); direction is derived downstream by comparing `from_team_id`/`to_team_id` against the team.
- **Counterparty clubs are usually foreign** and are **not** in `bronze.sportmonks__teams`/`dim_team`, so `fromTeam`/`toTeam` are included to capture the counterparty name/logo/country inline. Silver/gold modeling (denormalizing those) is intentionally deferred to a follow-up.

## No engine changes
Metadata-driven: the generic `team_based` handler and auto schema-creation pick the table up from the manifest alone.

## Verification
Smoke-tested against a throwaway local DuckDB (bootstrap chain `league → seasons → teams` + transfers, incremental):
- 12 current-season teams → **3,823 rows, all distinct IDs** (dedup confirmed)
- Embedded counterparties resolve foreign clubs (FC Augsburg, Cardiff City, Bodø/Glimt, Pogoń Szczecin…) — the ones missing from `dim_team`
- Fee `amount` parses cleanly; disclosed-fee coverage by year: 2024 85/432, 2025 87/362, 2026 29/126

🤖 Generated with [Claude Code](https://claude.com/claude-code)