### PR TITLE
feat(dashboards): Transfer Intelligence improvements + transfer window filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,37 @@ erDiagram
         varchar message
     }
 
+    dim_transfer_type {
+        int transfer_type_sk PK
+        varchar transfer_type_name
+        varchar transfer_direction
+    }
+
+    dim_transfer_status {
+        int transfer_status_sk PK
+        varchar transfer_status
+    }
+
+    dim_transfer_partner_team {
+        int transfer_partner_team_sk PK
+        int transfer_partner_team_id
+        varchar transfer_partner_team_name
+        varchar transfer_partner_team_country
+        varchar transfer_partner_team_logo
+    }
+
+    fct_team_transfers {
+        int transfer_id
+        int date_sk FK
+        int team_sk FK
+        int transfer_partner_team_sk FK
+        int player_sk FK
+        int transfer_type_sk FK
+        int transfer_status_sk FK
+        int transfer_count
+        int transfer_fee_eur
+    }
+
     fct_team_matches }o--|| dim_date : "date_sk"
     fct_team_matches }o--|| dim_time : "time_sk"
     fct_team_matches }o--|| dim_match : "match_sk"
@@ -302,6 +333,12 @@ erDiagram
     fct_match_discussions }o--|| dim_match : "match_sk"
     fct_match_discussions }o--|| dim_persona : "persona_sk"
     fct_match_discussions }o--|| dim_date : "date_sk"
+    fct_team_transfers }o--|| dim_date : "date_sk"
+    fct_team_transfers }o--|| dim_team : "team_sk"
+    fct_team_transfers }o--|| dim_transfer_partner_team : "transfer_partner_team_sk"
+    fct_team_transfers }o--|| dim_player : "player_sk"
+    fct_team_transfers }o--|| dim_transfer_type : "transfer_type_sk"
+    fct_team_transfers }o--|| dim_transfer_status : "transfer_status_sk"
 ```
 
 ### Dimensional model bus matrix

--- a/README.md
+++ b/README.md
@@ -308,25 +308,28 @@ erDiagram
 
 The bus matrix shows which dimensions are conformed (shared) across business processes — the foundation of Kimball integration.
 
-| **BUSINESS PROCESSES →** | Team Match Performance | Player Appearance | Match Discussion |
-|---|:---:|:---:|:---:|
-| **COMMON DIMENSIONS ↓** | | | |
-| Date | X | X | X |
-| Time of Day | X | X | |
-| Match | X | X | X |
-| Team | X | X | |
-| Opponent Team | X | X | |
-| League | X | X | |
-| Stadium / Venue | X | X | |
-| Referee | X | X | |
-| Coach | X | X | |
-| Formation | X | X | |
-| Home / Away | X | X | |
-| Match Result | X | X | |
-| Player | | X | |
-| Playing Position | | X | |
-| Appearance Type | | X | |
-| Persona | | | X |
+| **BUSINESS PROCESSES →** | Team Match Performance | Player Appearance | Match Discussion | Team Transfers |
+|---|:---:|:---:|:---:|:---:|
+| **COMMON DIMENSIONS ↓** | | | | |
+| Date | X | X | X | X |
+| Time of Day | X | X | | |
+| Match | X | X | X | |
+| Team | X | X | | X |
+| Opponent Team | X | X | | |
+| League | X | X | | |
+| Stadium / Venue | X | X | | |
+| Referee | X | X | | |
+| Coach | X | X | | |
+| Formation | X | X | | |
+| Home / Away | X | X | | |
+| Match Result | X | X | | |
+| Player | | X | | X |
+| Playing Position | | X | | |
+| Appearance Type | | X | | |
+| Persona | | | X | |
+| Transfer Type | | | | X |
+| Transfer Status | | | | X |
+| Counterparty Team | | | | X |
 
 All dimension surrogate keys are **stable across runs** — new records get new SKs, existing records keep theirs. Sentinel rows (`-1 Unknown`, `-2 Not Applicable`) handle missing lookups, with all VARCHAR attributes filled with descriptive defaults (e.g. `'Unknown Stadium Country'`).
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The gold layer follows **Kimball dimensional modelling**. Four fact tables cover
 - **`fct_team_matches`** — one row per team per match (each fixture produces two rows, one per side); team-level stats, results, and tactical data
 - **`fct_player_appearances`** — one row per player per match; individual performance stats and ratings
 - **`fct_match_discussions`** — one row per match per persona; LLM-generated fan discussion comments (via Groq) powering the Fan Forum on the Match Analysis page
-- **`fct_team_transfers`** — one row per club per transfer; incoming/outgoing moves with fee, type, status, counterparty, and player, powering the Transfer Intelligence page
+- **`fct_team_transfers`** — one row per club per transfer; incoming/outgoing moves with fee, type, status, transfer partner, and player, powering the Transfer Intelligence page
 
 ```mermaid
 erDiagram
