### PR TITLE
feat(dashboards): "About this project" top-right menu

### DIFF
--- a/dashboards/components/ProjectMenu.svelte
+++ b/dashboards/components/ProjectMenu.svelte
@@ -1,0 +1,55 @@
+<script>
+  // "About this project" overflow menu, mirrored top-right against the logo.
+  // Aligned to Evidence's header container (max-w-7xl + matching padding) so it
+  // sits exactly where the built-in kebab did, symmetric with the logo.
+  import { fly } from 'svelte/transition';
+  let open = false;
+  const close = () => (open = false);
+  const toggle = () => (open = !open);
+  function onKey(e) {
+    if (e.key === 'Escape') close();
+  }
+</script>
+
+<svelte:window on:keydown={onKey} />
+
+<div class="pointer-events-none fixed top-0 left-0 z-50 h-12 w-full">
+  <div class="mx-auto flex h-full max-w-7xl items-center justify-end px-5 sm:px-6 md:px-12">
+    <div class="pointer-events-auto relative">
+      <button
+        type="button"
+        aria-label="About this project"
+        aria-haspopup="true"
+        aria-expanded={open}
+        class="rounded-lg p-2 text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-300"
+        on:click|stopPropagation={toggle}
+      >
+        <svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+          <circle cx="4" cy="10" r="1.6" />
+          <circle cx="10" cy="10" r="1.6" />
+          <circle cx="16" cy="10" r="1.6" />
+        </svg>
+      </button>
+
+      {#if open}
+        <!-- click-away backdrop -->
+        <button class="pointer-events-auto fixed inset-0 z-40 cursor-default focus:outline-none" aria-label="Close menu" tabindex="-1" on:click={close}></button>
+
+        <div
+          class="pointer-events-auto absolute right-0 top-11 z-50 w-60 overflow-hidden rounded-xl border border-gray-200 bg-white py-1.5 text-sm shadow-lg"
+          transition:fly={{ y: -4, duration: 130 }}
+        >
+          <a href="https://saugki1773.github.io/data-engineering-blog" target="_blank" rel="noreferrer" class="flex items-center justify-between px-4 py-2 text-gray-700 no-underline hover:bg-gray-50" on:click={close}>
+            Data Engineer's Diary <span class="text-xs text-gray-300">↗</span>
+          </a>
+          <a href="https://github.com/SaUgKi1773/data-engineering-demo" target="_blank" rel="noreferrer" class="flex items-center justify-between px-4 py-2 text-gray-700 no-underline hover:bg-gray-50" on:click={close}>
+            Source Code on GitHub <span class="text-xs text-gray-300">↗</span>
+          </a>
+          <div class="my-1 border-t border-gray-100"></div>
+          <a href="/glossary" class="block px-4 py-2 text-gray-700 no-underline hover:bg-gray-50" on:click={close}>Data Glossary</a>
+          <a href="/about" class="block px-4 py-2 text-gray-700 no-underline hover:bg-gray-50" on:click={close}>About This Project</a>
+        </div>
+      {/if}
+    </div>
+  </div>
+</div>

--- a/dashboards/evidence.config.yaml
+++ b/dashboards/evidence.config.yaml
@@ -1,6 +1,6 @@
 appearance:
   default: light
-  switcher: true
+  switcher: false
 
 theme:
   colorPalettes:

--- a/dashboards/pages/+layout.svelte
+++ b/dashboards/pages/+layout.svelte
@@ -14,6 +14,7 @@
   import { afterNavigate } from '$app/navigation';
   import { inject } from '@vercel/analytics';
   import InstallBanner from '../components/InstallBanner.svelte';
+  import ProjectMenu from '../components/ProjectMenu.svelte';
 
   export let data;
 
@@ -35,18 +36,16 @@
   <slot slot="content" />
 </EvidenceDefaultLayout>
 
+<ProjectMenu />
+
 <InstallBanner />
 
 <style>
   :global(header img[alt="Home"]) {
     height: 2.5rem;
   }
-  /* Header kebab: keep only the Appearance option */
-  :global(.w-52 [role="group"]:first-of-type [role="menuitem"]:not(:last-of-type)) {
-    display: none;
-  }
-  :global(.w-52 [role="separator"]),
-  :global(.w-52 [role="group"]:not(:first-of-type)) {
+  /* Hide Evidence's built-in kebab; replaced by the custom ProjectMenu */
+  :global(header button[aria-label="Menu"]) {
     display: none;
   }
   :global(.standings-table table) {


### PR DESCRIPTION
Replaces Evidence's built-in kebab with a custom **"About this project"** overflow menu in the top-right — restoring the logo-left / dots-right symmetry without exposing appearance or other settings.

## What it does
- New `components/ProjectMenu.svelte`: a three-dot dropdown with
  - **Data Engineer's Diary ↗** — the build blog
  - **Source Code on GitHub ↗** — the repo
  - **Data Glossary** — /glossary
  - **About This Project** — /about
- Aligned to the header's `max-w-7xl` container so the dots sit exactly where the kebab used to (symmetric with the logo), not at the screen edge.
- Fly-in animation, click-away + Escape to close, keyboard-only focus ring, divider between external (↗) and in-app links.

## Also
- Hide Evidence's built-in kebab (`button[aria-label="Menu"]`) in `+layout.svelte`.
- Turn the appearance switcher back **off** in `evidence.config.yaml` (no theme/settings exposed to users).

🤖 Generated with [Claude Code](https://claude.com/claude-code)