### PR TITLE
feat(silver): flatten sportmonks transfers into silver layer

### DIFF
--- a/dbt/models/silver/_sources.yml
+++ b/dbt/models/silver/_sources.yml
@@ -33,6 +33,8 @@ sources:
       - name: sportmonks__round_statistics
         freshness: null
       - name: sportmonks__rivals
+      - name: sportmonks__transfers
+        freshness: null
       - name: sportmonks__core_continents
       - name: sportmonks__core_countries
       - name: sportmonks__core_regions

--- a/dbt/models/silver/transfers.sql
+++ b/dbt/models/silver/transfers.sql
@@ -1,0 +1,50 @@
+{{ config(
+    materialized='incremental',
+    incremental_strategy='delete+insert',
+    unique_key='id'
+) }}
+
+SELECT
+    id,
+    (raw_json->>'sport_id')::INTEGER             AS sport_id,
+    (raw_json->>'player_id')::INTEGER            AS player_id,
+    (raw_json->>'type_id')::INTEGER              AS type_id,
+    (raw_json->>'from_team_id')::INTEGER         AS from_team_id,
+    (raw_json->>'to_team_id')::INTEGER           AS to_team_id,
+    (raw_json->>'position_id')::INTEGER          AS position_id,
+    (raw_json->>'detailed_position_id')::INTEGER AS detailed_position_id,
+    (raw_json->>'date')::DATE                    AS transfer_date,
+    (raw_json->>'career_ended')::BOOLEAN         AS career_ended,
+    (raw_json->>'completed')::BOOLEAN            AS completed,
+    (raw_json->>'amount')::BIGINT                AS amount,
+    -- player (embedded; counterparty club is frequently foreign / not in bronze)
+    raw_json->'player'->>'name'                  AS player_name,
+    raw_json->'player'->>'common_name'           AS player_common_name,
+    raw_json->'player'->>'display_name'          AS player_display_name,
+    raw_json->'player'->>'image_path'            AS player_image_path,
+    -- from team
+    raw_json->'fromteam'->>'name'                AS from_team_name,
+    raw_json->'fromteam'->>'short_code'          AS from_team_short_code,
+    raw_json->'fromteam'->>'image_path'          AS from_team_image_path,
+    (raw_json->'fromteam'->>'country_id')::INTEGER AS from_team_country_id,
+    (raw_json->'fromteam'->>'placeholder')::BOOLEAN AS from_team_placeholder,
+    -- to team
+    raw_json->'toteam'->>'name'                  AS to_team_name,
+    raw_json->'toteam'->>'short_code'            AS to_team_short_code,
+    raw_json->'toteam'->>'image_path'            AS to_team_image_path,
+    (raw_json->'toteam'->>'country_id')::INTEGER AS to_team_country_id,
+    (raw_json->'toteam'->>'placeholder')::BOOLEAN AS to_team_placeholder,
+    -- type
+    raw_json->'type'->>'name'                    AS type_name,
+    raw_json->'type'->>'code'                    AS type_code,
+    raw_json->'type'->>'developer_name'          AS type_developer_name,
+    -- position
+    raw_json->'position'->>'name'                AS position_name,
+    raw_json->'position'->>'code'                AS position_code,
+    raw_json->'detailedposition'->>'name'        AS detailed_position_name,
+    raw_json->'detailedposition'->>'code'        AS detailed_position_code,
+    _ingested_at
+FROM {{ source('bronze', 'sportmonks__transfers') }}
+{% if is_incremental() %}
+WHERE _ingested_at > (SELECT MAX(_ingested_at) FROM {{ this }})
+{% endif %}

--- a/dbt/tests/silver/assert_transfers_distinct_teams.sql
+++ b/dbt/tests/silver/assert_transfers_distinct_teams.sql
@@ -1,0 +1,9 @@
+-- A transfer always moves a player between two different clubs; the source and
+-- destination team can never be the same. Both sides may legitimately be null
+-- (counterparty club outside our scope), so only flag rows where both are set
+-- and equal.
+SELECT id, player_name, from_team_id, to_team_id
+FROM {{ ref('transfers') }}
+WHERE from_team_id IS NOT NULL
+  AND to_team_id IS NOT NULL
+  AND from_team_id = to_team_id


### PR DESCRIPTION
## What
Promotes `bronze.sportmonks__transfers` (added in #351) to the silver layer as `silver.transfers`.

## Changes
- **`models/silver/transfers.sql`** — incremental (`delete+insert` on `id`) model that types the raw JSON into columns: core ids (`player_id`, `from_team_id`, `to_team_id`, `type_id`, position ids), `transfer_date`, `career_ended`/`completed` flags, fee `amount` (EUR), and embedded names for player, from/to team, type and position. The counterparty club is carried inline since it's frequently foreign and not in bronze `teams`.
- **`models/silver/_sources.yml`** — registers the bronze source (`freshness: null`, matching the other large endpoints).
- **`tests/silver/assert_transfers_distinct_teams.sql`** — asserts `from_team_id != to_team_id` whenever both are set (162 rows legitimately have a null counterparty).

## Verification
Built and tested against prod MotherDuck:
- 5,486 rows, all `id`s distinct
- 747 rows carry a fee, max €25M
- dates span 1999-07-01 → 2026-07-01
- `dbt test --select transfers` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)