@@ -329,7 +329,7 @@ The bus matrix shows which dimensions are conformed (shared) across business pro
 | Persona | | | X | |
 | Transfer Type | | | | X |
 | Transfer Status | | | | X |
-| Counterparty Team | | | | X |
+| Transfer Partner | | | | X |
 
 All dimension surrogate keys are **stable across runs** — new records get new SKs, existing records keep theirs. Sentinel rows (`-1 Unknown`, `-2 Not Applicable`) handle missing lookups, with all VARCHAR attributes filled with descriptive defaults (e.g. `'Unknown Stadium Country'`).
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ Sportmonks API        Groq LLM
   Gold layer          Kimball star schema  ─────────────────────────────┐
                       (dims + fct_team_matches                          │
                            + fct_player_appearances                     │
-                           + fct_match_discussions)  (dbt)             │
+                           + fct_match_discussions                      │
+                           + fct_team_transfers)  (dbt)                 │
                                                                         ▼
                                                              Evidence.dev dashboard
                                                              deployed on Vercel
@@ -49,11 +50,12 @@ The nightly GitHub Actions pipeline runs all three layers sequentially, then tri
 
 ## Data model
 
-The gold layer follows **Kimball dimensional modelling**. Three fact tables cover three business processes:
+The gold layer follows **Kimball dimensional modelling**. Four fact tables cover four business processes:
 
 - **`fct_team_matches`** — one row per team per match (each fixture produces two rows, one per side); team-level stats, results, and tactical data
 - **`fct_player_appearances`** — one row per player per match; individual performance stats and ratings
 - **`fct_match_discussions`** — one row per match per persona; LLM-generated fan discussion comments (via Groq) powering the Fan Forum on the Match Analysis page
