### PR TITLE
feat(dashboards): efficiency measures across match/league/player pages

### DIFF
--- a/dashboards/pages/league-analytics.md
+++ b/dashboards/pages/league-analytics.md
@@ -57,7 +57,7 @@ with curr as (
         round(sum(goals_scored)::double / count(distinct match_id), 2)                                  as goals_per_match,
         round(100.0 * count(*) filter (where team_side='Home' and result='Win')
               / nullif(count(*) filter (where team_side='Home'), 0), 1)                                 as home_win_pct,
-        round(sum(big_chances_created)::double / count(distinct match_id), 2)                            as big_chances_pm,
+        round(100.0 * sum(shots_on_goal) / nullif(sum(total_shots), 0), 1)                              as shot_accuracy,
         round(100.0 * sum(goals_scored) / nullif(sum(total_shots), 0), 1)                               as shot_conversion,
         round(100.0 * sum(passes_accurate) / nullif(sum(total_passes), 0), 1)                           as pass_accuracy,
         round(sum(yellow_cards)::double / count(distinct match_id), 2)                                  as yc_per_match,
@@ -72,7 +72,7 @@ prev as (
     select
         sum(goals_scored)                                                                               as prev_total_goals,
         round(sum(goals_scored)::double / count(distinct match_id), 2)                                  as prev_goals_per_match,
-        round(sum(big_chances_created)::double / count(distinct match_id), 2)                            as prev_big_chances_pm,
+        round(100.0 * sum(shots_on_goal) / nullif(sum(total_shots), 0), 1)                              as prev_shot_accuracy,
         round(100.0 * sum(goals_scored) / nullif(sum(total_shots), 0), 1)                               as prev_shot_conversion,
         round(100.0 * sum(passes_accurate) / nullif(sum(total_passes), 0), 1)                           as prev_pass_accuracy,
         round(sum(yellow_cards)::double / count(distinct match_id), 2)                                  as prev_yc_per_match,
@@ -92,7 +92,7 @@ select
     prev.*,
     round(curr.total_goals       / nullif(prev.prev_total_goals,       0), 2) as total_goals_ratio,
     round(curr.goals_per_match   / nullif(prev.prev_goals_per_match,   0), 2) as goals_ratio,
-    round(curr.big_chances_pm    / nullif(prev.prev_big_chances_pm,    0), 2) as big_chances_ratio,
+    round(curr.shot_accuracy     / nullif(prev.prev_shot_accuracy,     0), 2) as shot_acc_ratio,
     round(curr.shot_conversion   / nullif(prev.prev_shot_conversion,   0), 2) as shot_conv_ratio,
     round(curr.pass_accuracy     / nullif(prev.prev_pass_accuracy,     0), 2) as pass_ratio,
     round(curr.yc_per_match      / nullif(prev.prev_yc_per_match,      0), 2) as yc_ratio,
@@ -466,11 +466,11 @@ order by case period_of_day
   </div>
 
   <div class="rounded-xl border border-gray-200 bg-white shadow-sm p-4 flex flex-col">
-    <div class="text-xs text-gray-500 text-center mb-2">Big Chances / Match</div>
-    <div class="text-3xl font-black text-center text-gray-900 flex-1 flex items-center justify-center">{k.big_chances_pm}</div>
+    <div class="text-xs text-gray-500 text-center mb-2">Shot Accuracy %</div>
+    <div class="text-3xl font-black text-center text-gray-900 flex-1 flex items-center justify-center">{k.shot_accuracy}%</div>
     <div class="flex justify-between items-center mt-3">
-      <span class="text-xs text-gray-400">Prev season: {k.prev_big_chances_pm ?? '—'}</span>
-      {#if k.big_chances_ratio != null}<span class="text-sm font-bold {k.big_chances_ratio >= 1 ? 'text-green-600' : 'text-red-500'}">{k.big_chances_ratio >= 1 ? '▲' : '▼'}</span>{/if}
+      <span class="text-xs text-gray-400">Prev season: {k.prev_shot_accuracy != null ? k.prev_shot_accuracy + '%' : '—'}</span>
+      {#if k.shot_acc_ratio != null}<span class="text-sm font-bold {k.shot_acc_ratio >= 1 ? 'text-green-600' : 'text-red-500'}">{k.shot_acc_ratio >= 1 ? '▲' : '▼'}</span>{/if}
     </div>
   </div>
 

--- a/dashboards/pages/match-results.md
+++ b/dashboards/pages/match-results.md
@@ -31,6 +31,9 @@ order by 1 desc
 
 ```sql results
 select *,
+    round(100.0 * total_goals / nullif(total_shots, 0), 1)         as shot_conversion,
+    round(100.0 * total_shots_on_goal / nullif(total_shots, 0), 1) as shot_accuracy,
+    round(total_goals::double / nullif(total_big_chances, 0), 2)   as goals_per_big_chance,
     referee_name as referee,
     '<a href="/match-analysis?match=' || cast(match_id as varchar) || '&season=' || season || '&round=' || cast(cast(match_round_number as integer) as varchar) || '" style="color:#2563eb;font-weight:600;text-decoration:none;">' || match_name       || '</a>' as match_link,
     '<a href="/match-analysis?match=' || cast(match_id as varchar) || '&season=' || season || '&round=' || cast(cast(match_round_number as integer) as varchar) || '" style="color:#2563eb;font-weight:600;text-decoration:none;">' || match_short_name || '</a>' as match_short_link
@@ -44,16 +47,16 @@ order by match_date desc
 with curr as (
     select
         sum(total_goals)                                                                      as total_goals,
-        round(sum(total_goals)::double / count(distinct match_id), 2)                        as avg_goals_per_match,
-        round(sum(total_shots_on_goal)::double / count(distinct match_id), 1)                as avg_shots_on_goal,
+        round(100.0 * sum(total_goals) / nullif(sum(total_shots), 0), 1)                     as shot_conversion_pct,
+        round(100.0 * sum(total_shots_on_goal) / nullif(sum(total_shots), 0), 1)             as shot_accuracy_pct,
         round(sum(total_goals)::double / nullif(sum(total_big_chances), 0), 2)               as goals_per_big_chance
     from ${results}
 ),
 prev as (
     select
         sum(total_goals)                                                                      as prev_total_goals,
-        round(sum(total_goals)::double / count(distinct match_id), 2)                        as prev_avg_goals_per_match,
-        round(sum(total_shots_on_goal)::double / count(distinct match_id), 1)                as prev_avg_shots_on_goal,
+        round(100.0 * sum(total_goals) / nullif(sum(total_shots), 0), 1)                     as prev_shot_conversion_pct,
+        round(100.0 * sum(total_shots_on_goal) / nullif(sum(total_shots), 0), 1)             as prev_shot_accuracy_pct,
         round(sum(total_goals)::double / nullif(sum(total_big_chances), 0), 2)               as prev_goals_per_big_chance
     from superligaen.mart_match_results
     where season = '${inputs.season.value}'
@@ -76,19 +79,19 @@ from curr cross join prev
     </div>
   </div>
   <div class="rounded-xl border border-gray-200 bg-white shadow-sm p-4 flex flex-col">
-    <div class="text-xs text-gray-500 text-center mb-2">Avg Goals / Match</div>
-    <div class="text-3xl font-black text-center text-gray-900 flex-1 flex items-center justify-center">{k.avg_goals_per_match}</div>
+    <div class="text-xs text-gray-500 text-center mb-2">Shot Conversion %</div>
+    <div class="text-3xl font-black text-center text-gray-900 flex-1 flex items-center justify-center">{k.shot_conversion_pct}%</div>
     <div class="flex justify-between items-center mt-3">
-      <span class="text-xs text-gray-400">Prev round: {k.prev_avg_goals_per_match ?? '—'}</span>
-      {#if k.prev_avg_goals_per_match != null}<span class="text-sm font-bold {k.avg_goals_per_match >= k.prev_avg_goals_per_match ? 'text-green-600' : 'text-red-500'}">{k.avg_goals_per_match >= k.prev_avg_goals_per_match ? '▲' : '▼'}</span>{/if}
+      <span class="text-xs text-gray-400">Prev round: {k.prev_shot_conversion_pct != null ? k.prev_shot_conversion_pct + '%' : '—'}</span>
+      {#if k.prev_shot_conversion_pct != null}<span class="text-sm font-bold {k.shot_conversion_pct >= k.prev_shot_conversion_pct ? 'text-green-600' : 'text-red-500'}">{k.shot_conversion_pct >= k.prev_shot_conversion_pct ? '▲' : '▼'}</span>{/if}
     </div>
   </div>
   <div class="rounded-xl border border-gray-200 bg-white shadow-sm p-4 flex flex-col">
-    <div class="text-xs text-gray-500 text-center mb-2">Avg Shots on Target / Match</div>
-    <div class="text-3xl font-black text-center text-gray-900 flex-1 flex items-center justify-center">{k.avg_shots_on_goal}</div>
+    <div class="text-xs text-gray-500 text-center mb-2">Shot Accuracy %</div>
+    <div class="text-3xl font-black text-center text-gray-900 flex-1 flex items-center justify-center">{k.shot_accuracy_pct}%</div>
     <div class="flex justify-between items-center mt-3">
-      <span class="text-xs text-gray-400">Prev round: {k.prev_avg_shots_on_goal ?? '—'}</span>
-      {#if k.prev_avg_shots_on_goal != null}<span class="text-sm font-bold {k.avg_shots_on_goal >= k.prev_avg_shots_on_goal ? 'text-green-600' : 'text-red-500'}">{k.avg_shots_on_goal >= k.prev_avg_shots_on_goal ? '▲' : '▼'}</span>{/if}
+      <span class="text-xs text-gray-400">Prev round: {k.prev_shot_accuracy_pct != null ? k.prev_shot_accuracy_pct + '%' : '—'}</span>
+      {#if k.prev_shot_accuracy_pct != null}<span class="text-sm font-bold {k.shot_accuracy_pct >= k.prev_shot_accuracy_pct ? 'text-green-600' : 'text-red-500'}">{k.shot_accuracy_pct >= k.prev_shot_accuracy_pct ? '▲' : '▼'}</span>{/if}
     </div>
   </div>
   <div class="rounded-xl border border-gray-200 bg-white shadow-sm p-4 flex flex-col">
@@ -111,10 +114,10 @@ from curr cross join prev
     <Column id=referee             title="Referee"        />
     <Column id=score               title="Score"          align=center />
     <Column id=total_goals         title="Goals"          contentType=colorscale colorPalette={['white','#22c55e']} align=center />
-    <Column id=total_shots         title="Shots"          contentType=bar        colorPalette={['#6366f1']} />
-    <Column id=total_big_chances   title="Big Ch."        contentType=colorscale colorPalette={['white','#f59e0b']} align=center />
-    <Column id=total_yellow_cards  title="YC"             contentType=colorscale colorPalette={['white','#eab308']} align=center />
-    <Column id=total_red_cards     title="RC"             contentType=colorscale colorPalette={['white','#ef4444']} align=center />
+    <Column id=shot_conversion      title="Shot Conv %"    fmt='0.0"%"' contentType=colorscale colorPalette={['white','#6366f1']} align=center />
+    <Column id=shot_accuracy        title="Shot Acc %"     fmt='0.0"%"' contentType=colorscale colorPalette={['white','#0ea5e9']} align=center />
+    <Column id=goals_per_big_chance title="Goals / Big Ch" fmt='0.00'   contentType=colorscale colorPalette={['white','#f59e0b']} align=center />
+    <Column id=total_red_cards      title="RC"             contentType=colorscale colorPalette={['white','#ef4444']} align=center />
 </DataTable>
 </div>
 <div class="hidden md:block">
@@ -124,10 +127,10 @@ from curr cross join prev
     <Column id=referee             title="Referee"        />
     <Column id=score               title="Score"          align=center />
     <Column id=total_goals         title="Goals"          contentType=colorscale colorPalette={['white','#22c55e']} align=center />
-    <Column id=total_shots         title="Shots"          contentType=bar        colorPalette={['#6366f1']} />
-    <Column id=total_big_chances   title="Big Chances"    contentType=colorscale colorPalette={['white','#f59e0b']} align=center />
-    <Column id=total_yellow_cards  title="YC"             contentType=colorscale colorPalette={['white','#eab308']} align=center />
-    <Column id=total_red_cards     title="RC"             contentType=colorscale colorPalette={['white','#ef4444']} align=center />
+    <Column id=shot_conversion      title="Shot Conv %"    fmt='0.0"%"' contentType=colorscale colorPalette={['white','#6366f1']} align=center />
+    <Column id=shot_accuracy        title="Shot Acc %"     fmt='0.0"%"' contentType=colorscale colorPalette={['white','#0ea5e9']} align=center />
+    <Column id=goals_per_big_chance title="Goals / Big Ch" fmt='0.00'   contentType=colorscale colorPalette={['white','#f59e0b']} align=center />
+    <Column id=total_red_cards      title="RC"             contentType=colorscale colorPalette={['white','#ef4444']} align=center />
 </DataTable>
 </div>
 

--- a/dashboards/pages/match-results.md
+++ b/dashboards/pages/match-results.md
@@ -33,7 +33,6 @@ order by 1 desc
 select *,
     round(100.0 * total_goals / nullif(total_shots, 0), 1)         as shot_conversion,
     round(100.0 * total_shots_on_goal / nullif(total_shots, 0), 1) as shot_accuracy,
-    round(total_goals::double / nullif(total_big_chances, 0), 2)   as goals_per_big_chance,
     referee_name as referee,
     '<a href="/match-analysis?match=' || cast(match_id as varchar) || '&season=' || season || '&round=' || cast(cast(match_round_number as integer) as varchar) || '" style="color:#2563eb;font-weight:600;text-decoration:none;">' || match_name       || '</a>' as match_link,
     '<a href="/match-analysis?match=' || cast(match_id as varchar) || '&season=' || season || '&round=' || cast(cast(match_round_number as integer) as varchar) || '" style="color:#2563eb;font-weight:600;text-decoration:none;">' || match_short_name || '</a>' as match_short_link
@@ -116,7 +115,7 @@ from curr cross join prev
     <Column id=total_goals         title="Goals"          contentType=colorscale colorPalette={['white','#22c55e']} align=center />
     <Column id=shot_conversion      title="Shot Conv %"    fmt='0.0"%"' contentType=colorscale colorPalette={['white','#6366f1']} align=center />
     <Column id=shot_accuracy        title="Shot Acc %"     fmt='0.0"%"' contentType=colorscale colorPalette={['white','#0ea5e9']} align=center />
-    <Column id=goals_per_big_chance title="Goals / Big Ch" fmt='0.00'   contentType=colorscale colorPalette={['white','#f59e0b']} align=center />
+    <Column id=total_big_chances    title="Big Chances"    contentType=colorscale colorPalette={['white','#f59e0b']} align=center />
     <Column id=total_red_cards      title="RC"             contentType=colorscale colorPalette={['white','#ef4444']} align=center />
 </DataTable>
 </div>
@@ -129,7 +128,7 @@ from curr cross join prev
     <Column id=total_goals         title="Goals"          contentType=colorscale colorPalette={['white','#22c55e']} align=center />
     <Column id=shot_conversion      title="Shot Conv %"    fmt='0.0"%"' contentType=colorscale colorPalette={['white','#6366f1']} align=center />
     <Column id=shot_accuracy        title="Shot Acc %"     fmt='0.0"%"' contentType=colorscale colorPalette={['white','#0ea5e9']} align=center />
-    <Column id=goals_per_big_chance title="Goals / Big Ch" fmt='0.00'   contentType=colorscale colorPalette={['white','#f59e0b']} align=center />
+    <Column id=total_big_chances    title="Big Chances"    contentType=colorscale colorPalette={['white','#f59e0b']} align=center />
     <Column id=total_red_cards      title="RC"             contentType=colorscale colorPalette={['white','#ef4444']} align=center />
 </DataTable>
 </div>

--- a/dashboards/pages/player-analytics.md
+++ b/dashboards/pages/player-analytics.md
@@ -76,6 +76,7 @@ select * from (values
   ('assists',                'Assists'),
   ('shots_on_target',        'Shots on Target'),
   ('shot_conv',              'Shot Conv %'),
+  ('shot_acc',               'Shot Accuracy %'),
   ('woodwork_hits',          'Woodwork Hits'),
   -- Creativity
   ('big_chances_created',    'Big Chances Created'),
@@ -177,6 +178,7 @@ with base as (
         assists::double                     as assists,
         shots_on_target::double             as shots_on_target,
         shot_conv::double                   as shot_conv,
+        round(100.0 * shots_on_target / nullif(shots_total, 0), 1)::double as shot_acc,
         woodwork_hits::double               as woodwork_hits,
         big_chances_created::double         as big_chances_created,
         chances_created::double             as all_chances,
@@ -267,6 +269,7 @@ ranked as (
             when 'assists'                then assists
             when 'shots_on_target'        then shots_on_target
             when 'shot_conv'              then shot_conv
+            when 'shot_acc'               then shot_acc
             when 'woodwork_hits'          then woodwork_hits
             when 'big_chances_created'    then big_chances_created
             when 'all_chances'            then all_chances
@@ -352,6 +355,7 @@ ranked as (
                 when 'assists'                then assists
                 when 'shots_on_target'        then shots_on_target
                 when 'shot_conv'              then shot_conv
+                when 'shot_acc'               then shot_acc
                 when 'woodwork_hits'          then woodwork_hits
                 when 'big_chances_created'    then big_chances_created
                 when 'all_chances'            then all_chances

--- a/dashboards/pages/player-analytics.md
+++ b/dashboards/pages/player-analytics.md
@@ -718,15 +718,15 @@ where season = '${inputs.season.value}'
   </div>
 
   <div class="rounded-xl border border-gray-200 bg-white shadow-sm p-4 flex flex-col">
-    <div class="text-xs text-gray-500 text-center mb-2">Shot Accuracy %</div>
-    <div class="text-3xl font-black text-center text-gray-900 flex-1 flex items-center justify-center">{p.shot_accuracy != null ? p.shot_accuracy + '%' : '—'}</div>
-    <div class="text-xs text-gray-400 text-center mt-3">{p.shots_on_target} of {p.shots} on target</div>
+    <div class="text-xs text-gray-500 text-center mb-2">Chances Created</div>
+    <div class="text-3xl font-black text-center text-gray-900 flex-1 flex items-center justify-center">{p.chances_created}</div>
+    <div class="text-xs text-gray-400 text-center mt-3">{p.big_chances_created} big · {p.key_passes} key passes</div>
   </div>
 
   <div class="rounded-xl border border-gray-200 bg-white shadow-sm p-4 flex flex-col">
     <div class="text-xs text-gray-500 text-center mb-2">Shots on Target</div>
     <div class="text-3xl font-black text-center text-gray-900 flex-1 flex items-center justify-center">{p.shots_on_target}</div>
-    <div class="text-xs text-gray-400 text-center mt-3">{p.shots} total shots</div>
+    <div class="text-xs text-gray-400 text-center mt-3">{p.shots} total · {p.shot_accuracy != null ? p.shot_accuracy + '% on target' : '—'}</div>
   </div>
 
   <div class="rounded-xl border border-gray-200 bg-white shadow-sm p-4 flex flex-col">

--- a/dashboards/pages/player-analytics.md
+++ b/dashboards/pages/player-analytics.md
@@ -490,6 +490,7 @@ select
     contributions_per90,
     pass_accuracy,
     shot_conversion,
+    round(100.0 * shots_on_target / nullif(shots_total, 0), 1)  as shot_accuracy,
     duel_win_pct,
     def_actions,
     wins,
@@ -713,9 +714,9 @@ where season = '${inputs.season.value}'
   </div>
 
   <div class="rounded-xl border border-gray-200 bg-white shadow-sm p-4 flex flex-col">
-    <div class="text-xs text-gray-500 text-center mb-2">G+A / 90</div>
-    <div class="text-3xl font-black text-center text-gray-900 flex-1 flex items-center justify-center">{p.contributions_per90}</div>
-    <div class="text-xs text-gray-400 text-center mt-3">{p.goals_per90} G · {p.assists_per90} A per 90</div>
+    <div class="text-xs text-gray-500 text-center mb-2">Shot Accuracy %</div>
+    <div class="text-3xl font-black text-center text-gray-900 flex-1 flex items-center justify-center">{p.shot_accuracy != null ? p.shot_accuracy + '%' : '—'}</div>
+    <div class="text-xs text-gray-400 text-center mt-3">{p.shots_on_target} of {p.shots} on target</div>
   </div>
 
   <div class="rounded-xl border border-gray-200 bg-white shadow-sm p-4 flex flex-col">


### PR DESCRIPTION
Closes #355, plus follow-on tweaks surfacing the same efficiency measures on two more pages.

Swaps volume metrics for **efficiency** metrics. Page-only — all derived from existing mart columns (goals / shots / shots-on-target / big-chances), no mart or prod change.

## Match Results (#355)
- KPI cards: Avg Goals/Match → **Shot Conversion %**, Avg Shots on Target → **Shot Accuracy %** (benchmarked vs previous round)
- Table: Shots → **Shot Conv %**, added **Shot Acc %**, removed **Yellow Cards** (kept RC); Big Chances kept as a count

## League Analytics
- KPI card: **Big Chances / Match → Shot Accuracy %**, benchmarked vs previous season. Radar/creativity charts unchanged.

## Player Intelligence
- Season Overview KPI: **G+A / 90 → Shot Accuracy %** (shots on target / total shots). The `contributions_per90` measure stays available in the radar/log selectors.

Verified metrics produce sensible values (Match Results 2025/26 R32: 16.3% conv / 43.3% acc; league 2025/26: 36.8%; players e.g. 37.9%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)