### PR TITLE
feat(marts): scope every dashboard mart to a single league

### DIFF
--- a/dashboards/sources/superligaen/home/mart_home_summary.sql
+++ b/dashboards/sources/superligaen/home/mart_home_summary.sql
@@ -22,6 +22,7 @@ WITH matches AS (
     JOIN superligaen.gold.dim_team           t  ON t.team_sk         = f.team_sk
     JOIN superligaen.gold.dim_match_result   r  ON r.match_result_sk = f.match_result_sk
     WHERE r.match_result IN ('Win', 'Draw', 'Loss')
+      AND f.league_sk = (SELECT league_sk FROM superligaen.gold.dim_league WHERE league_id = 271)  -- Superliga only
 ),
 latest_season AS (
     SELECT MAX(season) AS season FROM matches

--- a/dashboards/sources/superligaen/league-analytics/mart_match_facts.sql
+++ b/dashboards/sources/superligaen/league-analytics/mart_match_facts.sql
@@ -187,3 +187,4 @@ LEFT JOIN player_agg                     pa  ON pa.match_sk         = f.match_sk
                                            AND pa.team_sk           = f.team_sk
 WHERE d.season >= '2020/21'
   AND r.match_result IN ('Win', 'Draw', 'Loss')
+  AND f.league_sk = (SELECT league_sk FROM superligaen.gold.dim_league WHERE league_id = 271)  -- Superliga only

--- a/dashboards/sources/superligaen/league-analytics/mart_player_facts.sql
+++ b/dashboards/sources/superligaen/league-analytics/mart_player_facts.sql
@@ -128,3 +128,4 @@ JOIN superligaen.gold.dim_coach               dc     ON dc.coach_sk             
 JOIN superligaen.gold.dim_time                dt     ON dt.time_sk                = f.time_sk
 WHERE d.season >= '2020/21'
   AND r.match_result IN ('Win', 'Draw', 'Loss')
+  AND f.league_sk = (SELECT league_sk FROM superligaen.gold.dim_league WHERE league_id = 271)  -- Superliga only

--- a/dashboards/sources/superligaen/match-results/llm_round_discussions.sql
+++ b/dashboards/sources/superligaen/match-results/llm_round_discussions.sql
@@ -17,4 +17,5 @@ from superligaen.gold.fct_match_discussions f
 join superligaen.gold.dim_match             dm on dm.match_sk   = f.match_sk
 join superligaen.gold.dim_persona           dp on dp.persona_sk = f.persona_sk
 join superligaen.gold.dim_date              dd on dd.date_sk    = f.date_sk
+where f.league_sk = (select league_sk from superligaen.gold.dim_league where league_id = 271)  -- Superliga only
 order by dd.date, dm.match_name, dp.sort_order

--- a/dashboards/sources/superligaen/match-results/mart_match_results.sql
+++ b/dashboards/sources/superligaen/match-results/mart_match_results.sql
@@ -63,6 +63,7 @@ base AS (
                                                AND pa.team_sk         = f.team_sk
     WHERE d.season >= '2020/21'
       AND r.match_result IN ('Win', 'Draw', 'Loss')
+      AND f.league_sk = (SELECT league_sk FROM superligaen.gold.dim_league WHERE league_id = 271)  -- Superliga only
 )
 SELECT
     match_id,

--- a/dashboards/sources/superligaen/match-results/mart_round_potw.sql
+++ b/dashboards/sources/superligaen/match-results/mart_round_potw.sql
@@ -19,6 +19,7 @@ WITH base AS (
     JOIN superligaen.gold.dim_position             dpos   ON dpos.position_sk        = f.position_sk
     WHERE d.season >= '2020/21'
       AND r.match_result IN ('Win', 'Draw', 'Loss')
+      AND f.league_sk = (SELECT league_sk FROM superligaen.gold.dim_league WHERE league_id = 271)  -- Superliga only
       AND f.rating IS NOT NULL
       AND f.minutes_played >= 30
 ),

--- a/dashboards/sources/superligaen/player-analytics/mart_player_season.sql
+++ b/dashboards/sources/superligaen/player-analytics/mart_player_season.sql
@@ -86,6 +86,7 @@ WITH base AS (
     JOIN superligaen.gold.dim_position             dpos   ON dpos.position_sk        = f.position_sk
     WHERE d.season >= '2020/21'
       AND r.match_result IN ('Win', 'Draw', 'Loss')
+      AND f.league_sk = (SELECT league_sk FROM superligaen.gold.dim_league WHERE league_id = 271)  -- Superliga only
     GROUP BY
         d.season,
         p.player_name,

--- a/dashboards/sources/superligaen/referee-analytics/mart_referee_season.sql
+++ b/dashboards/sources/superligaen/referee-analytics/mart_referee_season.sql
@@ -30,5 +30,6 @@ LEFT JOIN fouls_agg                       fa  ON fa.match_sk       = f.match_sk
                                             AND fa.team_sk         = f.team_sk
 WHERE d.season >= '2020/21'
   AND r.match_result IN ('Win', 'Draw', 'Loss')
+  AND f.league_sk = (SELECT league_sk FROM superligaen.gold.dim_league WHERE league_id = 271)  -- Superliga only
 GROUP BY d.season, ref.referee_common_name
 ORDER BY d.season DESC, matches_managed DESC

--- a/dashboards/sources/superligaen/shared/mart_match_card.sql
+++ b/dashboards/sources/superligaen/shared/mart_match_card.sql
@@ -58,6 +58,7 @@ base AS (
     LEFT JOIN player_agg                     pa  ON pa.match_sk     = f.match_sk
                                                AND pa.team_sk       = f.team_sk
     WHERE d.season >= '2020/21'
+      AND f.league_sk = (SELECT league_sk FROM superligaen.gold.dim_league WHERE league_id = 271)  -- Superliga only
 )
 SELECT
     match_id,

--- a/dashboards/sources/superligaen/shared/mart_match_lineup.sql
+++ b/dashboards/sources/superligaen/shared/mart_match_lineup.sql
@@ -88,3 +88,4 @@ JOIN superligaen.gold.dim_formation            df     ON df.formation_sk        
 JOIN superligaen.gold.dim_position             dpos   ON dpos.position_sk        = f.position_sk
 WHERE d.season >= '2020/21'
   AND at_dim.appearance_type IN ('Starter', 'Substitute')
+  AND f.league_sk = (SELECT league_sk FROM superligaen.gold.dim_league WHERE league_id = 271)  -- Superliga only

--- a/dashboards/sources/superligaen/shared/mart_team_match.sql
+++ b/dashboards/sources/superligaen/shared/mart_team_match.sql
@@ -57,5 +57,6 @@ per_match AS (
                                                AND pa.team_sk            = f.team_sk
     WHERE d.season >= '2020/21'
       AND r.match_result IN ('Win', 'Draw', 'Loss')
+      AND f.league_sk = (SELECT league_sk FROM superligaen.gold.dim_league WHERE league_id = 271)  -- Superliga only
 )
 SELECT * FROM per_match

--- a/dashboards/sources/superligaen/stadium-analytics/mart_stadium_season.sql
+++ b/dashboards/sources/superligaen/stadium-analytics/mart_stadium_season.sql
@@ -71,6 +71,7 @@ LEFT JOIN (
                                                AND fouls.team_sk   = f.team_sk
 WHERE d.season >= '2020/21'
   AND r.match_result IN ('Win', 'Draw', 'Loss')
+  AND f.league_sk = (SELECT league_sk FROM superligaen.gold.dim_league WHERE league_id = 271)  -- Superliga only
   AND st.stadium_latitude  BETWEEN 54.5 AND 57.8
   AND st.stadium_longitude BETWEEN 7.5  AND 15.5
   AND st.stadium_name NOT LIKE '%Unknown%'

--- a/dashboards/sources/superligaen/stadium-analytics/mart_surface_season.sql
+++ b/dashboards/sources/superligaen/stadium-analytics/mart_surface_season.sql
@@ -47,6 +47,7 @@ LEFT JOIN fouls_agg                      fouls ON fouls.match_sk  = f.match_sk
                                                AND fouls.team_sk  = f.team_sk
 WHERE d.season >= '2020/21'
   AND r.match_result IN ('Win', 'Draw', 'Loss')
+  AND f.league_sk = (SELECT league_sk FROM superligaen.gold.dim_league WHERE league_id = 271)  -- Superliga only
   AND st.stadium_surface IS NOT NULL AND st.stadium_surface != ''
   AND st.stadium_latitude  BETWEEN 54.5 AND 57.8
   AND st.stadium_longitude BETWEEN 7.5  AND 15.5

--- a/dashboards/sources/superligaen/standings/mart_standings.sql
+++ b/dashboards/sources/superligaen/standings/mart_standings.sql
@@ -25,3 +25,4 @@ JOIN superligaen.gold.dim_team           t  ON t.team_sk         = f.team_sk
 JOIN superligaen.gold.dim_match_result   r  ON r.match_result_sk = f.match_result_sk
 WHERE d.season >= '2020/21'
   AND r.match_result IN ('Win', 'Draw', 'Loss')
+  AND f.league_sk = (SELECT league_sk FROM superligaen.gold.dim_league WHERE league_id = 271)  -- Superliga only

--- a/dashboards/sources/superligaen/team-analytics/mart_team_season.sql
+++ b/dashboards/sources/superligaen/team-analytics/mart_team_season.sql
@@ -50,6 +50,7 @@ per_match AS (
                                                AND pa.team_sk          = f.team_sk
     WHERE d.season >= '2020/21'
       AND r.match_result IN ('Win', 'Draw', 'Loss')
+      AND f.league_sk = (SELECT league_sk FROM superligaen.gold.dim_league WHERE league_id = 271)  -- Superliga only
 ),
 season_agg AS (
     SELECT
@@ -126,6 +127,7 @@ avg_age_calc AS (
         FROM superligaen.gold.fct_player_appearances f
         JOIN superligaen.gold.dim_match_result r ON r.match_result_sk = f.match_result_sk
         WHERE r.match_result IN ('Win', 'Draw', 'Loss')
+          AND f.league_sk = (SELECT league_sk FROM superligaen.gold.dim_league WHERE league_id = 271)  -- Superliga only
     ) f
     JOIN superligaen.gold.dim_date   d ON d.date_sk   = f.date_sk
     JOIN superligaen.gold.dim_player p ON p.player_sk = f.player_sk

--- a/dashboards/sources/superligaen/transfer-intelligence/mart_club_transfer_log.sql
+++ b/dashboards/sources/superligaen/transfer-intelligence/mart_club_transfer_log.sql
@@ -1,13 +1,17 @@
 -- Single source for the Transfer Intelligence page: row-level transfer log from
 -- the perspective of each league club. One row per (transfer, league club),
 -- included only for years the club actually played a league match (a
--- fct_team_matches record in that calendar year). Every KPI / chart / table
--- aggregates from this, so all filters affect everything.
+-- fct_team_matches record in that calendar year). A transfer is not bound to a
+-- league, so we scope by the club's league participation rather than tagging the
+-- transfer fact. Every KPI / chart / table aggregates from this, so all filters
+-- affect everything.
 WITH team_match_years AS (
     SELECT DISTINCT m.team_sk, dd.year AS match_year
     FROM superligaen.gold.fct_team_matches m
     JOIN superligaen.gold.dim_date dd ON dd.date_sk = m.date_sk
     WHERE m.team_sk > 0
+      -- fct_team_transfers has no league_sk; scope to clubs via their Superliga matches
+      AND m.league_sk = (SELECT league_sk FROM superligaen.gold.dim_league WHERE league_id = 271)
 )
 SELECT
     f.transfer_id,

--- a/dashboards/sources/superligaen/upcoming-matches/mart_upcoming.sql
+++ b/dashboards/sources/superligaen/upcoming-matches/mart_upcoming.sql
@@ -26,6 +26,7 @@ WITH base AS (
     JOIN superligaen.gold.dim_stadium       st  ON st.stadium_sk      = f.stadium_sk
     JOIN superligaen.gold.dim_referee       ref ON ref.referee_sk     = f.referee_sk
     WHERE r.match_result = 'Pending'
+      AND f.league_sk = (SELECT league_sk FROM superligaen.gold.dim_league WHERE league_id = 271)  -- Superliga only
     GROUP BY m.match_id, d.date, d.season, m.match_round_number, m.match_round_name,
              m.kick_off_time, st.stadium_name, ref.referee_common_name
 )

--- a/dbt/models/gold/_schema.yml
+++ b/dbt/models/gold/_schema.yml
@@ -35,6 +35,8 @@ models:
           - not_null:
               config:
                 where: "match_result_sk IN (1, 2, 3)"
+      - name: league_sk
+        tests: [not_null]
 
   - name: fct_match_discussions
     tests:
@@ -49,6 +51,8 @@ models:
       - name: date_sk
         tests: [not_null]
       - name: message
+        tests: [not_null]
+      - name: league_sk
         tests: [not_null]
 
   - name: fct_team_transfers
@@ -111,4 +115,6 @@ models:
               arguments:
                 values: [1, 2, -1, -2]
       - name: minutes_played
+        tests: [not_null]
+      - name: league_sk
         tests: [not_null]

--- a/dbt/models/gold/fct_match_discussions.sql
+++ b/dbt/models/gold/fct_match_discussions.sql
@@ -8,10 +8,14 @@ SELECT
     dm.match_sk,
     dp.persona_sk,
     (year(s.generated_at) * 10000 + month(s.generated_at) * 100 + day(s.generated_at))::INTEGER AS date_sk,
+    COALESCE(dl.league_sk, -1)               AS league_sk,
     s.message
 FROM {{ ref('llm_match_discussions') }}  s
 JOIN {{ ref('dim_match') }}              dm ON dm.match_id    = s.match_id
 JOIN {{ ref('dim_persona') }}            dp ON dp.persona_name = s.persona_name
+-- a discussion's league is the league of its match (resolved via fixtures)
+LEFT JOIN {{ ref('fixtures') }}          fx ON fx.id          = s.match_id
+LEFT JOIN {{ ref('dim_league') }}        dl ON dl.league_id   = fx.league_id
 {% if is_incremental() %}
 WHERE {{ gold_incremental_filter() }}
 {% endif %}


### PR DESCRIPTION
## What

Makes adding a second league a **no-op for the existing Superligaen dashboards** by filtering every mart to `league_id = 271`. Today's dashboards render identically; a future second league simply won't leak in.

## Changes

**Marts (17 sources)**
- 16 marts now filter on `fct.league_sk` (the league-bound facts already carry it), e.g. `AND f.league_sk = (SELECT league_sk FROM dim_league WHERE league_id = 271)`.
- `mart_club_transfer_log` keeps **club league-participation** scoping (`team_match_years` filtered to Superliga clubs) — a transfer is an event between clubs and is *not* bound to a single league, so we don't tag the fact.

**dbt gold layer**
- `fct_match_discussions` gains `league_sk` (a match *is* league-bound), resolved via the match's `fixtures.league_id`.
- `fct_team_transfers` left **unchanged** (intentionally no league column).
- `_schema.yml`: `league_sk not_null` test added to the three facts that carry it (`fct_match_discussions`, `fct_team_matches`, `fct_player_appearances`).

## Validation

- Built `fct_match_discussions` (full-refresh) and `fct_team_transfers` in dev; **all gold tests pass**.
- Filters are no-ops while only one league exists — confirmed filtered counts == totals, no row fanout, transfer mart output unchanged.

## Deploy note

Dashboards query **prod** gold at build time, so prod needs the new `fct_match_discussions.league_sk` column before the dashboards rebuild. A standard **full gold load** at deploy handles this (no special flags needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)