+- **`fct_team_transfers`** — one row per club per transfer; incoming/outgoing moves with fee, type, status, counterparty, and player, powering the Transfer Intelligence page
 
 ```mermaid
 erDiagram
@@ -343,6 +345,7 @@ All dimension surrogate keys are **stable across runs** — new records get new 
 | **Referee Intelligence** | Cards and fouls by referee, strictness rankings, and per-match discipline logs |
 | **Stadium Intelligence** | Interactive stadium map, fortress rankings, and home-advantage stats |
 | **Player Intelligence** | League top-player podium by any measure, individual player deep dive with profile, characteristics radar, performance timeline, and match log |
+| **Transfer Intelligence** | Club transfer market: spend KPIs, record signing & sale, net spend (spent/received/net) and transfer flows by team, market trend over time, and a searchable transfer ledger — filterable by year and transfer window |
 | **About** | Project background, stack overview, and the full build journey |
 | **Data Glossary** | Definitions of all metrics and KPIs used across the dashboard |
 

--- a/dashboards/pages/glossary.md
+++ b/dashboards/pages/glossary.md
@@ -234,6 +234,23 @@ Unlike the team radar which uses per-match averages, player scores are calculate
 
 ---
 
+## Transfers
+
+<div class="divide-y divide-gray-100 rounded-xl border border-gray-200 overflow-hidden">
+  <div class="p-3"><div class="font-semibold text-sm">Transfer Window</div><div class="text-sm text-gray-500 mt-0.5">The registration period a transfer falls in, derived from its month: <strong>Summer Window</strong> (Jun–Sep), <strong>Winter Window</strong> (Dec–Feb), and <strong>Outside Window</strong> for any other month (free agents, loan returns, and contract terminations that can occur year-round).</div></div>
+  <div class="p-3"><div class="font-semibold text-sm">Deals</div><div class="text-sm text-gray-500 mt-0.5">Count of distinct transfers matching the current filters, regardless of whether a fee was disclosed</div></div>
+  <div class="p-3"><div class="font-semibold text-sm">Fee Disclosed Deals</div><div class="text-sm text-gray-500 mt-0.5">Transfers with a reported fee greater than zero. Many moves (free transfers, loans, undisclosed deals) carry no published fee.</div><div class="text-xs text-gray-400 mt-0.5">Count of deals where fee > 0</div></div>
+  <div class="p-3"><div class="font-semibold text-sm">Total Deal Amount</div><div class="text-sm text-gray-500 mt-0.5">Sum of all disclosed transfer fees, in millions of euros (€m)</div><div class="text-xs text-gray-400 mt-0.5">Σ disclosed fees ÷ 1,000,000</div></div>
+  <div class="p-3"><div class="font-semibold text-sm">Avg Deal Amount</div><div class="text-sm text-gray-500 mt-0.5">Average disclosed fee across fee-disclosed deals, in €m</div><div class="text-xs text-gray-400 mt-0.5">Total Deal Amount ÷ Fee Disclosed Deals</div></div>
+  <div class="p-3"><div class="font-semibold text-sm">Spent</div><div class="text-sm text-gray-500 mt-0.5">Fees a club paid on incoming moves — money spent acquiring players</div><div class="text-xs text-gray-400 mt-0.5">Σ fees on Incoming transfers</div></div>
+  <div class="p-3"><div class="font-semibold text-sm">Received</div><div class="text-sm text-gray-500 mt-0.5">Fees a club collected on outgoing moves — money received selling players</div><div class="text-xs text-gray-400 mt-0.5">Σ fees on Outgoing transfers</div></div>
+  <div class="p-3"><div class="font-semibold text-sm">Net Spend</div><div class="text-sm text-gray-500 mt-0.5">A club's transfer balance. Positive = net investment (bought more than sold); negative = net sales.</div><div class="text-xs text-gray-400 mt-0.5">Spent − Received</div></div>
+  <div class="p-3"><div class="font-semibold text-sm">Transfer Volume</div><div class="text-sm text-gray-500 mt-0.5">Total fees moving through a club in both directions — used to rank the busiest clubs by money. Distinct from deal count.</div><div class="text-xs text-gray-400 mt-0.5">Spent + Received</div></div>
+  <div class="p-3"><div class="font-semibold text-sm">Direction</div><div class="text-sm text-gray-500 mt-0.5">Whether a transfer is <strong>Incoming</strong> (player joining the club) or <strong>Outgoing</strong> (player leaving)</div></div>
+</div>
+
+---
+
 ## Competition Format
 
 <div class="divide-y divide-gray-100 rounded-xl border border-gray-200 overflow-hidden">

--- a/dashboards/pages/transfer-intelligence.md
+++ b/dashboards/pages/transfer-intelligence.md
@@ -34,6 +34,16 @@ select transfer_window from (
 ) order by ord
 ```
 
+```sql current_window
+-- Window today's (build-time) date falls in; mirrors the transfer_window logic
+-- in mart_club_transfer_log so the dropdown can default to the live window.
+select case
+  when month(current_date) in (6, 7, 8, 9) then 'Summer Window'
+  when month(current_date) in (12, 1, 2)   then 'Winter Window'
+  else 'Outside Window'
+end as transfer_window
+```
+
 ```sql teams
 select club from (
   select 'All Teams' as club, 0 as ord
@@ -199,12 +209,14 @@ order by (fee_eur is null), fee_eur desc, transfer_date desc
   {#key years[0]?.transfer_year}
   <Dropdown data={years} name=year value=transfer_year order="transfer_year desc" defaultValue={years[0]?.transfer_year} title="Year" />
   {/key}
-  <Dropdown data={windows} name=window value=transfer_window multiple=true selectAllByDefault=true title="Transfer Window" />
+  <Dropdown data={windows} name=window value=transfer_window multiple=true defaultValue={[current_window[0]?.transfer_window]} title="Transfer Window" />
   <Dropdown data={teams} name=team value=club multiple=true defaultValue={['All Teams']} title="Team" />
   <Dropdown data={directions} name=direction value=direction multiple=true selectAllByDefault=true title="Direction" />
   <Dropdown data={types} name=type value=transfer_type multiple=true selectAllByDefault=true title="Type" />
   <Dropdown data={statuses} name=status value=transfer_status multiple=true selectAllByDefault=true title="Status" />
 </div>
+
+## Transfer Intelligence — {inputs.year.value} · {inputs.window.label}
 
 <div class="grid grid-cols-2 md:grid-cols-4 gap-3 my-5">
   <div class="rounded-xl border border-gray-200 bg-white shadow-sm p-4 flex flex-col">

--- a/dashboards/pages/transfer-intelligence.md
+++ b/dashboards/pages/transfer-intelligence.md
@@ -40,6 +40,18 @@ from superligaen.mart_club_transfer_log
 order by transfer_month
 ```
 
+```sql windows
+select transfer_window from (
+  select distinct transfer_window,
+    case transfer_window
+      when 'Summer Window' then 1
+      when 'Winter Window' then 2
+      else 3
+    end as ord
+  from superligaen.mart_club_transfer_log
+) order by ord
+```
+
 ```sql teams
 select club from (
   select 'All Teams' as club, 0 as ord
@@ -71,6 +83,7 @@ with base as (
     and direction in ${inputs.direction.value}
     and transfer_type in ${inputs.type.value}
     and transfer_status in ${inputs.status.value}
+    and transfer_window in ${inputs.window.value}
     and transfer_year in (${inputs.year.value}, ${inputs.year.value} - 1)
 ),
 curr as (
@@ -104,6 +117,7 @@ with f as (
     and direction in ${inputs.direction.value}
     and transfer_type in ${inputs.type.value}
     and transfer_status in ${inputs.status.value}
+    and transfer_window in ${inputs.window.value}
 ),
 agg as (
   select club,
@@ -134,6 +148,7 @@ where transfer_year = ${inputs.year.value}
   and direction in ${inputs.direction.value}
   and transfer_type in ${inputs.type.value}
   and transfer_status in ${inputs.status.value}
+  and transfer_window in ${inputs.window.value}
 group by club
 having count(*) > 0
 order by count(*) desc
@@ -150,6 +165,7 @@ with base as (
     and direction in ${inputs.direction.value}
     and transfer_type in ${inputs.type.value}
     and transfer_status in ${inputs.status.value}
+    and transfer_window in ${inputs.window.value}
 )
 select cast(transfer_year as integer)::varchar as transfer_year,
   count(*)                     as transfers,
@@ -169,6 +185,7 @@ where direction = 'Incoming' and fee_eur > 0
   and direction in ${inputs.direction.value}
   and transfer_type in ${inputs.type.value}
   and transfer_status in ${inputs.status.value}
+  and transfer_window in ${inputs.window.value}
 order by fee_eur desc
 limit 1
 ```
@@ -185,6 +202,7 @@ where direction = 'Outgoing' and fee_eur > 0
   and direction in ${inputs.direction.value}
   and transfer_type in ${inputs.type.value}
   and transfer_status in ${inputs.status.value}
+  and transfer_window in ${inputs.window.value}
 order by fee_eur desc
 limit 1
 ```
@@ -200,6 +218,7 @@ where transfer_year = ${inputs.year.value}
   and direction in ${inputs.direction.value}
   and transfer_type in ${inputs.type.value}
   and transfer_status in ${inputs.status.value}
+  and transfer_window in ${inputs.window.value}
 order by (fee_eur is null), fee_eur desc, transfer_date desc
 ```
 
@@ -207,6 +226,7 @@ order by (fee_eur is null), fee_eur desc, transfer_date desc
   {#key years[0]?.transfer_year}
   <Dropdown data={years} name=year value=transfer_year order="transfer_year desc" defaultValue={years[0]?.transfer_year} title="Year" />
   {/key}
+  <Dropdown data={windows} name=window value=transfer_window multiple=true selectAllByDefault=true title="Transfer Window" />
   <Dropdown data={months} name=month value=transfer_month label=transfer_month_name multiple=true selectAllByDefault=true order="transfer_month asc" title="Month" />
   <Dropdown data={teams} name=team value=club multiple=true defaultValue={['All Teams']} title="Team" />
   <Dropdown data={directions} name=direction value=direction multiple=true selectAllByDefault=true title="Direction" />
@@ -240,7 +260,7 @@ order by (fee_eur is null), fee_eur desc, transfer_date desc
     </div>
   </div>
   <div class="rounded-xl border border-gray-200 bg-white shadow-sm p-4 flex flex-col">
-    <div class="text-gray-400 text-xs uppercase tracking-wide text-center">Paid Deals</div>
+    <div class="text-gray-400 text-xs uppercase tracking-wide text-center">Fee Disclosed Deals</div>
     <div class="text-3xl font-black text-gray-900 leading-none mt-2 text-center">{kpi[0]?.paid}</div>
     <div class="flex justify-between items-center mt-3">
       <span class="text-[11px] text-gray-400">Prev: {kpi[0]?.prev_paid ?? '—'}</span>
@@ -299,9 +319,8 @@ order by (fee_eur is null), fee_eur desc, transfer_date desc
     x=club
     y={['incoming','outgoing']}
     title="Incoming vs Outgoing"
-    type=grouped
+    type=stacked
     colorPalette={['#16a34a','#f97316']}
-    seriesOptions={{"barGap": "0%"}}
     sort=false
     echartsOptions={{xAxis: {axisLabel: {formatter: shortLabel}}}}
 />

--- a/dashboards/pages/transfer-intelligence.md
+++ b/dashboards/pages/transfer-intelligence.md
@@ -348,7 +348,7 @@ order by (fee_eur is null), fee_eur desc, transfer_date desc
     <Column id=player_name     title="Player" />
     <Column id=player_age      title="Age" align=center />
     <Column id=position        title="Pos" align=center />
-    <Column id=partner         title="Counterparty" />
+    <Column id=partner         title="Transfer Partner" />
     <Column id=fee_m           title="Fee" fmt='"€"0.0"m"' align=right contentType=colorscale colorPalette={['white','#236aa4']} />
 </DataTable>
 

--- a/dashboards/pages/transfer-intelligence.md
+++ b/dashboards/pages/transfer-intelligence.md
@@ -22,12 +22,6 @@ from superligaen.mart_club_transfer_log
 order by is_current desc, transfer_year desc
 ```
 
-```sql months
-select distinct cast(transfer_month as integer) as transfer_month, transfer_month_name
-from superligaen.mart_club_transfer_log
-order by transfer_month
-```
-
 ```sql windows
 select transfer_window from (
   select distinct transfer_window,
@@ -66,8 +60,7 @@ select distinct transfer_status from superligaen.mart_club_transfer_log order by
 with base as (
   select distinct transfer_id, transfer_year, fee_eur
   from superligaen.mart_club_transfer_log
-  where transfer_month in ${inputs.month.value}
-    and ('All Teams' in ${inputs.team.value} or club in ${inputs.team.value})
+  where ('All Teams' in ${inputs.team.value} or club in ${inputs.team.value})
     and direction in ${inputs.direction.value}
     and transfer_type in ${inputs.type.value}
     and transfer_status in ${inputs.status.value}
@@ -100,7 +93,6 @@ from curr cross join prev
 with f as (
   select * from superligaen.mart_club_transfer_log
   where transfer_year = ${inputs.year.value}
-    and transfer_month in ${inputs.month.value}
     and ('All Teams' in ${inputs.team.value} or club in ${inputs.team.value})
     and direction in ${inputs.direction.value}
     and transfer_type in ${inputs.type.value}
@@ -129,7 +121,6 @@ select club,
   count(*) filter (where direction = 'Outgoing') as outgoing
 from superligaen.mart_club_transfer_log
 where transfer_year = ${inputs.year.value}
-  and transfer_month in ${inputs.month.value}
   and ('All Teams' in ${inputs.team.value} or club in ${inputs.team.value})
   and direction in ${inputs.direction.value}
   and transfer_type in ${inputs.type.value}
@@ -146,8 +137,7 @@ limit 8
 with base as (
   select distinct transfer_id, transfer_year, fee_eur
   from superligaen.mart_club_transfer_log
-  where transfer_month in ${inputs.month.value}
-    and ('All Teams' in ${inputs.team.value} or club in ${inputs.team.value})
+  where ('All Teams' in ${inputs.team.value} or club in ${inputs.team.value})
     and direction in ${inputs.direction.value}
     and transfer_type in ${inputs.type.value}
     and transfer_status in ${inputs.status.value}
@@ -166,7 +156,6 @@ select player_name, player_photo, club, partner,
 from superligaen.mart_club_transfer_log
 where direction = 'Incoming' and fee_eur > 0
   and transfer_year = ${inputs.year.value}
-  and transfer_month in ${inputs.month.value}
   and ('All Teams' in ${inputs.team.value} or club in ${inputs.team.value})
   and direction in ${inputs.direction.value}
   and transfer_type in ${inputs.type.value}
@@ -183,7 +172,6 @@ select player_name, player_photo, club, partner,
 from superligaen.mart_club_transfer_log
 where direction = 'Outgoing' and fee_eur > 0
   and transfer_year = ${inputs.year.value}
-  and transfer_month in ${inputs.month.value}
   and ('All Teams' in ${inputs.team.value} or club in ${inputs.team.value})
   and direction in ${inputs.direction.value}
   and transfer_type in ${inputs.type.value}
@@ -194,12 +182,11 @@ limit 1
 ```
 
 ```sql ledger
-select transfer_date, transfer_month_name, club, direction, transfer_type, transfer_status,
+select transfer_date, club, direction, transfer_type, transfer_status,
   player_name, player_age, position, partner, partner_country,
   case when fee_eur is null then null else round(fee_eur / 1e6, 2) end as fee_m
 from superligaen.mart_club_transfer_log
 where transfer_year = ${inputs.year.value}
-  and transfer_month in ${inputs.month.value}
   and ('All Teams' in ${inputs.team.value} or club in ${inputs.team.value})
   and direction in ${inputs.direction.value}
   and transfer_type in ${inputs.type.value}
@@ -213,7 +200,6 @@ order by (fee_eur is null), fee_eur desc, transfer_date desc
   <Dropdown data={years} name=year value=transfer_year order="transfer_year desc" defaultValue={years[0]?.transfer_year} title="Year" />
   {/key}
   <Dropdown data={windows} name=window value=transfer_window multiple=true selectAllByDefault=true title="Transfer Window" />
-  <Dropdown data={months} name=month value=transfer_month label=transfer_month_name multiple=true selectAllByDefault=true order="transfer_month asc" title="Month" />
   <Dropdown data={teams} name=team value=club multiple=true defaultValue={['All Teams']} title="Team" />
   <Dropdown data={directions} name=direction value=direction multiple=true selectAllByDefault=true title="Direction" />
   <Dropdown data={types} name=type value=transfer_type multiple=true selectAllByDefault=true title="Type" />
@@ -343,7 +329,6 @@ order by (fee_eur is null), fee_eur desc, transfer_date desc
 
 <DataTable data={ledger} rows=15 search=true>
     <Column id=transfer_date   title="Date" />
-    <Column id=transfer_month_name title="Month" align=center />
     <Column id=club            title="Club" />
     <Column id=direction       title="Direction" align=center />
     <Column id=transfer_type   title="Type" />

--- a/dashboards/pages/transfer-intelligence.md
+++ b/dashboards/pages/transfer-intelligence.md
@@ -9,18 +9,6 @@ title: Transfer Intelligence
   let nameToCode = {};
   $: nameToCode = Object.fromEntries((team_lookup ?? []).map(r => [r.club, r.club_code]));
   $: shortLabel = (name) => nameToCode[name] ?? name;
-
-  // Net Spend tooltip: full club name + net / spent / received
-  $: clubFin = Object.fromEntries((by_club ?? []).map(r => [r.club, r]));
-  $: netSpendTip = (params) => {
-    const name = (Array.isArray(params) ? params[0] : params).axisValue;
-    const r = clubFin[name];
-    if (!r) return name;
-    return `<strong>${name}</strong>`
-      + `<br/>Net spend: €${r.net_spend_m}m`
-      + `<br/>Spent: €${r.spend_m}m`
-      + `<br/>Received: €${r.income_m}m`;
-  };
 </script>
 
 ```sql team_lookup
@@ -129,11 +117,9 @@ agg as (
 )
 select club,
   round(net_raw / 1e6, 2) as net_spend_m,
-  case when net_raw >= 0 then round(net_raw / 1e6, 2) end as net_buy,
-  case when net_raw <  0 then round(net_raw / 1e6, 2) end as net_sell,
   spend_m, income_m
 from agg
-order by abs(net_raw) desc
+order by (spend_m + income_m) desc, abs(net_raw) desc
 limit 8
 ```
 
@@ -294,21 +280,21 @@ order by (fee_eur is null), fee_eur desc, transfer_date desc
 
 ## Net Spend by Team
 
-<p style="font-size:0.75rem;color:#6b7280;margin:0 0 1rem 0;font-style:italic;">Fees paid on incoming moves minus fees received on outgoing moves — the 8 biggest net movers (largest balance either way). <span style="color:#16a34a;font-weight:600;">Green = net investment</span>, <span style="color:#f97316;font-weight:600;">orange = net sales</span>.</p>
+<p style="font-size:0.75rem;color:#6b7280;margin:0 0 1rem 0;font-style:italic;">Fees <span style="color:#16a34a;font-weight:600;">spent</span> on incoming moves vs <span style="color:#f97316;font-weight:600;">received</span> on outgoing moves, with the resulting <span style="color:#236aa4;font-weight:600;">net spend</span> — the 8 clubs with the highest transfer volume (total fees in + out).</p>
 
-<BarChart
+<Chart
     data={by_club}
     x=club
-    y={['net_buy','net_sell']}
-    type=stacked
-    yFmt='#,##0.00'
-    title="Net Spend (€m)"
+    yFmt='"€"#,##0.00"m"'
+    title="Spent vs Received vs Net (€m)"
     yAxisTitle="€m"
     sort=false
-    legend=false
-    colorPalette={['#16a34a','#f97316']}
-    echartsOptions={{xAxis: {axisLabel: {formatter: shortLabel}}, tooltip: {formatter: netSpendTip}}}
-/>
+    echartsOptions={{xAxis: {axisLabel: {formatter: shortLabel}}}}
+>
+    <Bar y=spend_m name="Spent" fillColor="#16a34a" />
+    <Bar y=income_m name="Received" fillColor="#f97316" />
+    <Scatter y=net_spend_m name="Net Spend" fillColor="#236aa4" pointSize={11} />
+</Chart>
 
 ## Transfers by Team
 

--- a/dashboards/pages/transfer-intelligence.md
+++ b/dashboards/pages/transfer-intelligence.md
@@ -34,16 +34,6 @@ select transfer_window from (
 ) order by ord
 ```
 
-```sql current_window
--- Window today's (build-time) date falls in; mirrors the transfer_window logic
--- in mart_club_transfer_log so the dropdown can default to the live window.
-select case
-  when month(current_date) in (6, 7, 8, 9) then 'Summer Window'
-  when month(current_date) in (12, 1, 2)   then 'Winter Window'
-  else 'Outside Window'
-end as transfer_window
-```
-
 ```sql teams
 select club from (
   select 'All Teams' as club, 0 as ord
@@ -209,14 +199,14 @@ order by (fee_eur is null), fee_eur desc, transfer_date desc
   {#key years[0]?.transfer_year}
   <Dropdown data={years} name=year value=transfer_year order="transfer_year desc" defaultValue={years[0]?.transfer_year} title="Year" />
   {/key}
-  <Dropdown data={windows} name=window value=transfer_window multiple=true defaultValue={[current_window[0]?.transfer_window]} title="Transfer Window" />
+  <Dropdown data={windows} name=window value=transfer_window multiple=true selectAllByDefault=true title="Transfer Window" />
   <Dropdown data={teams} name=team value=club multiple=true defaultValue={['All Teams']} title="Team" />
   <Dropdown data={directions} name=direction value=direction multiple=true selectAllByDefault=true title="Direction" />
   <Dropdown data={types} name=type value=transfer_type multiple=true selectAllByDefault=true title="Type" />
   <Dropdown data={statuses} name=status value=transfer_status multiple=true selectAllByDefault=true title="Status" />
 </div>
 
-## Transfer Intelligence — {inputs.year.value} · {inputs.window.label}
+## Transfer Intelligence — {inputs.year.value}
 
 <div class="grid grid-cols-2 md:grid-cols-4 gap-3 my-5">
   <div class="rounded-xl border border-gray-200 bg-white shadow-sm p-4 flex flex-col">

--- a/dashboards/sources/superligaen/transfer-intelligence/mart_club_transfer_log.sql
+++ b/dashboards/sources/superligaen/transfer-intelligence/mart_club_transfer_log.sql
@@ -14,6 +14,13 @@ SELECT
     d.year       AS transfer_year,
     d.month      AS transfer_month,
     d.month_name AS transfer_month_name,
+    -- Derived football transfer window: summer (Jun–Sep) and winter (Dec–Feb)
+    -- registration periods; everything else is outside the windows.
+    CASE
+        WHEN d.month IN (6, 7, 8, 9) THEN 'Summer Window'
+        WHEN d.month IN (12, 1, 2)   THEN 'Winter Window'
+        ELSE 'Outside Window'
+    END AS transfer_window,
     d.date       AS transfer_date,
     t.team_name  AS club,
     t.team_code  AS club_code,


### PR DESCRIPTION
Closes #358.

Reworks the **Transfer Intelligence** page per the issue and follow-up requests, and brings the docs (glossary + README data model) in line.

## Dashboard changes
- **Transfers by Team** → stacked bars, so the busiest team shows the single tallest bar (issue #358).
- **Net Spend by Team** → combo chart showing **Spent** & **Received** as grouped bars plus **Net Spend** as standalone dots; sorted by monetary volume (total fees in + out). Colors match the Transfers chart (green = incoming/spent, orange = outgoing/received), Net in blue.
- New **Transfer Window** filter (derived Summer / Winter / Outside), all selected by default.
- Removed the **Month** filter and the ledger's Month column to cut filter-bar clutter.
- Renamed **Paid Deals** KPI → **Fee Disclosed Deals**.
- Added a live **Transfer Intelligence — {year}** heading above the KPI cards (matching the league page).
- Renamed the ledger's **Counterparty** column → **Transfer Partner** (matches `dim_transfer_partner_team`).

## Docs
- New **Transfers** section in the Data Glossary (Transfer Window, Spent, Received, Net Spend, Transfer Volume, Fee Disclosed Deals, …).
- README: documented the Transfer Intelligence page, added `fct_team_transfers` as the fourth gold fact (prose, pipeline diagram, **ER diagram**, and **bus matrix**).

## Notes
- The derived `transfer_window` column was added to the `mart_club_transfer_log` Evidence source; a deploy/rebuild of the parquet is needed for the published site.
- Verified locally against MotherDuck prod data via the Evidence dev server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)